### PR TITLE
feat(feat_conventions_001): add conventions, license, and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sri Harsha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # minimalist-app
+
+A minimalist web application template with a **FastAPI** backend, **React + TypeScript** frontend, **Postgres**, and **Redis**, orchestrated via **docker-compose**. The template ships with documentation conventions and an AutoDev workflow (Atlas + Vulcan agents) so new features can be added predictably from day one.
+
+This repository is intended to be consumed via GitHub's **"Use this template"** button. Click it, give your new repo a name, then customize the parts that are project-specific (name in `README.md`, copyright holder in `LICENSE`, and so on).
+
+## Tech stack
+
+- **Backend:** FastAPI, Python (project managed with `uv`), SQLAlchemy, Alembic, structlog
+- **Data:** Postgres, Redis
+- **Frontend:** Vite + React + TypeScript, managed with `bun` (package manager + script runner; Vite handles the dev server and bundling on Node)
+- **Local orchestration:** `docker-compose`
+- **Container runtime:** Docker
+
+Specific versions are pinned by the feature that introduces each tool, not here. See [`conventions.md`](conventions.md) for the current locked stack.
+
+## Directory layout
+
+```
+minimalist-app/
+  conventions.md       # Naming, branching, PR, and label conventions (read this first)
+  LICENSE              # MIT license
+  README.md            # This file
+  docs/
+    specs/             # One subfolder per feature, each with 3 spec files
+  backend/             # (added by feat_backend_001)   FastAPI service
+  frontend/            # (added by feat_frontend_001)  Vite + React + TS app
+  infra/               # (added by feat_infra_001)     Dockerfiles, docker-compose, env templates
+  tests/               # (added by feat_testing_001)   test.sh driver and cross-cutting tests
+  deployment/          # (added by a later infra feature) production artifacts
+```
+
+Folders marked "added by `feat_xxx_NNN`" do not exist yet; they land when their owning feature is merged.
+
+## Using this template
+
+1. On GitHub, click **"Use this template"** and create a new repository.
+2. Clone the new repo locally.
+3. Update the project name, description, and `LICENSE` copyright holder to match your project.
+4. Add features one at a time using the AutoDev workflow (see below).
+
+## Getting started
+
+Setup instructions for running the backend, frontend, and local services will be added when the corresponding features land:
+
+- `backend/` run/test instructions come with `feat_backend_001`.
+- `frontend/` run/test instructions come with `feat_frontend_001`.
+- `make up` / `docker-compose` orchestration comes with `feat_infra_001`.
+- `./test.sh` test driver comes with `feat_testing_001`.
+
+Until then, this template ships documentation and conventions only — there is nothing to run.
+
+## Workflow
+
+This template uses the **AutoDev** workflow, in which two agents collaborate with the human:
+
+- **Atlas** plans features and produces three spec files per feature (feature spec, design spec, test spec) on a `spec/<feat_id>` branch.
+- **Vulcan** implements merged specs on a `build/<feat_id>` branch, runs tests, and opens a build PR.
+
+Every Atlas session begins by reading [`conventions.md`](conventions.md); every feature's specs live under [`docs/specs/`](docs/specs/). See [`docs/specs/README.md`](docs/specs/README.md) for a guide to reading a feature end-to-end.
+
+## License
+
+Released under the MIT License. See [`LICENSE`](LICENSE) for the full text.

--- a/conventions.md
+++ b/conventions.md
@@ -1,0 +1,166 @@
+# Project Conventions
+
+This document is the single source of truth for naming, paths, and workflow conventions in this repository. It is read by humans when navigating the repo and by the **Atlas** (planner) and **Vulcan** (builder) agents at the start of every session. If you are adding a new feature, branch, commit, PR, or label, it must conform to the rules here. If a rule needs to change, update this file in a dedicated PR before applying the new rule elsewhere.
+
+## 1. Feature IDs
+
+Every unit of work is identified by a **Feature ID** of the form:
+
+```
+feat_<domain>_<NNN>
+```
+
+- `<domain>` is a short lowercase token naming the area of the codebase the feature touches.
+- `<NNN>` is a three-digit, zero-padded, monotonically increasing counter **per domain** (so `feat_backend_001`, `feat_backend_002`, ...). Counters do not reset across domains and do not share a pool.
+
+### Approved initial domains
+
+| Domain        | Scope                                                                    |
+|---------------|--------------------------------------------------------------------------|
+| `conventions` | Repo-wide conventions, licensing, top-level docs, spec scaffolding.      |
+| `backend`     | Python service (FastAPI), database models, migrations, server code.     |
+| `frontend`    | Web UI (Vite + React + TypeScript).                                      |
+| `infra`       | Docker images, `docker-compose`, local orchestration, environment files. |
+| `testing`     | Test harness (`test.sh`), test tooling, cross-cutting test utilities.    |
+
+### Adding a new domain
+
+Adding a new domain (e.g., `auth`, `mobile`, `cli`) requires **explicit human approval**. Atlas must propose the new domain in a planning session and wait for the human to confirm before using it in a feature ID. Once approved, the domain is added to the table above in a `feat_conventions_NNN` follow-up PR.
+
+## 2. Spec files
+
+Every feature has exactly three spec files, all under a per-feature directory:
+
+```
+docs/specs/<feat_id>/
+  feat_<domain>_<NNN>.md     # Feature spec: problem, requirements, scope, acceptance criteria
+  design_<domain>_<NNN>.md   # Design spec: approach, files to create/modify, data flow, risks
+  test_<domain>_<NNN>.md     # Test spec:   happy path, error cases, boundary conditions, security
+```
+
+The feature spec answers "what and why," the design spec answers "how," and the test spec answers "how do we know it works."
+
+A guide to reading specs end-to-end lives in [`docs/specs/README.md`](docs/specs/README.md).
+
+## 3. Branches
+
+All work happens on short-lived branches cut from fresh `main`:
+
+| Branch            | Owner  | Purpose                                                     |
+|-------------------|--------|-------------------------------------------------------------|
+| `spec/<feat_id>`  | Atlas  | Holds the three spec files and the GitHub issue reference. |
+| `build/<feat_id>` | Vulcan | Holds the implementation: source code, tests, doc updates. |
+
+- Always branch from an up-to-date `main` (`git checkout main && git pull --ff-only && git checkout -b <branch>`).
+- One branch per feature per agent. Do not reuse a spec branch for implementation; cut a new `build/<feat_id>` from fresh `main` after the spec PR is merged.
+- Branches are deleted after their PR is merged.
+
+## 4. Commits
+
+Every commit message uses the prefix:
+
+```
+autodev(<feat_id>): <description>
+```
+
+- `<description>` is a short imperative phrase in lowercase (e.g., `add conventions, license, and readme`).
+- Keep commits focused; prefer several small commits over one large one when the changes are logically separate.
+- Do not include `Co-Authored-By` lines unless the human explicitly asks for them.
+
+## 5. Pull requests
+
+Exactly one PR per branch, always targeting `main`:
+
+| PR kind         | Title format                        | Branch             |
+|-----------------|-------------------------------------|--------------------|
+| Spec PR         | `spec(<feat_id>): <short title>`    | `spec/<feat_id>`   |
+| Build PR        | `build(<feat_id>): <short title>`   | `build/<feat_id>`  |
+
+PR bodies should:
+
+- Link the GitHub issue with `Closes #<n>`.
+- Reference the three spec files by path.
+- Summarize the diff at a level a reviewer can skim.
+
+## 6. Labels
+
+Every AutoDev issue and PR receives **two labels**:
+
+- `autodev` — marks the item as owned by the AutoDev workflow.
+- `<feat_id>` — the per-feature label (e.g., `feat_conventions_001`).
+
+The `autodev` label is created once (manually or by the first Atlas run). The per-feature label is created by Atlas the first time it is needed; subsequent issues/PRs for the same feature reuse it. Colors are not significant but should be distinct enough to skim in the GitHub UI.
+
+## 7. Status vocabulary
+
+Features move through a small, strict lifecycle. The current status of every feature lives in `docs/tracking/features.md` (created when tracking is needed) or in the GitHub issue labels.
+
+| Status     | Meaning                                                                             |
+|------------|-------------------------------------------------------------------------------------|
+| `Planned`  | Feature ID is reserved; no specs yet. Listed in the roster for visibility.          |
+| `In Spec`  | Atlas is writing (or revising) the three spec files; spec PR may be open.           |
+| `Ready`    | Spec PR merged to `main`; specs are final; Vulcan can pick it up.                   |
+| `In Build` | Vulcan is implementing; build branch exists; build PR may be open.                  |
+| `Merged`   | Build PR merged to `main`; feature is live.                                         |
+
+A feature only advances; it does not skip states. If a spec needs to change after `Ready`, open a new `spec/<feat_id>_revN` branch or a new conventions-style fix PR — do not silently edit merged specs.
+
+## 8. Directory layout
+
+The target monorepo layout is:
+
+| Path           | Contents                                                              | Introduced by        |
+|----------------|-----------------------------------------------------------------------|----------------------|
+| `backend/`     | FastAPI service, models, migrations, Python packages.                 | `feat_backend_001`   |
+| `frontend/`    | Vite + React + TypeScript web app.                                    | `feat_frontend_001`  |
+| `infra/`       | Dockerfiles, `docker-compose.yml`, env templates, local orchestration.| `feat_infra_001`     |
+| `tests/`       | Cross-cutting tests and the `test.sh` driver.                          | `feat_testing_001`   |
+| `docs/`        | Specs (`docs/specs/`), tracking, ADRs, narrative docs.                | `feat_conventions_001` (this feature) |
+| `deployment/`  | Production deployment artifacts (Helm charts, Terraform, etc.).        | a later infra feature |
+
+Empty placeholder folders are **not** committed by this feature; each folder is created when the feature that owns it lands.
+
+## 9. Locked tech stack
+
+The following choices are fixed for this template. A change to any of them requires a `feat_conventions_NNN` PR that updates this file first.
+
+| Area                         | Choice                                                        |
+|------------------------------|---------------------------------------------------------------|
+| Backend language             | Python                                                        |
+| Python package/project tool  | `uv`                                                          |
+| Backend web framework        | FastAPI                                                       |
+| Relational database          | Postgres                                                      |
+| Cache / key-value store      | Redis                                                         |
+| Frontend build tool          | Vite                                                          |
+| Frontend framework           | React                                                         |
+| Frontend language            | TypeScript                                                    |
+| JS package manager / runner  | `bun` (package manager + script runner; Vite handles the dev server and bundling on Node) |
+| Local orchestration          | `docker-compose`                                              |
+| Container runtime / images   | Docker                                                        |
+
+Specific versions of `uv`, `bun`, Python, Node, Postgres, and Redis are **not** pinned here — each is pinned by the feature that introduces the corresponding tool.
+
+## 10. Initial feature roster
+
+The five bootstrap features of this template:
+
+| Feature ID              | Scope (one line)                                                            |
+|-------------------------|-----------------------------------------------------------------------------|
+| `feat_conventions_001`  | This file, `LICENSE`, top-level `README.md`, `docs/specs/README.md`.        |
+| `feat_backend_001`      | FastAPI app skeleton, `uv` project, Postgres + Redis wiring, first endpoint.|
+| `feat_frontend_001`     | Vite + React + TypeScript app skeleton managed with `bun`.                  |
+| `feat_infra_001`        | Dockerfiles, `docker-compose.yml`, `.env` templates, local orchestration.   |
+| `feat_testing_001`      | `test.sh` driver, test conventions, minimal backend+frontend test examples. |
+
+## 11. Deferred (intentionally out of scope for now)
+
+These are **not** folded into the five bootstrap features. They may land as future `feat_conventions_NNN` or domain-specific features.
+
+- Linting and formatting configuration (e.g., `ruff`, `eslint`, `prettier`).
+- Pre-commit hooks (`.pre-commit-config.yaml`).
+- CI/CD workflows (`.github/workflows/`).
+- Community-health files (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`).
+- Top-level `.gitignore` with common entries (each domain feature contributes ignores for its area).
+- Dependabot or Renovate configuration.
+
+Anyone tempted to bolt one of these onto an in-flight feature: don't. Propose a new feature instead.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,45 @@
+# Specs
+
+This directory holds the design history of every feature in the repository. Each feature lives in its own subfolder and contains exactly three markdown files — a feature spec, a design spec, and a test spec. Reading the three files in order gives you the full picture of why a feature exists, how it is built, and how it is verified.
+
+## Subfolder per feature
+
+Every feature gets its own subfolder named after its feature ID:
+
+```
+docs/specs/
+  feat_conventions_001/
+    feat_conventions_001.md     # what and why
+    design_conventions_001.md   # how
+    test_conventions_001.md     # how do we know it works
+  feat_backend_001/             # (added by feat_backend_001)
+    ...
+```
+
+The subfolder name matches the feature ID exactly (`feat_<domain>_<NNN>`). Inside it, the three files follow the same `<domain>_<NNN>` suffix so they are unambiguous when opened out of context.
+
+## The three-file convention
+
+| File                                  | Purpose                                                         |
+|---------------------------------------|-----------------------------------------------------------------|
+| `feat_<domain>_<NNN>.md`              | Problem statement, requirements, scope, acceptance criteria.    |
+| `design_<domain>_<NNN>.md`            | Approach, files to create/modify, data flow, edge cases, risks. |
+| `test_<domain>_<NNN>.md`              | Happy path, error cases, boundary conditions, security notes.   |
+
+Files are authored by **Atlas** during the spec phase and merged via a `spec(<feat_id>)` PR before **Vulcan** begins implementation. Merged specs are treated as historical artifacts: if a spec needs to change later, open a new conventions/spec PR rather than silently rewriting the file.
+
+## Full rules
+
+The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labels, and status lifecycle lives in the repository root [`conventions.md`](../../conventions.md). Consult it when you are unsure whether a name, branch, or label is correct.
+
+## Feature roster
+
+| Feature ID              | Status     | One-line scope                                                              |
+|-------------------------|------------|-----------------------------------------------------------------------------|
+| `feat_conventions_001`  | In Build   | Conventions, `LICENSE`, top-level `README.md`, and this spec guide.         |
+| `feat_backend_001`      | Planned    | FastAPI app skeleton, `uv` project, Postgres + Redis wiring, first endpoint.|
+| `feat_frontend_001`     | Planned    | Vite + React + TypeScript app skeleton managed with `bun`.                  |
+| `feat_infra_001`        | Planned    | Dockerfiles, `docker-compose.yml`, `.env` templates, local orchestration.   |
+| `feat_testing_001`      | Planned    | `test.sh` driver, test conventions, minimal backend + frontend test examples.|
+
+Future features append rows to this table as they are planned.


### PR DESCRIPTION
## Summary

Implements **feat_conventions_001** per the specs merged in PR #1.

Deliverables:
- `conventions.md` — project conventions (feature IDs, branching, commits, stack)
- `LICENSE` — MIT
- `README.md` — rewritten template description
- `docs/specs/README.md` — spec directory guide

Spec files (already on `main` from PR #1) are intentionally not re-emitted.

## Test plan
- [x] All files present at repo root / correct paths
- [x] LICENSE is MIT, 2026, Sri Harsha
- [x] README references conventions.md and LICENSE
- [x] docs/specs/README.md documents the `feat_`/`design_`/`test_` file naming

Closes #2