### PR TITLE
spec(feat_frontend_001): frontend scaffold + hello-world page

### DIFF
--- a/docs/specs/feat_frontend_001/design_frontend_001.md
+++ b/docs/specs/feat_frontend_001/design_frontend_001.md
@@ -1,0 +1,153 @@
+# Design: Frontend scaffold and hello-world page
+
+## Approach
+
+Stand up a stock Vite + React + TypeScript project in `frontend/`, managed by `bun` for installs and scripts. Keep the structure as close to `bun create vite frontend --template react-ts` output as possible so the scaffold is recognizable to anyone who has used Vite before. Then add three small things on top of that scaffold:
+
+1. A typed API-client module (`src/api/client.ts`) wrapping `fetch`, exporting a typed `getHello()` function and the `HelloResponse` type.
+2. A replacement `App.tsx` that mounts, calls `getHello()`, and renders one of three states: loading, error, success.
+3. Configuration: `.env.example` declaring `VITE_API_BASE_URL`, and a Vite dev-server proxy entry so calls to `/api/...` in development are forwarded to the backend (sidestepping CORS without any backend change).
+
+The `bun.lockb` lockfile is committed so subsequent `bun install` calls are reproducible. The Vite dev server, esbuild, and the production build still execute on Node — Bun is the package manager and script runner only, per `conventions.md` §9.
+
+Bun version: pin to a specific minor (e.g. `>=1.1.0`) in `package.json#packageManager` if Bun supports it for this template, or document the minimum version in `frontend/README.md`. Vulcan should pick the current stable Bun at implementation time and document the chosen version.
+
+Node engine: the Vite scaffold typically targets Node `>=20.19` for Vite 7 / Node `>=20` for Vite 6. Vulcan should defer to whatever the chosen Vite template requires and reflect the minimum in `frontend/package.json#engines.node` and the README.
+
+## Files to Modify
+
+| File | Change Description |
+|---|---|
+| (none) | This feature does not modify any existing files. All changes are additive under `frontend/`. |
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `frontend/package.json` | Project manifest. Declares Vite, React, React-DOM, TypeScript, `@types/react`, `@types/react-dom`, `@vitejs/plugin-react`. Scripts: `dev` (`vite`), `build` (`tsc -b && vite build`), `preview` (`vite preview`). |
+| `frontend/bun.lockb` | Bun lockfile produced by `bun install`. Committed for reproducibility. |
+| `frontend/tsconfig.json` | TypeScript root config (typically references `tsconfig.app.json` and `tsconfig.node.json` per the Vite template). |
+| `frontend/tsconfig.app.json` | App-side TS config (DOM lib, JSX, strict mode on). |
+| `frontend/tsconfig.node.json` | Vite-config TS settings (Node env). |
+| `frontend/vite.config.ts` | Vite config: `@vitejs/plugin-react`, plus `server.proxy` mapping `/api` -> `${VITE_API_BASE_URL}` so dev-mode calls bypass CORS. |
+| `frontend/index.html` | Vite entry HTML; mounts `#root` and loads `/src/main.tsx`. |
+| `frontend/src/main.tsx` | React entry. Renders `<App />` into `#root`. Standard Vite scaffold output. |
+| `frontend/src/App.tsx` | The hello-world page. Uses `useState` + `useEffect` to call `getHello()` and render loading / error / success. |
+| `frontend/src/App.css` | Minimal styling for legibility. Optional but typical in Vite scaffolds. |
+| `frontend/src/index.css` | Global styles (default Vite scaffold). |
+| `frontend/src/api/client.ts` | Typed API client. Exports `HelloResponse` type and `async function getHello(): Promise<HelloResponse>`. |
+| `frontend/src/vite-env.d.ts` | Vite-supplied type shim plus `ImportMetaEnv` augmentation declaring `VITE_API_BASE_URL: string`. |
+| `frontend/.env.example` | `VITE_API_BASE_URL=http://localhost:8000`. |
+| `frontend/.gitignore` | `node_modules/`, `dist/`, `.env`, `.env.local`, `*.log`, etc. Does NOT ignore `bun.lockb` or `.env.example`. |
+| `frontend/README.md` | One-screen doc covering prerequisites (Bun + Node versions), `bun install`, `bun run dev`, `bun run build`, `bun run preview`, and the `VITE_API_BASE_URL` env var. |
+| `frontend/public/` (optional) | Static assets directory if the Vite scaffold places anything there (e.g. a favicon). Acceptable to omit if the chosen template inlines the favicon. |
+
+Vulcan may use `bun create vite frontend --template react-ts` (or the equivalent current invocation) to generate the baseline and then layer the api-client module, env-var wiring, and proxy config on top. Generated boilerplate (e.g. the default Vite splash component) should be replaced by the hello page rather than left in place.
+
+## API Client Shape
+
+`frontend/src/api/client.ts` exports:
+
+```ts
+export interface HelloResponse {
+  message: string;
+  item_name: string;
+  hello_count: number;
+}
+
+export async function getHello(): Promise<HelloResponse>;
+```
+
+Implementation contract:
+
+- The base URL is read from `import.meta.env.VITE_API_BASE_URL`. If unset, fall back to an empty string so that the path `/api/v1/hello` resolves against the current origin (which works under the Vite dev proxy without any env file).
+- The request URL is `${baseUrl}/api/v1/hello`.
+- A non-2xx response throws an `Error` whose message includes the HTTP status. The page surfaces this in the error state.
+- A network failure (fetch rejection) propagates as an `Error` with a useful message; the page surfaces it likewise.
+- The function does not retry, does not cache, does not set auth headers. Keep it boring.
+
+The `HelloResponse` type intentionally mirrors the backend's `app.schemas.HelloResponse` (`message: str`, `item_name: str`, `hello_count: int`). If the backend contract drifts, this file is the single point of update on the frontend.
+
+## Page Behavior
+
+`frontend/src/App.tsx`:
+
+- On mount (in a `useEffect`), call `getHello()`.
+- Track three pieces of state: `data: HelloResponse | null`, `error: string | null`, `loading: boolean`.
+- Render exactly one of:
+  - Loading: a visible "Loading..." indicator.
+  - Error: a visible message such as "Failed to load: \<error message\>" — never a blank screen, never a raw stack trace beyond the error's `message` string.
+  - Success: render at minimum `data.message`. Rendering the additional fields (`item_name`, `hello_count`) is encouraged so the user can confirm Postgres + Redis are also live.
+- No automatic refetch, polling, or refresh button is required. Page reload is sufficient for a re-fetch.
+
+## Env Var Handling
+
+- Vite exposes only env vars prefixed with `VITE_` to client code via `import.meta.env`.
+- `VITE_API_BASE_URL` is the single env var this feature defines.
+- `frontend/.env.example` ships `VITE_API_BASE_URL=http://localhost:8000` so a developer can `cp .env.example .env` and immediately have a working setup.
+- `frontend/src/vite-env.d.ts` augments `ImportMetaEnv` with `readonly VITE_API_BASE_URL: string` so TypeScript users get autocomplete and type-checking on the var.
+- Document in the README that env vars are baked in at build time, not read at runtime — a production build needs the env var present during `bun run build`, not when the static bundle is served.
+
+## CORS / Dev Server Strategy
+
+The backend (`feat_backend_001`) does not currently install `CORSMiddleware`. Rather than modify the backend (out of scope for this feature), the Vite dev server proxies API calls to it:
+
+```ts
+// vite.config.ts
+server: {
+  proxy: {
+    '/api': {
+      target: process.env.VITE_API_BASE_URL ?? 'http://localhost:8000',
+      changeOrigin: true,
+    },
+  },
+},
+```
+
+With the proxy in place, the frontend can issue same-origin requests to `/api/v1/hello` from `http://localhost:5173` and the dev server forwards to `http://localhost:8000`. No browser CORS preflight occurs.
+
+For production-style serving via `bun run preview`, the same proxy applies. For a fully built static bundle served from elsewhere (a future concern, not this feature's), the operator either fronts everything behind a single reverse proxy or the backend gains CORS — both options are deferred.
+
+## Build + Dev Workflow
+
+| Command (run inside `frontend/`) | Purpose |
+|---|---|
+| `bun install` | Installs dependencies into `node_modules/` using `bun.lockb`. |
+| `bun run dev` | Starts the Vite dev server (default port 5173) with HMR and the `/api` proxy. |
+| `bun run build` | Type-checks (`tsc -b`) and produces a production bundle in `dist/`. |
+| `bun run preview` | Serves the built `dist/` over a local static server for sanity checks. |
+
+Vulcan should verify, before committing, that `bun install` from a clean `node_modules/` succeeds and that `bun run build` produces `dist/` with zero TypeScript errors. (Manual verification only — no automated tests are added, per the test spec.)
+
+## Data Flow
+
+1. User loads `http://localhost:5173/` in the browser.
+2. React mounts `<App />`. `useState` initializes `loading=true`, `data=null`, `error=null`. The page renders the loading state.
+3. `useEffect` fires once; it invokes `getHello()` from `src/api/client.ts`.
+4. `getHello()` issues `fetch('/api/v1/hello')` (relative path; same-origin under the Vite dev proxy).
+5. The Vite dev server receives the request, matches the `/api` proxy rule, and forwards to `http://localhost:8000/api/v1/hello`.
+6. FastAPI executes the hello handler (round-tripping Postgres and Redis) and returns the JSON `HelloResponse`.
+7. `getHello()` resolves with the typed response. `App` updates state to `loading=false`, `data=<response>`, and re-renders the success view.
+8. If step 4–7 fail at any point, `getHello()` throws; `App` updates to `loading=false`, `error=<message>`, and re-renders the error view.
+
+## Edge Cases & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Backend not running when the user opens the page. | Page renders a clear error state with the underlying fetch/network error message. |
+| Backend returns 503 (e.g. seed item missing — see `backend/app/api/v1/hello.py`). | API client throws on non-2xx; page renders the status code in the error message so the user knows what to fix. |
+| Backend response shape drifts from `HelloResponse`. | Type lives in one file (`src/api/client.ts`); update there. No runtime schema validation is added (out of scope; can be revisited if drift becomes painful). |
+| User forgets to copy `.env.example` to `.env`. | Defaults are designed so this works anyway: the API client falls back to a relative URL, and the Vite proxy default-targets `http://localhost:8000`. The README still recommends copying the file for clarity. |
+| Browser CORS blocks the request. | Avoided by routing through the Vite dev-server proxy in development. Production CORS is explicitly deferred. |
+| Port collision: backend already on 8000, Vite default 5173. | Both default ports are unchanged from upstream defaults; if the user has a conflict, Vite auto-increments to 5174 and the proxy still works. Backend port collision is outside the frontend's concern. |
+| `bun.lockb` is a binary file — non-Bun users (e.g. someone running `npm install` by mistake) will get a different resolution. | Convention is documented in `conventions.md` §9 (Bun is the chosen package manager) and reiterated in `frontend/README.md`. We do not add a `package-lock.json` or `yarn.lock`. |
+| Bun and Node version drift across contributors' machines. | Document a minimum Bun version and a minimum Node version in `frontend/README.md` and (where supported) in `package.json#engines`. |
+| Future Docker build (`feat_infra_001`) needs the same `VITE_API_BASE_URL` machinery. | Env-var contract is intentionally one variable, prefixed `VITE_`, so the Docker build stage can pass it via `--build-arg` / `ENV` without redesign. |
+
+## Dependencies
+
+- **Runtime (bundled):** `react`, `react-dom`.
+- **Build / dev:** `vite`, `@vitejs/plugin-react`, `typescript`, `@types/react`, `@types/react-dom`. Exact versions are picked by Vulcan from the current stable `bun create vite --template react-ts` output and pinned via `bun.lockb`.
+- **Tooling on the host machine:** `bun` (package manager + script runner) and `node` (Vite dev server + bundler runtime). Versions documented in `frontend/README.md`.
+- **External services consumed at runtime:** the backend from `feat_backend_001` (specifically `GET /api/v1/hello`, plus its dependencies on Postgres and Redis to serve a 200).
+- No new top-level repo dependencies. No backend changes.

--- a/docs/specs/feat_frontend_001/feat_frontend_001.md
+++ b/docs/specs/feat_frontend_001/feat_frontend_001.md
@@ -1,0 +1,69 @@
+# Feature: Frontend scaffold and hello-world page
+
+## Problem Statement
+
+The repo has a working FastAPI backend (`feat_backend_001`) exposing `GET /api/v1/hello`, but no client. To complete the minimalist full-stack template, we need a small, conventional Vite + React + TypeScript application that:
+
+1. Demonstrates the canonical way to scaffold a frontend in this repo (so future features have a pattern to copy).
+2. Calls the backend's hello endpoint and renders the response, proving end-to-end connectivity for whoever clones the template.
+3. Is managed entirely with `bun` for installs and scripts (per `conventions.md` §9), while leaving the Vite dev server and bundling on Node where they belong.
+
+Without this, the template has a backend that nothing visibly consumes, and there is no precedent established for how a UI lives next to the backend in this monorepo.
+
+## Requirements
+
+- A `frontend/` directory at the monorepo root, sibling to `backend/`.
+- A standard Vite + React + TypeScript scaffold managed with `bun`. The `bun.lockb` lockfile is committed.
+- A single page that, on mount, calls `GET /api/v1/hello` and renders the response payload.
+- Three rendering states are handled: loading, error, and success.
+- The base URL of the backend is configurable via the Vite env var `VITE_API_BASE_URL`, defaulting to `http://localhost:8000` in local development. A `frontend/.env.example` ships this default.
+- A small typed API-client module (e.g. `src/api/client.ts`) exports a typed `getHello()` function; the response type lives alongside it. The page imports from this module rather than calling `fetch` inline.
+- A short `frontend/README.md` documents `bun install`, `bun run dev`, `bun run build`, and the `VITE_API_BASE_URL` env var.
+- A `frontend/.gitignore` covers Node/Vite/Bun artifacts (`node_modules/`, `dist/`, `.env`, etc.) — but the lockfile (`bun.lockb`) is **not** ignored.
+
+## User Stories
+
+- As a developer cloning this template, I want to run `bun install && bun run dev` inside `frontend/` and immediately see a page that talks to my local backend, so I know the full stack is wired up.
+- As the author of a future frontend feature, I want a minimal but conventional Vite + React + TypeScript layout to copy from, so I do not have to reinvent project structure or rediscover how `bun` and Vite cooperate.
+- As an operator, I want to point the frontend at a non-default backend URL via a single env var, so I can run the UI against staging or a docker-compose stack later without code changes.
+
+## Scope
+
+### In Scope
+
+- Vite + React + TypeScript scaffold under `frontend/`.
+- Bun-driven install and script lifecycle (`bun install`, `bun run dev`, `bun run build`, `bun run preview`).
+- One page (the default route — no router) that calls the backend's `/api/v1/hello` and renders loading, error, and success states.
+- A typed API-client module wrapping `fetch`, with a typed response model that mirrors the backend's `HelloResponse` schema (`message`, `item_name`, `hello_count`).
+- `frontend/.env.example` declaring `VITE_API_BASE_URL=http://localhost:8000`.
+- `frontend/README.md` covering install, dev, build, env var, and how the dev server reaches the backend.
+- `frontend/.gitignore` for the frontend subtree.
+
+### Out of Scope
+
+- Routing libraries (React Router, TanStack Router, etc.) — single page only.
+- State management libraries (Redux, Zustand, Jotai, React Query, etc.) — `useState` + `useEffect` is sufficient.
+- UI component frameworks or design systems (MUI, Chakra, shadcn, Tailwind, etc.). Default Vite styling is fine; minor inline or CSS-module styling for legibility is acceptable.
+- Authentication, sessions, cookies, or auth headers.
+- Docker images, `Dockerfile`, or `docker-compose` integration — owned by `feat_infra_001`.
+- All forms of frontend testing (unit, component, integration, e2e, Playwright, Vitest). Explicitly deferred; see the test spec.
+- Linting/formatting beyond what the Vite TypeScript template ships with by default. Custom ESLint/Prettier configuration is a separate future feature.
+- CI/CD or GitHub Actions wiring.
+- Backend CORS configuration. The frontend will reach the backend via Vite's dev-server proxy (see design spec), so no backend change is required for `feat_frontend_001`.
+- Production hosting / deploy artifacts.
+
+## Acceptance Criteria
+
+- [ ] `frontend/` exists at the repo root, sibling to `backend/`.
+- [ ] `frontend/package.json` declares Vite + React + TypeScript dependencies and `dev`, `build`, `preview` scripts.
+- [ ] `bun install` (run inside `frontend/`) succeeds against the committed `bun.lockb` with no network surprises.
+- [ ] `bun run build` (run inside `frontend/`) completes successfully with zero TypeScript errors.
+- [ ] With the backend running locally on `http://localhost:8000`, `bun run dev` serves the UI and the page successfully fetches and renders the `/api/v1/hello` payload (showing at least the `message` field).
+- [ ] When the backend is not reachable, the page renders a visible, human-readable error state (not a blank screen, not a raw stack trace).
+- [ ] While the request is in flight, the page renders a visible loading state.
+- [ ] The API call goes through the typed client module; the page component does not call `fetch` directly.
+- [ ] `frontend/.env.example` exists and declares `VITE_API_BASE_URL=http://localhost:8000`.
+- [ ] `frontend/README.md` documents install, dev, build, and the env var.
+- [ ] `frontend/.gitignore` excludes `node_modules/`, `dist/`, and `.env` (but not `.env.example` or `bun.lockb`).
+- [ ] `bun.lockb` is committed.
+- [ ] No changes are made outside `frontend/` (no backend edits, no top-level config edits).

--- a/docs/specs/feat_frontend_001/test_frontend_001.md
+++ b/docs/specs/feat_frontend_001/test_frontend_001.md
@@ -1,0 +1,67 @@
+# Test Spec: Frontend scaffold and hello-world page
+
+## Testing Posture for This Feature
+
+**This feature ships with no automated tests.** That is a deliberate choice, not an oversight:
+
+- The user has explicitly rejected adding any flavor of frontend test (unit, component, integration, end-to-end, snapshot, Vitest, Playwright, Cypress, Testing Library) to `feat_frontend_001`. Adding any of these would expand scope and lock the template into a test toolchain before the testing feature is designed.
+- The cross-cutting test harness for this template is owned by `feat_testing_001` and is, per the user's pre-approved plan, **REST-only against the running stack**. It exercises the backend's HTTP contract (including `GET /api/v1/hello`) directly. Because the frontend's only contract with the rest of the system is "call `/api/v1/hello` and render the response," the REST-level coverage in `feat_testing_001` is what indirectly guards the contract this frontend depends on.
+- No frontend-side test framework, runner, or fixture infrastructure is introduced by this feature. Adding one later is a separate, explicit feature decision (likely a `feat_testing_NNN` or a `feat_frontend_NNN` follow-up) and would update `conventions.md` §9 if the choice locks in a tool.
+
+Therefore the sections below describe **manual verification steps** that Vulcan (and a human reviewer) should execute before declaring `feat_frontend_001` done. They are not automated test cases. Vulcan must not invent component tests, install Vitest, add a `tests/` directory under `frontend/`, or wire Playwright. If any of those appear in the build PR, the PR should be rejected.
+
+## What `feat_testing_001` Will Cover (For Reference)
+
+When `feat_testing_001` lands, its REST suite is expected to assert at minimum:
+
+- `GET /api/v1/hello` returns HTTP 200 with a JSON body matching the `HelloResponse` shape (`message`, `item_name`, `hello_count`).
+- `hello_count` is a non-negative integer and increments across successive calls (Redis round-trip works).
+- `item_name` is the seeded value (Postgres round-trip works).
+- The error envelope shape (`{"error": {"code", "message", "request_id"}}`) is returned for failure modes.
+
+Those assertions are the ground truth that the frontend's typed `HelloResponse` and its rendering logic depend on. If any of them break, the frontend's success view will misrender, and the REST suite will catch the regression at the source.
+
+## Manual Verification Checklist (For Vulcan and Reviewer)
+
+### Happy Path
+
+| # | Step | Expected Outcome |
+|---|---|---|
+| 1 | From repo root: `cd frontend && bun install`. | Completes without errors; `node_modules/` populated; no lockfile churn (i.e. `bun.lockb` does not change after install). |
+| 2 | Start the backend per `backend/README.md` so `http://localhost:8000/api/v1/hello` returns 200. Then in a second terminal: `cd frontend && bun run dev`. | Vite dev server starts (default `http://localhost:5173`) with no errors. |
+| 3 | Open `http://localhost:5173/` in a browser. | Page first shows the loading state, then transitions to the success view, displaying at least the backend's `message` field. |
+| 4 | Reload the page several times. | Each reload re-fetches; if `hello_count` is rendered, it increments by 1 each time. |
+| 5 | From repo root: `cd frontend && bun run build`. | Build completes with zero TypeScript errors and produces `frontend/dist/`. |
+| 6 | `cd frontend && bun run preview`. | Preview server serves the built bundle; opening it in a browser shows the same hello page behavior as step 3 (assuming the proxy/env target is reachable). |
+
+### Error / Degraded Cases
+
+| # | Step | Expected Outcome |
+|---|---|---|
+| 1 | Stop the backend, then load `http://localhost:5173/`. | Page renders a visible, human-readable error state (e.g. "Failed to load: ..."). No blank screen, no uncaught exception in the browser console beyond the expected fetch failure. |
+| 2 | Restart the backend in a state where the seed row is missing (the `/api/v1/hello` handler returns HTTP 503 — see `backend/app/api/v1/hello.py`). | Page renders the error state; the rendered message includes enough information (e.g. the HTTP status) for a developer to know what to fix. |
+| 3 | Set `VITE_API_BASE_URL` to a clearly wrong value (e.g. `http://localhost:9999`) and run `bun run dev`. | The Vite proxy fails to forward; the page renders the error state without crashing. |
+| 4 | Delete `frontend/.env` (if present), keep `.env.example`, and run `bun run dev`. | App still works against the default proxy target (`http://localhost:8000`) because the API client uses a relative URL and the proxy default-targets the backend. |
+
+### Boundary / Convention Checks
+
+| # | Check | Expected |
+|---|---|---|
+| 1 | `frontend/bun.lockb` is committed in the build PR. | Present in `git status`; not gitignored. |
+| 2 | `frontend/.gitignore` excludes `node_modules/`, `dist/`, and `.env`. | These paths do not appear in `git status` after a fresh `bun install` and `bun run build`. |
+| 3 | `frontend/.env` is NOT committed; `frontend/.env.example` IS committed. | `git ls-files frontend/.env` is empty; `git ls-files frontend/.env.example` lists the file. |
+| 4 | The page component (`src/App.tsx`) does not call `fetch` directly. | `grep -n "fetch(" frontend/src/App.tsx` returns no matches; all HTTP goes through `src/api/client.ts`. |
+| 5 | `HelloResponse` is defined exactly once. | `grep -rn "interface HelloResponse\|type HelloResponse" frontend/src` returns one definition, in `src/api/client.ts`. |
+| 6 | No backend files are touched by this feature's PR. | `git diff --name-only origin/main...HEAD` shows changes only under `frontend/`. |
+| 7 | No test framework is added. | `frontend/package.json` does not depend on `vitest`, `@testing-library/*`, `playwright`, `cypress`, `jest`, `mocha`, etc. No `tests/` or `__tests__/` directory exists under `frontend/`. |
+| 8 | TypeScript strict mode is on. | `frontend/tsconfig.app.json` (or equivalent) has `"strict": true`. |
+
+### Security Considerations
+
+This feature has a small attack surface — it is a single GET against an endpoint that takes no input — so the security checklist is short:
+
+- **No secrets in env files.** `frontend/.env.example` contains only the public backend base URL. `.env` (if a developer creates one) is gitignored. Document in the README that anything truly secret must NOT live in a `VITE_*` variable, since `VITE_*` vars are inlined into the client bundle and visible to anyone who loads the page.
+- **Render all backend strings as plain text.** The success view renders `data.message` (and optionally `data.item_name`, `data.hello_count`) using React's default text-node rendering, which HTML-escapes the content. The error view renders the `Error.message` string the same way. Vulcan must not introduce any raw-HTML-injection escape hatch (such as React's `dangerously*` props) in either render path; if rich rendering is ever needed later, route untrusted strings through a vetted sanitizer library first.
+- **No auth headers, no cookies, no credentials.** The fetch call uses default credentials mode (`same-origin`), which under the Vite proxy means no cookies are forwarded cross-origin and no `Authorization` header is added. This is correct for the current scope.
+- **Error rendering does not leak stack traces.** The error view shows the `Error.message` string only, not the full `Error.stack`. This avoids inadvertently surfacing implementation paths to a viewer.
+- **Dependency surface is minimal.** Only the Vite + React baseline (plus `@types/*`). Vulcan should not add transient dependencies beyond what `bun create vite --template react-ts` ships.


### PR DESCRIPTION
## Specifications for feat_frontend_001

Stand up a minimal Vite + React + TypeScript app under `frontend/`, managed with `bun`. The single page calls the backend's `GET /api/v1/hello` (introduced in `feat_backend_001`) through a typed API client and renders loading, error, and success states. Vite's dev-server proxy is used so no backend CORS change is required.

This is the spec PR (Atlas). Implementation will land in a follow-on `build/feat_frontend_001` PR (Vulcan), gated on this merging.

### Spec files
- Feature: `docs/specs/feat_frontend_001/feat_frontend_001.md`
- Design: `docs/specs/feat_frontend_001/design_frontend_001.md`
- Test:    `docs/specs/feat_frontend_001/test_frontend_001.md`

### Notable scope boundaries (per pre-approved plan)
- No frontend tests of any kind in this feature (REST coverage is owned by `feat_testing_001`).
- No Docker / `docker-compose` (owned by `feat_infra_001`).
- No routing library, no state library, no UI framework, no auth.
- No lint/format config beyond Vite template defaults; no CI.
- Backend is not modified — Vite dev proxy sidesteps CORS.

### Backend contract this depends on
The backend's `HelloResponse` shape on `main` is `{ message: string, item_name: string, hello_count: number }` (see `backend/app/api/v1/hello.py` and `backend/app/schemas.py`). The frontend's typed client mirrors that shape.