### PR TITLE
spec(feat_infra_001): docker-compose stack + dockerfiles

### DIFF
--- a/docs/specs/feat_infra_001/design_infra_001.md
+++ b/docs/specs/feat_infra_001/design_infra_001.md
@@ -1,0 +1,256 @@
+# Design: Docker Compose stack and per-service Dockerfiles
+
+## Approach
+
+Introduce a minimal, dev-first docker-compose stack whose job is strictly **local orchestration** per `conventions.md` §8. Compose file, env template, and Makefile plumbing live in `infra/`; Dockerfiles live adjacent to the code they build (`backend/Dockerfile`, `frontend/Dockerfile`) because they are a property of the service, not of the orchestration.
+
+Design principles driving the decisions below:
+
+1. **One entrypoint script per service.** The Dockerfile `CMD`s invoke `backend/start.sh` and `frontend/start.sh`, the same scripts used for local non-Docker runs. Both scripts already carry top-of-file comments stating they will be reused as container entrypoints (`backend/start.sh:19`, `frontend/start.sh:20`). No shell logic is duplicated between "how I run this locally" and "how the container runs this."
+2. **Dev by default.** `make up` (i.e. `docker compose up`) yields a hot-reload dev loop: backend uvicorn `--reload`, Vite dev server with HMR, source bind-mounted into containers. This is the most common path on a template repo and should be frictionless.
+3. **Prod mode is opt-in and minimal.** A `prod` compose profile builds static frontend assets and serves them from `nginx:alpine`; backend runs uvicorn without `--reload`. No source bind mounts. This exists so the Dockerfiles are exercised against a production-shape build, and so a future deployment feature can reuse the Dockerfile targets unchanged.
+4. **Database and cache are internal by default.** Postgres and Redis have no `ports:` stanza — they are reachable only over the compose network. Backend publishes 8000; frontend publishes 5173 (dev) or 8080 (prod, nginx). An operator who wants `psql` from the host can uncomment a line in `infra/.env` or use `docker compose exec postgres psql`.
+5. **Migrations run on container start in dev.** The `MIGRATE=1` knob on `backend/start.sh` already exists; compose sets it in `infra/.env.example`. This is the right default for a template (clean clone → working DB in one command). For situations where that is wrong (e.g. pinning a specific revision while debugging), `make migrate` runs migrations as a one-shot and `MIGRATE` can be turned off in `infra/.env`.
+
+### Open design calls surfaced for human review
+
+Two choices are judgment calls allowed by the prompt; both are documented here and called out in the spec PR body so the human can veto:
+
+- **Dev-by-default with opt-in `prod` profile**, rather than a separate `docker-compose.prod.yml` or a flag-driven split. Rationale: this is a template for local development; adding a second compose file doubles surface area for a path most users will never take. The `--profile prod` switch gives us a single source of truth with one additional keyword.
+- **`MIGRATE=1` by default in `infra/.env.example`**, rather than requiring `make migrate` as a manual step. Rationale: the existing `backend/start.sh` already supports this cleanly; the first-run experience of "one command, working DB" outweighs the rare case where auto-migration surprises someone. The escape hatch (`make migrate`, plus toggling `MIGRATE=0`) is documented.
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `infra/docker-compose.yml` | Four-service stack (`backend`, `frontend`, `postgres`, `redis`), one user-defined network, named volumes for Postgres and Redis data, health checks, dev + `prod` profile. |
+| `infra/.env.example` | Consolidated env for the compose stack: Postgres credentials, `DATABASE_URL` as seen from the backend container, `REDIS_URL`, published host ports, `VITE_API_BASE_URL`, `MIGRATE` flag, `ENV`. Copied to `infra/.env` (gitignored) on first run. |
+| `infra/.gitignore` | Ignores `.env` and `.env.*` but **not** `.env.example`. |
+| `backend/Dockerfile` | Multi-stage image for the FastAPI service: uv-based build stage, slim runtime stage, non-root user, `CMD ["./start.sh"]`. |
+| `backend/.dockerignore` | Excludes `.venv/`, `.pytest_cache/`, `__pycache__/`, `*.pyc`, `.env`, `.env.*` (keeps `.env.example`), `tests/` from the runtime image but not the build context, etc. |
+| `frontend/Dockerfile` | Multi-target image: `dev` target runs `bun run dev`; `prod` target builds via `bun run build` and serves from `nginx:alpine`. Both finals run as non-root. |
+| `frontend/.dockerignore` | Excludes `node_modules/`, `dist/`, `.vite/`, `.env`, `.env.*` (keeps `.env.example`), etc. |
+| `.dockerignore` (repo root) | Excludes `.git/`, `docs/`, `.claude/`, `backend/.venv`, `frontend/node_modules`, any `.env` files except `.env.example`, etc. Relevant when a build uses the repo root as context (not the default, but guarded anyway). |
+| `Makefile` (repo root) | Developer-ergonomic forwarders: `up`, `down`, `logs`, `migrate`, `ps`, `build`, `clean`. Each target `cd`s into `infra/` and invokes `docker compose`. |
+
+## Files to Modify
+
+| File | Change Description |
+|---|---|
+| `README.md` (repo root) | Append a "Running with Docker" section documenting: prerequisites (Docker + Docker Compose v2), `cp infra/.env.example infra/.env`, `make up`, host-published ports (8000 backend, 5173 frontend dev), `make logs`, `make migrate`, `make down`, `make clean`, and a pointer to `infra/docker-compose.yml` as the source of truth. Existing content must remain byte-for-byte unchanged above the new section. Vulcan should add the section near the end of the file, below "Workflow" and above "License". |
+
+## Compose Topology
+
+Service graph:
+
+```
+ frontend  -->  backend  -->  postgres  (condition: service_healthy)
+                       \-->  redis     (condition: service_healthy)
+```
+
+Network: one user-defined bridge network, e.g. `appnet`. Compose injects service-name DNS so `backend` reaches Postgres at `postgres:5432` and Redis at `redis:6379`.
+
+### Service: `postgres`
+
+- Image: `postgres:16-alpine` (version chosen to match the `postgresql+asyncpg://` driver that `backend/app/settings.py:34` defaults to; Vulcan may bump the minor at build time if 16 turns out to be problematic — document the chosen tag in `infra/.env.example`).
+- Env: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` all sourced from `infra/.env`. Defaults in `.env.example`: `postgres` / `postgres` / `app` (matches `backend/app/settings.py:34` defaults so migrations "just work" out of the box).
+- Volume: named volume `pgdata` mounted at `/var/lib/postgresql/data`.
+- Health check: `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB` with a 5s interval, 5s timeout, 10 retries, 10s start period.
+- Ports: **none published.** Internal only.
+
+### Service: `redis`
+
+- Image: `redis:7-alpine`.
+- Volume: named volume `redisdata` mounted at `/data`. Config enables AOF persistence via the command line (e.g. `command: ["redis-server", "--appendonly", "yes"]`).
+- Health check: `redis-cli ping` expecting `PONG` with a 5s interval, 3s timeout, 10 retries, 5s start period.
+- Ports: **none published.** Internal only.
+
+### Service: `backend`
+
+- Build: `context: ..` (the repo root, so the build can see `backend/` without escaping upward), `dockerfile: ../backend/Dockerfile`. Alternatively `context: ../backend` with all paths relative to backend — Vulcan picks whichever keeps the Dockerfile simpler; design requires only that the choice be internally consistent.
+- Env: loaded from `infra/.env`; maps to the backend's expected variables (`DATABASE_URL`, `REDIS_URL`, `HOST`, `PORT`, `LOG_LEVEL`, `MIGRATE`, `ENV`, `REQUEST_ID_HEADER`). The `DATABASE_URL` in `infra/.env.example` uses the compose hostname: `postgresql+asyncpg://postgres:postgres@postgres:5432/app`. Likewise `REDIS_URL=redis://redis:6379/0`.
+- Ports: publishes container `8000` → host `${BACKEND_PORT:-8000}`.
+- `depends_on`:
+  ```yaml
+  postgres: { condition: service_healthy }
+  redis:    { condition: service_healthy }
+  ```
+- Dev mode (default): bind-mounts `../backend` → `/app` so code changes hot-reload via uvicorn's `--reload`. Startup runs `./start.sh serve --reload` (the compose `command:` overrides CMD in dev mode). When `MIGRATE=1` (default), `start.sh` runs `alembic upgrade head` before uvicorn.
+- Prod profile (`profiles: ["prod"]` on an alternate `backend` command OR a second service `backend-prod`): no bind mount; runs `./start.sh serve` (no `--reload`).
+
+### Service: `frontend`
+
+- Build: `context: ..`, `dockerfile: ../frontend/Dockerfile`, `target: dev` (default) or `target: prod` under the `prod` profile.
+- Env: `VITE_API_BASE_URL=http://localhost:${BACKEND_PORT:-8000}` from `infra/.env`. Because the Vite dev server runs inside the frontend container but the browser runs on the developer's host, the browser's idea of the backend is the host-published port, not the compose hostname — see "Data Flow" below.
+- Ports: publishes container `5173` → host `${FRONTEND_PORT:-5173}` in dev; `8080` → host `${FRONTEND_PORT:-8080}` in prod (nginx).
+- Dev mode: bind-mounts `../frontend` → `/app` with a named volume masking `/app/node_modules` so the container's installed `node_modules/` is not clobbered by the host bind mount. `CMD ["./start.sh", "dev"]`.
+- `depends_on`: `backend` (condition: `service_started` is sufficient; frontend does not call backend at boot).
+
+### Volumes
+
+```yaml
+volumes:
+  pgdata:
+  redisdata:
+  frontend_node_modules:   # named volume masking /app/node_modules in the dev bind mount
+```
+
+### Network
+
+```yaml
+networks:
+  appnet:
+```
+
+All four services are attached to `appnet`. No custom driver or subnet — the default bridge is sufficient.
+
+## Dockerfile Stages
+
+### `backend/Dockerfile`
+
+Two stages:
+
+1. **`builder`** (based on `python:3.12-slim` or `python:3.11-slim` to match `requires-python = ">=3.11"` in `backend/pyproject.toml:6`):
+   - Install `uv` (pin a version; document in a comment).
+   - Copy `pyproject.toml`, `uv.lock` first to maximize Docker layer cache on dependency changes.
+   - `uv sync --frozen --no-install-project` to install dependencies.
+   - Copy the rest of `backend/`.
+   - `uv sync --frozen` to install the project itself.
+2. **`runtime`** (same slim base):
+   - Create a non-root user (`appuser`, uid 1000).
+   - Copy the `.venv` from `builder` and the app source.
+   - `WORKDIR /app`.
+   - `USER appuser`.
+   - `EXPOSE 8000`.
+   - `ENTRYPOINT ["./start.sh"]` and `CMD ["serve"]`. The entrypoint/CMD split lets `make migrate` override with `["migrate"]` via compose `command:`.
+
+### `frontend/Dockerfile`
+
+Three stages:
+
+1. **`base`** (based on `oven/bun:1` or `node:20-alpine` + `bun` — Vulcan picks the simpler option; document the choice with a one-line comment). Installs OS deps needed by Vite if any, copies `package.json` and `bun.lock`, runs `bun install --frozen-lockfile`.
+2. **`dev`** (default target for dev mode): copies the rest of `frontend/`, creates a non-root user, `USER appuser`, `EXPOSE 5173`, `CMD ["./start.sh", "dev"]`.
+3. **`build`**: reuses `base`, copies source, runs `bun run build` to produce `dist/`.
+4. **`prod`**: based on `nginx:alpine`, copies the `dist/` output from the `build` stage, uses a tiny default nginx config that serves `/` as SPA (try_files with fallback to `index.html`), exposes `8080`, runs as the stock nginx non-root variant (`nginx:alpine` already includes `nginx-unprivileged`-style defaults; Vulcan confirms at build time).
+
+## Data Flow
+
+From a developer's host, after `make up`:
+
+```
+browser (host)
+   │  GET http://localhost:5173
+   ▼
+frontend container  (Vite dev server on :5173, source bind-mounted)
+   │  (Vite's proxy or direct fetch; see note below)
+   ▼
+browser (host)  ── GET http://localhost:8000/api/v1/hello ──▶  backend container (:8000)
+                                                                  │
+                                                                  ├── SELECT 1 ──▶  postgres (:5432, internal only)
+                                                                  └── PING     ──▶  redis    (:6379, internal only)
+```
+
+Note on the Vite proxy: `frontend/vite.config.ts` already proxies `/api` to `VITE_API_BASE_URL`. In compose, we set `VITE_API_BASE_URL=http://backend:8000` if the proxy runs inside the container (server-side), **but** if the frontend code calls the backend directly from the browser, the URL must be the host-published address (`http://localhost:8000`). The current frontend (`feat_frontend_001`) relies on Vite's dev-server proxy for `/api` — so the proxy target can be `http://backend:8000` (server-side resolution inside the frontend container) and the browser only ever hits `http://localhost:5173/api/...`. Vulcan must confirm this by reading `frontend/src/api/client.ts` at build time; if the client uses an absolute URL, the env var must point at the host-published backend instead. This is the single subtle wiring decision in the whole feature — call it out in the build PR.
+
+For migrations:
+
+```
+make migrate
+   │  docker compose run --rm backend ./start.sh migrate
+   ▼
+backend container  ── alembic upgrade head ──▶  postgres
+```
+
+## Env var flow
+
+Single source of truth: `infra/.env` (copied from `infra/.env.example`).
+
+`infra/docker-compose.yml` declares `env_file: .env` under each service and additionally uses `${VAR}` interpolation for values that appear in `ports:` or compose-level config. This means:
+
+- **Stack-shape vars** (host port mappings, Postgres credentials used by the `postgres` service init, image tags) — come from `${VAR}` interpolation at compose parse time.
+- **Runtime vars** (consumed by the app processes: `DATABASE_URL`, `REDIS_URL`, `LOG_LEVEL`, etc.) — come from `env_file:` and land in the container environment, where pydantic-settings in `backend/app/settings.py` picks them up.
+
+`infra/.env.example` documents every variable with a comment. Backend's own `backend/.env.example` is retained (it works for non-Docker local runs) but the compose flow does not read it; the two templates may drift intentionally (e.g. `DATABASE_URL` points at `localhost` in `backend/.env.example`, at `postgres` in `infra/.env.example`).
+
+Proposed `infra/.env.example` keys (non-exhaustive):
+
+```
+# Host-published ports
+BACKEND_PORT=8000
+FRONTEND_PORT=5173
+
+# Postgres
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=app
+
+# Backend runtime
+ENV=dev
+LOG_LEVEL=INFO
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/app
+REDIS_URL=redis://redis:6379/0
+MIGRATE=1
+REQUEST_ID_HEADER=X-Request-ID
+
+# Frontend runtime
+VITE_API_BASE_URL=http://backend:8000
+```
+
+## Health check design
+
+- **postgres** — `pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB`. The double `$$` escapes compose variable interpolation so the shell inside the container resolves it. Interval 5s, retries 10, start_period 10s. This is well-established Docker idiom; the reason we're being explicit is so `backend` can `depends_on: { condition: service_healthy }` without flakiness on slow laptops.
+- **redis** — `redis-cli ping` matched against `PONG`. Interval 5s, retries 10, start_period 5s.
+- **backend** — a compose-level health check is **not** required for this feature (no other service waits on backend's readiness). The application exposes `GET /readyz` (`backend/app/api/health.py:24`) which is used by humans and by `feat_testing_001` validation, not by compose itself. Optional polish: we could add `healthcheck: curl -fsS http://localhost:8000/readyz` using `curl` if it's in the slim image, or use Python + urllib to avoid installing curl. Vulcan may add this if it's a one-liner; it's not a blocker.
+- **frontend** — no health check. Readiness is "Vite printed its bind line" which is hard to express portably; `depends_on: backend` on downstream services (there are none today) is enough.
+
+## Makefile targets
+
+Root `Makefile`, intentionally small (< 40 lines of non-comment content). Every target is a thin forwarder:
+
+| Target | Behavior |
+|---|---|
+| `make up` | `cd infra && docker compose up -d --build` (dev profile). Exits after services report healthy on their own (compose handles this). |
+| `make down` | `cd infra && docker compose down`. Containers and network go; named volumes stay. Idempotent. |
+| `make logs` | `cd infra && docker compose logs -f`. |
+| `make ps` | `cd infra && docker compose ps`. |
+| `make build` | `cd infra && docker compose build`. Rebuilds images without starting services. |
+| `make migrate` | `cd infra && docker compose run --rm backend ./start.sh migrate`. One-shot. |
+| `make clean` | `cd infra && docker compose down -v`. Named volumes removed. Destructive. Print a confirmation-prompting `@echo` header so this is not accidentally invoked by muscle memory; interactive `read` is overkill for a template. |
+| `make help` (default) | Prints the target list with one-line descriptions. |
+
+A mirror `Makefile` inside `infra/` is **not** planned unless Vulcan finds that some target genuinely reads more clearly there; per prompt, that's optional and should only land if it simplifies something.
+
+## Migration Strategy (recap)
+
+- Dev (default): `MIGRATE=1` in `infra/.env.example` → `backend/start.sh` runs `alembic upgrade head` before uvicorn. No code change on backend side — already supported by `backend/start.sh:52`.
+- Escape hatch: `make migrate` → `docker compose run --rm backend ./start.sh migrate`. Useful when `MIGRATE=0` is set locally for debugging, or when the operator wants an explicit migration step in a script.
+- Prod profile: Vulcan should leave `MIGRATE=1` on in the prod profile too unless there is a concrete reason not to; this is a template, not a prod deployment pipeline, and hardening is `deployment/`'s job.
+
+## Edge Cases & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Host bind mount of `frontend/` masks the container's `node_modules/`, breaking `bun run dev`. | Declare a named volume `frontend_node_modules` mounted at `/app/node_modules` in the dev profile so the container-local install is preserved. |
+| Backend container starts before Postgres is actually accepting connections (TCP up but not ready). | `postgres` health check is `pg_isready`, not a TCP probe. Backend uses `depends_on: { condition: service_healthy }`. |
+| `MIGRATE=1` on every container restart slows down the dev loop. | Alembic no-ops if the DB is already at head, so the cost is a single `SELECT` per restart. Operators who mind can set `MIGRATE=0`. |
+| Vite dev server inside a container does not reach the host browser because HMR websocket is misconfigured. | Vite's default `server.host` is `localhost`; the `frontend/start.sh dev` entrypoint forwards `--host 0.0.0.0` (see `frontend/start.sh:53`). No extra config needed, but Vulcan must verify by hitting `http://localhost:5173` from the host browser during manual validation. |
+| Frontend code uses absolute backend URLs (not the `/api` prefix + proxy), so the `VITE_API_BASE_URL=http://backend:8000` value does not work for the browser. | Read `frontend/src/api/client.ts` at build time. If absolute URLs are in use, switch `infra/.env.example` to `VITE_API_BASE_URL=http://localhost:8000` and accept that the browser, not the container, is the caller. Flag the choice in the build PR. |
+| Ports 5432 or 6379 accidentally published, exposing unauthenticated DB to the network. | Compose has no `ports:` stanza on `postgres` or `redis`. `infra/.env.example` does not define `POSTGRES_PORT` / `REDIS_PORT` host mapping vars. To expose, an operator must hand-edit compose, which is a deliberate act. |
+| `deployment/` silently appears in this feature. | Acceptance criterion gates on this, and the review checklist in the spec PR body should include "confirm `deployment/` not created". |
+| Image bloat (hundreds of MB). | `-slim` / `-alpine` bases; multi-stage build discards build tooling; `.dockerignore` trims context. Not a blocker for this feature; a later feature can tune further. |
+| `make clean` destroys data unexpectedly. | Target prints a clear `@echo` warning line before running `docker compose down -v`. No interactive confirm (template repo; users who type `make clean` deserve to be believed). |
+| Docker Compose v1 (`docker-compose` with a hyphen) vs v2 (`docker compose`). | Makefile and README standardize on v2 syntax (`docker compose`). README "Running with Docker" lists Docker Desktop 4.x / Docker Engine 20.10+ as the prerequisite so v2 is guaranteed. |
+| Alembic migrations race when multiple backend replicas start simultaneously. | N/A for this feature — compose runs one `backend` replica. Future deployment work owns multi-replica migration strategy. |
+
+## Dependencies
+
+External (pulled at image build / compose-up time, **not** committed):
+
+- `python:3.11-slim` or `python:3.12-slim` (Docker Hub)
+- `postgres:16-alpine` (Docker Hub)
+- `redis:7-alpine` (Docker Hub)
+- `oven/bun:1` or `node:20-alpine` + `bun` — Vulcan's call, documented inline
+- `nginx:alpine` (prod profile only)
+- `uv` (installed into the backend builder stage; version pinned in the Dockerfile)
+
+No Python or Node packages added. No backend or frontend source changes. No new runtime services.

--- a/docs/specs/feat_infra_001/feat_infra_001.md
+++ b/docs/specs/feat_infra_001/feat_infra_001.md
@@ -1,0 +1,79 @@
+# Feature: Docker Compose stack and per-service Dockerfiles
+
+## Problem Statement
+
+`feat_backend_001` and `feat_frontend_001` each produce working services, but running the full template today requires four manual terminals: start Postgres, start Redis, run `backend/start.sh`, run `frontend/start.sh`. There is no reproducible way for someone who just cloned this template to bring the whole stack up, and no containerized build that a future deployment feature (DigitalOcean, AWS, Azure, etc.) can reuse.
+
+This feature introduces the local orchestration layer promised by `conventions.md` §8 (the `infra/` directory) and §10 (feature 4 of 5 in the bootstrap roster): a `docker-compose.yml` that stands up `backend`, `frontend`, `postgres`, and `redis` together, a per-service `Dockerfile` for the two application services, a small root `Makefile` with ergonomic shortcuts, and a consolidated `infra/.env.example` so a new contributor can get from clean clone to running stack in one command.
+
+Deployment artifacts (Helm, Terraform, cloud-specific scripts) are **not** part of this feature. Per `conventions.md` §8, `deployment/` is introduced by a later infra feature; this feature owns local orchestration only.
+
+## Requirements
+
+- A new `infra/` directory at the repo root containing:
+  - `infra/docker-compose.yml` — defines four services (`backend`, `frontend`, `postgres`, `redis`), a shared network, and named volumes for Postgres and Redis data.
+  - `infra/.env.example` — a single consolidated env template for the compose stack, committed (the real `.env` is gitignored).
+- A `backend/Dockerfile` adjacent to backend code (per user decision, not inside `infra/`).
+- A `frontend/Dockerfile` adjacent to frontend code (per user decision, not inside `infra/`).
+- A `.dockerignore` at the repo root, and per-service `.dockerignore` files under `backend/` and `frontend/`, so build contexts stay small and do not leak secrets or build artifacts.
+- A root `Makefile` with developer-ergonomic targets (`make up`, `make down`, `make logs`, `make migrate`, `make ps`, `make build`, `make clean`) that forward into `infra/` so the compose file can live there without forcing every command to `cd infra`.
+- The stack defaults to **dev mode** (bind-mounted source, backend uvicorn `--reload`, Vite dev server with HMR). A minimal `prod` profile builds static frontend assets behind nginx and runs uvicorn without reload; it is opt-in via `docker compose --profile prod up`.
+- Postgres and Redis expose health checks so `backend` can `depends_on: condition: service_healthy` and `make up` does not race.
+- A new "Running with Docker" section is **appended** to the root `README.md` (existing content stays intact) documenting the `make up` path from clean clone.
+
+## User Stories
+
+- As a developer cloning this template, I want to run `cp infra/.env.example infra/.env && make up` from the repo root and have the full stack (frontend, backend, Postgres, Redis) come up healthy in one command, so I can start working on features immediately without rediscovering service wiring.
+- As the author of `feat_testing_001`, I want a reliable `make up` that yields healthy services at known ports, so the REST functional suite can target `http://localhost:8000` (or the compose-exposed port) without starting services by hand.
+- As the author of a future deployment feature, I want per-service Dockerfiles that already build a production-suitable image (multi-stage, non-root, slim base), so `deployment/` only has to orchestrate and configure — not re-define — the runtime image.
+- As an operator running this template in a shared environment, I want Postgres and Redis to be reachable only on the compose network by default (not published to the host), so a development laptop does not accidentally expose an unauthenticated database.
+
+## Scope
+
+### In Scope
+
+- `infra/docker-compose.yml` with services `backend`, `frontend`, `postgres`, `redis`; named volumes for Postgres and Redis data; a shared user-defined network.
+- Health checks on `postgres` and `redis`; `backend` waits for both to be healthy before starting.
+- `backend/Dockerfile` — multi-stage (uv-based build stage, slim runtime stage), non-root user, uses `backend/start.sh` as the `CMD` entrypoint so local and containerized runs share one script (per the comment block at the top of `backend/start.sh`).
+- `frontend/Dockerfile` — dual-target:
+  - default (dev) stage runs `bun run dev` with bind-mounted source for HMR;
+  - `prod` stage builds static assets via `bun run build` and serves them from `nginx:alpine`.
+  - Both stages run as a non-root user in the final image.
+- `infra/.env.example` — consolidated env for the stack: Postgres credentials, DB URL as seen from the backend container, Redis URL, published host ports, `VITE_API_BASE_URL`, `MIGRATE` flag. The real `infra/.env` is gitignored.
+- `.dockerignore` at repo root, `backend/.dockerignore`, `frontend/.dockerignore`.
+- Root `Makefile` with targets documented in the design spec.
+- Append a "Running with Docker" section to the root `README.md` covering the one-command bring-up and tear-down, and listing the host-published ports.
+- Migration strategy: the backend container runs `alembic upgrade head` at startup when `MIGRATE=1` is set in `infra/.env` (the default in the committed `.env.example`). A `make migrate` target is also provided as a one-shot escape hatch. Leverages existing `MIGRATE=1` / `migrate` support in `backend/start.sh` — no backend source changes.
+
+### Out of Scope
+
+- `deployment/` directory and its contents. The user will add deployment scripts for DigitalOcean, AWS, and Azure in later features. This feature does **not** create `deployment/` even as a placeholder.
+- CI/CD (GitHub Actions, image publishing, registry auth). Deferred per `conventions.md` §11.
+- TLS termination, reverse proxies beyond the single `nginx:alpine` that serves frontend static assets under the `prod` profile, and any form of certificate management.
+- Secrets management (Vault, SOPS, Doppler, cloud KMS). Env vars come from `infra/.env` only.
+- Kubernetes manifests, Helm charts, Terraform, Pulumi, or any other IaC.
+- Automated tests for this feature. Validation is manual, documented in the test spec. Automated functional testing against this stack is `feat_testing_001`'s job.
+- Linting, formatting, or dev-tooling containers.
+- Changes to `backend/` or `frontend/` source code. The Dockerfiles must work with the services as they exist on `main` today; any needed behavior is already present in `backend/start.sh` and `frontend/start.sh`.
+- Changes to `docs/tracking/features.md` (tracking file is currently neutered).
+
+## Acceptance Criteria
+
+- [ ] `infra/docker-compose.yml` exists and declares exactly four services: `backend`, `frontend`, `postgres`, `redis`.
+- [ ] `infra/.env.example` exists and is sufficient, when copied to `infra/.env` with no edits, to bring the stack up on a clean machine.
+- [ ] `backend/Dockerfile` exists, is multi-stage, uses a slim Python base, runs as a non-root user in the runtime stage, and uses `backend/start.sh` as the entrypoint.
+- [ ] `frontend/Dockerfile` exists, is multi-stage, supports both a dev target (runs `bun run dev`) and a `prod` target (serves built assets from `nginx:alpine`), and runs as a non-root user in the final stage of both targets.
+- [ ] `.dockerignore` files exist at repo root, `backend/`, and `frontend/`, and they exclude at minimum: `.git`, `node_modules`, `.venv`, `__pycache__`, `dist/`, `.env`, `.env.*` (but not `.env.example`).
+- [ ] A root `Makefile` exists and implements `up`, `down`, `logs`, `migrate`, `ps`, `build`, `clean` targets that forward into the compose stack.
+- [ ] Postgres and Redis both declare health checks in compose; `backend` declares `depends_on` with `condition: service_healthy` on both.
+- [ ] Postgres and Redis do **not** publish ports to the host by default. Backend publishes port 8000; frontend publishes its dev server port (5173 by default).
+- [ ] Named volumes (e.g. `pgdata`, `redisdata`) are declared for Postgres and Redis persistence; destroying containers does not lose data unless `make clean` is invoked.
+- [ ] From a clean clone, running `cp infra/.env.example infra/.env && make up` brings all four services to healthy state without manual intervention.
+- [ ] With the stack up, `curl -fsS http://localhost:8000/readyz` returns HTTP 200 and a body with `"status": "ready"` and both `db` and `redis` reported as `"ok"`.
+- [ ] With the stack up, the frontend served at the published port successfully fetches `/api/v1/hello` through the compose network (no CORS surprises, no connection-refused).
+- [ ] `make down` stops the stack cleanly; running it twice is idempotent.
+- [ ] `make clean` removes containers **and** named volumes; a subsequent `make up` starts from a fresh database.
+- [ ] The root `README.md` contains a new "Running with Docker" section (appended; existing content intact).
+- [ ] No files under `backend/app/` or `frontend/src/` are modified.
+- [ ] `deployment/` is **not** created by this feature.
+- [ ] All commits on the branch use the prefix `autodev(feat_infra_001):` per `conventions.md` §4.

--- a/docs/specs/feat_infra_001/test_infra_001.md
+++ b/docs/specs/feat_infra_001/test_infra_001.md
@@ -1,0 +1,89 @@
+# Test Spec: Docker Compose stack and per-service Dockerfiles
+
+## Scope of this test spec
+
+This feature ships infrastructure (Dockerfiles, compose file, Makefile, env template), not application code. There are **no automated tests added by this feature**. Validation is manual, performed by Vulcan after implementation and by the human reviewer before merging.
+
+The automated REST functional suite that exercises running services (including services brought up via this compose stack) is owned by **`feat_testing_001`** — the next and final bootstrap feature. That feature will consume the `make up` contract defined here.
+
+Everything below is a manual validation checklist. Each case lists the command to run, the input/state it assumes, and the pass criteria.
+
+## Preconditions
+
+Before running any case:
+
+- Working tree is clean on `main` with `feat_infra_001` merged (for pre-merge validation: on the build branch).
+- Docker Engine 20.10+ / Docker Desktop 4.x or newer, providing `docker compose` (v2) is installed and running.
+- No other process is bound to host ports 8000 or 5173.
+- Run once: `cp infra/.env.example infra/.env`. Do not edit the file for the default-path cases.
+
+## Happy Path
+
+| # | Test Case | Input / Action | Expected Output |
+|---|---|---|---|
+| 1 | Clean-clone bring-up | From repo root: `cp infra/.env.example infra/.env && make up` | All four services (`backend`, `frontend`, `postgres`, `redis`) reach state `running` and, where applicable, `healthy`. `docker compose ps` (via `make ps`) shows no `Exit` or `Restarting` statuses. Command returns to the shell after compose reports healthy. |
+| 2 | Backend readiness through compose network | With the stack up from case 1: `curl -fsS http://localhost:8000/readyz` | HTTP 200. JSON body contains `"status": "ready"`, `"checks": {"db": "ok", "redis": "ok"}`. |
+| 3 | Backend liveness | `curl -fsS http://localhost:8000/healthz` | HTTP 200. JSON body contains `"status": "ok"`. |
+| 4 | Backend API reachable directly from host | `curl -fsS http://localhost:8000/api/v1/hello` | HTTP 200. JSON body contains the `message`, `item_name`, `hello_count` fields defined by `feat_backend_001`. |
+| 5 | Frontend served from host-published port | `curl -fsS -I http://localhost:5173/` | HTTP 200 (or 304). `content-type` is `text/html`. |
+| 6 | Frontend reaches backend through the compose network | In a browser: open `http://localhost:5173/`. | Page renders the `/api/v1/hello` payload (at least the `message` field is visible). No connection-refused or CORS error in the browser devtools console. |
+| 7 | Migrations ran automatically on first boot | `docker compose -f infra/docker-compose.yml exec postgres psql -U postgres -d app -c "SELECT version_num FROM alembic_version;"` (or `docker compose exec` from `infra/`) | Exactly one row; `version_num` is the head revision committed under `backend/alembic/versions/`. |
+| 8 | Hot reload in dev mode (backend) | With the stack up, edit any handler file under `backend/app/` (e.g. add a log line to `app/main.py`). Save. | Backend container logs show uvicorn reloading within ~2s. Subsequent request reflects the change without `make down`/`make up`. Revert the edit afterward. |
+| 9 | Hot reload in dev mode (frontend) | With the stack up, edit the page component under `frontend/src/`. Save. | Browser at `http://localhost:5173/` reflects the change via HMR without a manual refresh. Revert the edit afterward. |
+| 10 | Clean teardown | `make down` | All four service containers stop and are removed. Named volumes `pgdata`, `redisdata`, `frontend_node_modules` still exist (`docker volume ls` shows them). |
+| 11 | Teardown is idempotent | `make down` a second time | Exit status 0. No "not found" errors. |
+| 12 | Data persists across restart | From a freshly-torn-down state (case 10): `make up` again | Case 7 (alembic_version row) still passes; no duplicate migration was applied. |
+| 13 | Destructive clean removes volumes | `make clean` | Containers and network gone; `docker volume ls` no longer lists `pgdata`, `redisdata`, `frontend_node_modules` (at minimum the ones this stack owns). |
+| 14 | Clean-cycle-up after `make clean` | Immediately after case 13: `make up` | Stack comes up healthy; `alembic_version` shows the head revision again (migrations re-ran against a fresh database). No data from the previous run survives. |
+| 15 | Explicit one-shot migration works | With `MIGRATE=0` in `infra/.env`, from clean state: `make up` followed by `make migrate` | `make up` brings Postgres healthy and starts backend without running migrations (backend logs show no "running alembic upgrade head" line from `backend/start.sh`). `make migrate` exits 0 and leaves `alembic_version` populated to head. Restore `MIGRATE=1` in `infra/.env` afterward. |
+
+## Error Cases
+
+| # | Test Case | Input / State | Expected Behavior |
+|---|---|---|---|
+| 1 | `infra/.env` missing | Delete `infra/.env`, then `make up` | Compose fails with a clear message naming the missing file (compose's own error). No containers are left in a partial state. |
+| 2 | Backend fails to start because DB URL points nowhere | Edit `infra/.env`: set `DATABASE_URL=postgresql+asyncpg://postgres:postgres@does-not-exist:5432/app`. `make down && make up`. | Backend container enters a retry/error state. `curl http://localhost:8000/readyz` returns HTTP 503 with `"status": "not_ready"` and a populated `checks.db` error string (matches the error-path in `backend/app/api/health.py:32-38`). Fix: restore `.env`. |
+| 3 | Postgres health never goes healthy | Edit `infra/.env`: set `POSTGRES_PASSWORD=` (empty). `make down && make up`. | `postgres` service never reports `healthy`; `backend` stays in `created` or `waiting` and does not start (proves `depends_on: condition: service_healthy` is wired). Fix: restore `.env`. |
+| 4 | Frontend build context does not include source | Temporarily rename `frontend/src/` and run `make build`. | Frontend image build fails with a clear error (missing entry module). No stale image is tagged under the expected name. Restore `frontend/src/`. |
+| 5 | Host port 8000 already occupied | Before `make up`, run `nc -l 8000` (or any process that binds 8000). `make up`. | Compose fails on the `backend` service with "port is already allocated" or equivalent. Other services either did not start or are torn down. No silent fallback to another port. Stop the blocking process to recover. |
+| 6 | `MIGRATE=1` but database unreachable | Combine conditions of cases 2 and (implicitly) 1: break `DATABASE_URL`. `make up`. | Backend container exits with a non-zero status from `alembic upgrade head` before uvicorn starts. Logs show the alembic connection error. Compose does not mark backend healthy. |
+| 7 | `make clean` on a stack that is not up | From fully-stopped state: `make clean` | Exit status 0. `docker compose down -v` on a down stack is a no-op on containers and still removes the named volumes if present. |
+
+## Boundary Conditions
+
+| # | Test Case | Condition | Expected Behavior |
+|---|---|---|---|
+| 1 | Postgres and Redis ports are internal only | After `make up`: `nc -z localhost 5432` and `nc -z localhost 6379` | Both fail with "connection refused". Neither port is published to the host. |
+| 2 | Backend container runs as non-root | `docker compose exec backend id` | `uid` is not 0. User matches the one created in the Dockerfile (e.g. `appuser`, uid 1000). |
+| 3 | Frontend dev container runs as non-root | `docker compose exec frontend id` | `uid` is not 0. |
+| 4 | Named volumes survive `make down` | After case Happy-10, `docker volume ls` filtered to the project prefix | Lists `pgdata`, `redisdata`, `frontend_node_modules`. |
+| 5 | Build cache reuse on unchanged code | `make down && make up` without editing any source file | Image layers are cached; no long `uv sync` or `bun install` step is re-executed. Second `make up` completes substantially faster than the first. |
+| 6 | Build cache busts on dependency change | Edit `backend/pyproject.toml` to add a harmless dev dependency (remove afterward). `make build`. | The `uv sync` layer in `backend/Dockerfile` rebuilds; layers above it are reused. |
+| 7 | `prod` profile builds and serves | `cd infra && docker compose --profile prod build && docker compose --profile prod up -d` | Prod frontend serves built static assets from `nginx:alpine` on the configured `FRONTEND_PORT`. `curl -fsS http://localhost:${FRONTEND_PORT}/` returns HTTP 200 with `server: nginx/...`. Backend runs without `--reload` (no reloader messages in logs). |
+| 8 | `.dockerignore` keeps `.env` out of images | `docker build` the backend image, then `docker run --rm <image> ls -a /app` | No `.env` file present in the image. `.env.example` may be present. |
+| 9 | `docs/` and `.git/` not copied into images | Inspect image: `docker run --rm <backend-image> ls /app` and similarly for frontend | No `docs/`, `.git/`, `.claude/` directories inside the image. |
+| 10 | Makefile `help` target is the default | From repo root: `make` with no target | Prints a list of targets and one-line descriptions; does not run `up`, `build`, or `clean`. |
+
+## Security Considerations
+
+Manual review points rather than executable cases — Vulcan checks these at implementation time; the reviewer verifies during PR review.
+
+- **No hard-coded production credentials.** `infra/.env.example` uses `postgres`/`postgres` as the Postgres superuser/password. This is acceptable for a template because there is no production here; the commit message and README section state that these defaults are for local development only.
+- **`infra/.env` is gitignored.** Verified by `git check-ignore infra/.env` returning a match.
+- **`.env` / `.env.*` never shipped in images.** Covered by Boundary case 8.
+- **Non-root final image.** Covered by Boundary cases 2 and 3.
+- **Internal-only data services.** Covered by Boundary case 1.
+- **No unauthenticated ports on the host by default.** Only `backend:8000` and `frontend:5173` (or `frontend:8080` in prod) are published. Neither serves destructive endpoints.
+- **Image provenance.** All base images are from official Docker Hub namespaces (`library/postgres`, `library/redis`, `library/python`, `library/nginx`, and the widely-used `oven/bun` if chosen). No private or personal registries.
+- **Request ID propagation still works.** Indirect check via the `/readyz` response headers including `X-Request-ID`; this verifies `backend/app/middleware.py` runs inside the container the same way it does on a local uvicorn.
+- **`make clean` is destructive and is labeled as such.** README and Makefile `help` output both call this out in plain language.
+
+## Forward reference to `feat_testing_001`
+
+The next bootstrap feature, `feat_testing_001`, delivers:
+
+- A `test.sh` driver at the repo root (per `conventions.md` §8 and §10).
+- A minimal cross-cutting functional suite exercising the backend's HTTP surface (probably `/healthz`, `/readyz`, `/api/v1/hello`).
+- Convention for how backend and frontend unit tests are invoked from `test.sh`.
+
+That suite will **run against a stack brought up by `make up` from this feature.** This test spec therefore intentionally stops at the "services are up and healthy" boundary — proving correctness of application behavior is out of scope here and belongs in `feat_testing_001`. When that feature lands, the happy-path cases above should still pass unchanged; if they do not, that is a regression in `feat_infra_001`, not in `feat_testing_001`.


### PR DESCRIPTION
## Specifications for feat_infra_001

Closes #10

Feature 4 of 5 in the bootstrap roster (`conventions.md` §10). Introduces the `infra/` directory for local orchestration (compose file + consolidated env template), per-service Dockerfiles adjacent to their code (user's explicit call, not inside `infra/`), and a small root `Makefile` that forwards into `infra/`. Services: `backend`, `frontend`, `postgres`, `redis`. Dev-by-default with a minimal opt-in `prod` profile.

### Spec files
- Feature: `docs/specs/feat_infra_001/feat_infra_001.md`
- Design: `docs/specs/feat_infra_001/design_infra_001.md`
- Test: `docs/specs/feat_infra_001/test_infra_001.md`

### Design calls surfaced for review

Two judgment calls the prompt explicitly allowed; both are recorded in the design spec's "Open design calls surfaced for human review" section and previewed here so they are not easy to miss:

1. **Dev-by-default, `prod` as an opt-in compose profile** (rather than a separate `docker-compose.prod.yml`). Single source of truth, one keyword to flip, minimal surface area. Reject if you want a physical split.
2. **`MIGRATE=1` on by default in `infra/.env.example`**, leveraging the existing support in `backend/start.sh:52`. First-run experience is "one command, working DB". `make migrate` remains an explicit escape hatch. Reject if you prefer migrations to never run without an explicit action.

One subtler wiring point called out in the design (Edge Cases table, row "Frontend code uses absolute backend URLs"): Vulcan must read `frontend/src/api/client.ts` at implementation time to decide whether `VITE_API_BASE_URL` in `infra/.env.example` should point at `http://backend:8000` (server-side Vite proxy) or `http://localhost:8000` (direct browser call). Design proposes the former based on the current Vite proxy config at `frontend/vite.config.ts:17-22`.

### Explicitly NOT in this feature
- `deployment/` — deferred to a later feature (per `conventions.md` §8 and user's explicit instruction).
- CI/CD, TLS, secrets management, k8s/Helm/Terraform.
- Any automated tests — owned by `feat_testing_001`, the final bootstrap feature. Test spec here is a manual validation checklist only.

### Conventions compliance (§§3-5)
- Branch: `spec/feat_infra_001` cut from fresh `main` at `c7ab5dc`.
- One commit, prefix `autodev(feat_infra_001):`. No `Co-Authored-By`.
- Labels: `autodev`, `feat_infra_001`.
- Build branch (for Vulcan later) will be `build/feat_infra_001`; build PR title `build(feat_infra_001): ...`.