### PR TITLE
spec(feat_conventions_001): add project conventions, spec scaffolding, license, and README

### DIFF
--- a/docs/specs/feat_conventions_001/design_conventions_001.md
+++ b/docs/specs/feat_conventions_001/design_conventions_001.md
@@ -1,0 +1,100 @@
+# Design: Project Conventions, Spec Scaffolding, License, and README
+
+## Approach
+
+This is a documentation-only feature. No source code, no build tooling, no runtime artifacts. Vulcan creates four markdown files and one `LICENSE` file at fixed, well-known paths. Content is static and self-contained — no templating, no code generation.
+
+The feature is intentionally sequenced first so that `conventions.md` exists before any subsequent feature (`feat_backend_001`, `feat_frontend_001`, `feat_infra_001`, `feat_testing_001`) is planned or built. Atlas reads `conventions.md` at the start of every session per its system prompt; this feature produces that file.
+
+The top-level `README.md` is rewritten from its current one-line stub. Later features (`feat_backend_001`, etc.) will extend it with setup/run instructions for the components they add; this feature only establishes the skeleton and the "what is this template" framing.
+
+## Files to Modify
+
+| File | Change Description |
+|---|---|
+| `README.md` | Replace the existing one-line `# minimalist-app` stub with a full top-level README covering stack, layout, usage, license pointer. Mark folders that later features will add (e.g., "`backend/` — added by `feat_backend_001`"). |
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `conventions.md` | Single source of truth for naming, paths, branch/commit/PR/label conventions, status vocabulary, directory layout, and the locked-in tech stack. Read by Atlas at the start of every session. |
+| `LICENSE` | Standard MIT License text. Copyright line: `Copyright (c) 2026 Sri Harsha`. |
+| `docs/specs/README.md` | Explains the `docs/specs/` directory layout (one subfolder per feature, three spec files per feature, naming conventions) and how to read a feature end-to-end. |
+| `docs/specs/feat_conventions_001/feat_conventions_001.md` | This feature's feature spec (created by Atlas on the spec branch; listed here for completeness). |
+| `docs/specs/feat_conventions_001/design_conventions_001.md` | This design document (created by Atlas on the spec branch). |
+| `docs/specs/feat_conventions_001/test_conventions_001.md` | This feature's test spec (created by Atlas on the spec branch). |
+
+Note: the three files under `docs/specs/feat_conventions_001/` are authored by Atlas during spec creation and are already present when Vulcan begins. Vulcan does not create them; Vulcan's job for this feature is to create `conventions.md`, `LICENSE`, `docs/specs/README.md`, and rewrite `README.md`.
+
+## Data Flow
+
+There is no runtime data flow — this feature produces static documentation. The *workflow* flow is:
+
+1. Atlas creates the three spec files under `docs/specs/feat_conventions_001/` on branch `spec/feat_conventions_001`, opens a spec PR, creates a GitHub issue with labels `autodev` + `feat_conventions_001`.
+2. Human merges the spec PR into `main`.
+3. Vulcan picks up the issue, branches `build/feat_conventions_001` from fresh `main`, creates `conventions.md`, `LICENSE`, `docs/specs/README.md`, rewrites `README.md`, commits, pushes, opens a build PR.
+4. Human reviews and merges the build PR. From this point forward, every Atlas session reads `conventions.md` before proposing new work.
+
+## Content Outlines
+
+Vulcan should follow these outlines when authoring the files.
+
+### `conventions.md` outline
+
+1. Introduction — one paragraph on what this document is and who reads it (humans + Atlas + Vulcan).
+2. Feature IDs — format `feat_<domain>_<NNN>`; approved initial domains: `conventions`, `backend`, `frontend`, `infra`, `testing`; rule for adding new domains (human approval required); `NNN` is zero-padded and monotonically increasing per domain.
+3. Spec files — path `docs/specs/<feat_id>/`, three files: `feat_<domain>_<NNN>.md`, `design_<domain>_<NNN>.md`, `test_<domain>_<NNN>.md`.
+4. Branches — `spec/<feat_id>` for Atlas, `build/<feat_id>` for Vulcan, always branched from fresh `main`.
+5. Commits — prefix `autodev(<feat_id>): <description>`, imperative mood, lowercase description.
+6. PR titles — `spec(<feat_id>): <short title>` and `build(<feat_id>): <short title>`; one PR per branch; always target `main`.
+7. Labels — every AutoDev issue/PR gets `autodev` plus the per-feature label `<feat_id>`; Atlas creates the per-feature label if it does not exist.
+8. Status vocabulary — Planned / In Spec / Ready / In Build / Merged (and what each means).
+9. Directory layout — table showing `backend/`, `frontend/`, `infra/`, `tests/`, `docs/`, `deployment/`, noting which feature adds each.
+10. Locked tech stack — Python via `uv`, JS package manager `bun` (package manager + script runner only; Vite handles dev server and bundling on Node), Postgres, Redis, FastAPI, Vite + React + TypeScript, docker-compose for local orchestration, Docker for images.
+11. Initial feature roster — the five approved feature IDs with one-line scope each.
+12. "Deferred" list — linting/code quality, CI/CD, community health files; noted as future features so no one is tempted to fold them into an existing feature.
+
+### `LICENSE` content
+
+Standard MIT License text, verbatim from https://opensource.org/license/mit. Copyright line exactly: `Copyright (c) 2026 Sri Harsha`.
+
+### `README.md` outline
+
+1. Title and one-paragraph description: "A minimalist web application template with FastAPI backend, React+TypeScript frontend, Postgres, and Redis, orchestrated via docker-compose."
+2. "Use this template" section pointing to the GitHub button.
+3. Tech stack bullet list (FastAPI, uv, SQLAlchemy, Alembic, Postgres, Redis, structlog, Vite, React, TypeScript, Bun, docker-compose).
+4. Directory layout block (showing planned structure, with notes that `backend/`, `frontend/`, `infra/`, `tests/`, `deployment/` are added by later features).
+5. Getting started (placeholder section; later features will fill in `make up` / `bun run dev` once those exist — for now, note "setup instructions will be added when the backend/frontend/infra features land").
+6. Workflow pointer — "This template uses the AutoDev workflow (Atlas + Vulcan). See `conventions.md` and `docs/specs/`."
+7. License — one-liner pointing at `LICENSE`.
+
+### `docs/specs/README.md` outline
+
+1. One-paragraph description of what lives in this directory.
+2. Subfolder-per-feature rule with example `feat_conventions_001/`.
+3. The three-file convention.
+4. Pointer back to root `conventions.md` for full rules.
+5. A table listing all features in this repo (initially just `feat_conventions_001`); future features append rows.
+
+## Edge Cases & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Vulcan might re-create the spec files in `docs/specs/feat_conventions_001/` even though Atlas already committed them | Design spec explicitly lists those three spec files as "already present — Vulcan does not create them". Test spec asserts their existing content is unchanged. |
+| Future features might drift from the conventions established here | `conventions.md` is read by Atlas at session start per its system prompt; spec PRs that violate it will be caught in human review. |
+| MIT license boilerplate is frequently mangled (wrong year, missing permission notice) | Test spec requires exact header `Copyright (c) 2026 Sri Harsha` and presence of the phrase `THE SOFTWARE IS PROVIDED "AS IS"` to confirm the warranty clause. |
+| README might over-promise features that don't exist yet (backend, frontend, compose) | Design spec says the README explicitly labels later-feature folders as "added by feat_xxx_NNN", and the Getting Started section is a placeholder. |
+| Linting/code-quality concerns creep into this feature | Out-of-scope list in feature spec explicitly defers them. |
+| Developer adds a new domain (e.g., `feat_auth_001`) without approval | `conventions.md` states new domains require human approval; Atlas's workflow already requires human confirmation of feature IDs. |
+
+## Dependencies
+
+- GitHub CLI (`gh`) — already used by Atlas for issue/label/PR creation; no new dependency for the build side.
+- No runtime dependencies, no packages, no services.
+
+## Out-of-Band Notes for Vulcan
+
+- Do not add a `.gitignore` in this feature — the repo already has none, and each later feature will contribute ignores specific to its area (e.g., `feat_backend_001` adds Python ignores). A top-level `.gitignore` with common entries can be a separate future feature if desired.
+- Do not create empty placeholder folders (`backend/`, `frontend/`, etc.) in this feature. Empty folders require `.gitkeep` tricks and muddy later features' diffs.
+- Do not pin versions of `uv`, `bun`, Python, Node, Postgres, or Redis in `conventions.md`. Version pinning is the domain of the feature that introduces each tool.

--- a/docs/specs/feat_conventions_001/feat_conventions_001.md
+++ b/docs/specs/feat_conventions_001/feat_conventions_001.md
@@ -1,0 +1,75 @@
+# Feature: Project Conventions, Spec Scaffolding, License, and README
+
+## Problem Statement
+
+This repository is a greenfield template intended to be reused (via GitHub "Use this template") to bootstrap new minimalist web applications. Before any backend, frontend, or infrastructure code is written, the repository needs a shared source of truth for:
+
+- Naming conventions (feature IDs, spec file names, branch names, commit prefixes, PR titles, labels)
+- Directory layout for specs and future source folders
+- Status conventions used by the Atlas/Vulcan AutoDev workflow
+- A permissive open-source license so downstream users know their rights
+- A top-level README explaining what the template is, how it is organized, and how future features will be added
+
+Without these, every subsequent feature (backend, frontend, infra, testing) would invent its own conventions ad hoc, leading to drift. This feature establishes those conventions *first* so features 2-5 can reference and comply with them.
+
+This is the bootstrap feature of the AutoDev workflow on this template: it produces the very `conventions.md` that Atlas is instructed to read at the start of every session.
+
+## Requirements
+
+- Create `conventions.md` at the repository root documenting:
+  - Feature ID format: `feat_<domain>_<NNN>` with approved initial domains (`conventions`, `backend`, `frontend`, `infra`, `testing`) and how to add new ones
+  - Spec file naming: `feat_<domain>_<NNN>.md`, `design_<domain>_<NNN>.md`, `test_<domain>_<NNN>.md` under `docs/specs/<feat_id>/`
+  - Branch naming: `spec/<feat_id>` for Atlas, `build/<feat_id>` for Vulcan
+  - Commit message prefix: `autodev(<feat_id>): <description>`
+  - PR title format: `spec(<feat_id>): <title>` and `build(<feat_id>): <title>`
+  - GitHub label conventions: every AutoDev issue/PR gets `autodev` plus `<feat_id>`
+  - Status conventions for features (Planned / In Spec / Ready / In Build / Merged)
+  - Monorepo directory layout (`backend/`, `frontend/`, `infra/`, `tests/`, `docs/`, `deployment/`)
+  - Language/tooling choices locked in by this template (Python via `uv`, JS via `bun`, Postgres, Redis, FastAPI, Vite+React+TS, docker-compose)
+- Create `docs/specs/README.md` explaining the spec directory layout and how to read a feature
+- Create `LICENSE` at the repository root containing the standard MIT License text, copyright year `2026`, copyright holder `Sri Harsha`
+- Replace the current one-line `README.md` with a proper top-level README covering:
+  - What the template is and what stack it provides
+  - High-level directory layout (marking folders that will be added by later features as "added by feat_backend_001" etc.)
+  - How to use the template (GitHub "Use this template" button, then customize)
+  - Pointer to `conventions.md` and `docs/specs/`
+  - License note pointing to `LICENSE`
+- Preserve the existing `docs/specs/` directory (already created by this feature's spec commit) — do not delete it
+
+## User Stories
+
+- As a developer opening this template for the first time, I want a single `conventions.md` so I know the naming and workflow rules before I touch anything.
+- As Atlas (planner agent), I want `conventions.md` to exist so I can read it at session start as instructed by my system prompt.
+- As Vulcan (builder agent), I want the spec directory layout codified so I know where to find feature/design/test specs for any feature ID.
+- As a user of the template, I want a MIT `LICENSE` and a real `README.md` so the repo is immediately usable and legally clear when I click "Use this template".
+- As a reviewer of future PRs, I want label and branch conventions documented so I can filter and triage consistently.
+
+## Scope
+
+### In Scope
+
+- `conventions.md` at repo root
+- `LICENSE` at repo root (MIT, 2026, Sri Harsha)
+- `README.md` at repo root (full rewrite of the current one-line stub)
+- `docs/specs/README.md` (spec-directory guide)
+- Leaving `docs/specs/feat_conventions_001/` populated with its own three spec files (this PR)
+
+### Out of Scope
+
+- Any source code (no `backend/`, `frontend/`, `infra/` folders created here — each is produced by its own feature)
+- Any Dockerfiles or docker-compose setup (owned by `feat_infra_001`)
+- Any linting, formatting, or pre-commit configuration (deferred to a future feature per user decision)
+- Any test infrastructure or `test.sh` (owned by `feat_testing_001`)
+- CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, or other community health files (can be a later feature if desired)
+- CI/CD workflows under `.github/workflows/` (out of scope for this feature; may be part of `feat_infra_001` or a later feature)
+
+## Acceptance Criteria
+
+- [ ] `conventions.md` exists at the repo root and documents all items listed under Requirements
+- [ ] `LICENSE` exists at the repo root, contains the standard MIT License text, shows `Copyright (c) 2026 Sri Harsha`
+- [ ] `README.md` at the repo root is more than one line and covers stack, layout, usage, and license pointer
+- [ ] `docs/specs/README.md` exists and explains the spec directory layout
+- [ ] `docs/specs/feat_conventions_001/` contains `feat_conventions_001.md`, `design_conventions_001.md`, `test_conventions_001.md`
+- [ ] A GitHub issue titled `Implement feat_conventions_001: <short title>` exists with labels `autodev` and `feat_conventions_001`
+- [ ] A spec PR titled `spec(feat_conventions_001): <short title>` exists against `main`
+- [ ] `conventions.md` explicitly lists the 5 approved initial feature IDs (`feat_conventions_001`, `feat_backend_001`, `feat_frontend_001`, `feat_infra_001`, `feat_testing_001`) and their rough scope so future Atlas sessions have context

--- a/docs/specs/feat_conventions_001/test_conventions_001.md
+++ b/docs/specs/feat_conventions_001/test_conventions_001.md
@@ -1,0 +1,57 @@
+# Test Spec: Project Conventions, Spec Scaffolding, License, and README
+
+This feature produces documentation only — no runtime code, no HTTP endpoints, no build pipeline. Tests are therefore **file-presence and content assertions** that a reviewer (or a simple shell/grep check) can verify on the merged branch. No test framework is introduced; `feat_testing_001` owns that.
+
+All tests are run from the repository root on the `build/feat_conventions_001` branch after Vulcan's changes are applied.
+
+## Happy Path
+
+| # | Test Case | Input | Expected Output |
+|---|---|---|---|
+| 1 | `conventions.md` exists at repo root | `test -f conventions.md` | Exit code 0 |
+| 2 | `LICENSE` exists at repo root | `test -f LICENSE` | Exit code 0 |
+| 3 | `README.md` exists and is non-trivial | `wc -l < README.md` | Result > 10 (not the old one-liner) |
+| 4 | `docs/specs/README.md` exists | `test -f docs/specs/README.md` | Exit code 0 |
+| 5 | Feature spec file present | `test -f docs/specs/feat_conventions_001/feat_conventions_001.md` | Exit code 0 |
+| 6 | Design spec file present | `test -f docs/specs/feat_conventions_001/design_conventions_001.md` | Exit code 0 |
+| 7 | Test spec file present | `test -f docs/specs/feat_conventions_001/test_conventions_001.md` | Exit code 0 |
+| 8 | `conventions.md` documents feature ID format | grep `feat_<domain>_<NNN>` in `conventions.md` | Match found |
+| 9 | `conventions.md` documents branch naming | grep `spec/<feat_id>` and `build/<feat_id>` in `conventions.md` | Both matches found |
+| 10 | `conventions.md` documents commit prefix | grep `autodev(<feat_id>)` in `conventions.md` | Match found |
+| 11 | `conventions.md` lists all five approved feature IDs | grep each of `feat_conventions_001`, `feat_backend_001`, `feat_frontend_001`, `feat_infra_001`, `feat_testing_001` in `conventions.md` | All five matches found |
+| 12 | `conventions.md` documents status vocabulary | grep each of `Planned`, `In Spec`, `Ready`, `In Build`, `Merged` in `conventions.md` | All five matches found |
+| 13 | `conventions.md` names the locked tech stack | grep each of `FastAPI`, `Postgres`, `Redis`, `Vite`, `React`, `TypeScript`, `uv`, `bun`, `docker-compose` in `conventions.md` | All nine matches found |
+| 14 | `LICENSE` is MIT | grep `MIT License` in `LICENSE` | Match found |
+| 15 | `LICENSE` has correct copyright line | grep `Copyright (c) 2026 Sri Harsha` in `LICENSE` | Match found |
+| 16 | `LICENSE` contains the standard warranty clause | grep `THE SOFTWARE IS PROVIDED "AS IS"` in `LICENSE` | Match found |
+| 17 | `README.md` points to `conventions.md` | grep `conventions.md` in `README.md` | Match found |
+| 18 | `README.md` points to `LICENSE` | grep `LICENSE` in `README.md` | Match found |
+| 19 | `README.md` lists core stack keywords | grep each of `FastAPI`, `React`, `Postgres`, `Redis` in `README.md` | All four matches found |
+| 20 | `docs/specs/README.md` explains the three-file spec convention | grep each of `feat_`, `design_`, `test_` in `docs/specs/README.md` | All three matches found |
+
+## Error Cases
+
+| # | Test Case | Input | Expected Behavior |
+|---|---|---|---|
+| 1 | No empty placeholder folders committed | `find . -type d -empty -not -path './.git/*'` | No results (design spec forbids empty folders) |
+| 2 | Old one-line README stub replaced | grep-count of `^# minimalist-app$` as the only content of `README.md` | README contains more than just that line |
+| 3 | Conventions file not accidentally placed under `docs/` | `test -f docs/conventions.md` | Exit code 1 (file must be at repo root, not under `docs/`) |
+| 4 | License file has no trailing `TODO` or placeholder | grep -i `TODO\|FIXME\|xxx` in `LICENSE` | No matches |
+| 5 | README does not claim features that don't exist yet as "working" | grep-style review: mentions of `backend/`, `frontend/`, `make up`, `bun run dev` must be qualified as "added by feat_xxx" or "coming soon" | Qualifiers present near every such mention |
+
+## Boundary Conditions
+
+| # | Test Case | Condition | Expected Behavior |
+|---|---|---|---|
+| 1 | Vulcan did not re-author the three spec files | `git diff main...build/feat_conventions_001 -- docs/specs/feat_conventions_001/` | Zero changes for the three spec files (they were merged in via the spec PR already) |
+| 2 | `conventions.md` is at repository root, not nested | `find . -name conventions.md -not -path './.git/*'` | Exactly one result: `./conventions.md` |
+| 3 | Linting/CI config not introduced | `ls .github/workflows/ 2>/dev/null \|\| true` and `ls .pre-commit-config.yaml 2>/dev/null \|\| true` | No such files (linting is a deferred feature) |
+| 4 | No runtime code introduced | `find . -type f \( -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' \) -not -path './.git/*'` | No results |
+| 5 | Repo still has no `backend/`, `frontend/`, `infra/`, `tests/`, `deployment/` folders | `test -d backend \|\| test -d frontend \|\| test -d infra \|\| test -d tests \|\| test -d deployment` | All five return non-zero (folders do not yet exist) |
+
+## Security Considerations
+
+- **License correctness:** The MIT text must match the canonical text exactly. A malformed license (missing the "AS IS" warranty clause, wrong SPDX name, or altered terms) could create ambiguity for downstream users. Test cases 14-16 enforce the canonical markers.
+- **No secrets or credentials in docs:** `README.md` and `conventions.md` must not contain tokens, passwords, API keys, or private email addresses. Reviewer checks by visual inspection; automatable via a simple grep for patterns like `AWS_`, `BEGIN RSA`, `ghp_`, `sk_live_` (no matches expected).
+- **Copyright holder accuracy:** The LICENSE names `Sri Harsha` as the copyright holder per user instruction. Any change to the holder name in a future PR should go through explicit human review.
+- **No executable scripts introduced:** This feature must not add any shell scripts, `Makefile` targets, or CI workflows. Boundary test 3 enforces this.


### PR DESCRIPTION
## Specifications for feat_conventions_001

This is **feature #1 of a 5-feature template bootstrap** (`feat_conventions_001`, `feat_backend_001`, `feat_frontend_001`, `feat_infra_001`, `feat_testing_001`). It establishes the shared source of truth that features 2-5 will reference.

### What this spec establishes

Vulcan's deliverables when this PR merges and `feat_conventions_001` is implemented will be:

- **`conventions.md`** at repo root — feature ID format, spec/branch/commit/PR naming, label conventions, status values, monorepo directory layout, and locked-in stack choices
- **`LICENSE`** at repo root — standard MIT License, `Copyright (c) 2026 Sri Harsha`
- **`README.md`** at repo root — full rewrite of the current one-line stub covering stack, layout, template usage, and pointers to conventions and specs
- **`docs/specs/README.md`** — guide to the spec directory layout and how to read a feature

Note: the three spec files listed below are **already included in this PR** and will not be re-emitted by Vulcan.

### Spec Files

- Feature: `docs/specs/feat_conventions_001/feat_conventions_001.md`
- Design:  `docs/specs/feat_conventions_001/design_conventions_001.md`
- Test:    `docs/specs/feat_conventions_001/test_conventions_001.md`