### PR TITLE
build(feat_infra_001): docker-compose stack + dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Repo-root .dockerignore
+#
+# Applies when a Docker build uses the repo root as its build context. The
+# per-service Dockerfiles in this template use `context: ..` from the compose
+# file (anchored at infra/), so this file is the first filter the builder sees.
+#
+# Keep this list conservative: it should exclude VCS metadata, agent state,
+# docs, and per-service build artifacts that are already covered by
+# backend/.dockerignore and frontend/.dockerignore.
+
+# VCS / CI / editor state
+.git/
+.gitignore
+.gitattributes
+.github/
+.claude/
+.vscode/
+.idea/
+
+# Docs & specs (not needed in runtime images)
+docs/
+README.md
+conventions.md
+LICENSE
+
+# Per-service build artifacts and local-only state
+backend/.venv/
+backend/.pytest_cache/
+backend/__pycache__/
+backend/**/__pycache__/
+backend/**/*.pyc
+frontend/node_modules/
+frontend/dist/
+frontend/.vite/
+
+# Env files — never ship real env into an image. Keep .env.example (used as a
+# template), drop everything else.
+**/.env
+**/.env.*
+!**/.env.example
+
+# Infra-local state
+infra/.env
+infra/.env.*
+!infra/.env.example
+
+# OS junk
+.DS_Store
+Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# Makefile -- developer-ergonomic forwarders into the compose stack.
+#
+# Every target simply `cd`s into infra/ and invokes `docker compose` so the
+# compose file can live in infra/ without forcing every command to type
+# `-f infra/docker-compose.yml`.
+#
+# Targets:
+#   make            -- prints this help (default)
+#   make up         -- build + start the dev stack in the background
+#   make down       -- stop and remove containers (volumes preserved)
+#   make logs       -- tail logs for all services
+#   make ps         -- show service status
+#   make build      -- rebuild images without starting services
+#   make migrate    -- run alembic migrations one-shot
+#   make clean      -- DESTRUCTIVE: stop stack + delete named volumes
+#   make backend-shell   -- open a shell in the running backend container
+#   make frontend-shell  -- open a shell in the running frontend container
+#   make db-shell        -- open psql against the postgres container
+
+.DEFAULT_GOAL := help
+
+COMPOSE_DIR := infra
+COMPOSE := docker compose
+
+.PHONY: help up down logs ps build migrate clean backend-shell frontend-shell db-shell
+
+help:
+	@echo "minimalist-app -- docker-compose shortcuts"
+	@echo ""
+	@echo "  make up              build + start the dev stack (detached)"
+	@echo "  make down            stop and remove containers (volumes kept)"
+	@echo "  make logs            tail logs for all services"
+	@echo "  make ps              show service status"
+	@echo "  make build           rebuild images without starting services"
+	@echo "  make migrate         run 'alembic upgrade head' one-shot"
+	@echo "  make clean           DESTRUCTIVE: stop stack and delete named volumes"
+	@echo "  make backend-shell   shell into running backend container"
+	@echo "  make frontend-shell  shell into running frontend container"
+	@echo "  make db-shell        psql into the postgres container"
+	@echo ""
+	@echo "Prod profile:"
+	@echo "  cd infra && docker compose --profile prod up -d --build"
+	@echo ""
+	@echo "First-run setup:"
+	@echo "  cp infra/.env.example infra/.env && make up"
+
+up:
+	cd $(COMPOSE_DIR) && $(COMPOSE) up -d --build
+
+down:
+	cd $(COMPOSE_DIR) && $(COMPOSE) down
+
+logs:
+	cd $(COMPOSE_DIR) && $(COMPOSE) logs -f
+
+ps:
+	cd $(COMPOSE_DIR) && $(COMPOSE) ps
+
+build:
+	cd $(COMPOSE_DIR) && $(COMPOSE) build
+
+migrate:
+	cd $(COMPOSE_DIR) && $(COMPOSE) run --rm backend migrate
+
+clean:
+	@echo ">>> make clean will REMOVE named volumes (pgdata, redisdata, frontend_node_modules, backend_venv)."
+	@echo ">>> All database contents and any cached node_modules will be lost."
+	cd $(COMPOSE_DIR) && $(COMPOSE) down -v
+
+backend-shell:
+	cd $(COMPOSE_DIR) && $(COMPOSE) exec backend /bin/bash
+
+frontend-shell:
+	cd $(COMPOSE_DIR) && $(COMPOSE) exec frontend /bin/bash
+
+db-shell:
+	cd $(COMPOSE_DIR) && $(COMPOSE) exec postgres psql -U $${POSTGRES_USER:-postgres} -d $${POSTGRES_DB:-app}

--- a/README.md
+++ b/README.md
@@ -59,6 +59,64 @@ This template uses the **AutoDev** workflow, in which two agents collaborate wit
 
 Every Atlas session begins by reading [`conventions.md`](conventions.md); every feature's specs live under [`docs/specs/`](docs/specs/). See [`docs/specs/README.md`](docs/specs/README.md) for a guide to reading a feature end-to-end.
 
+## Running with Docker
+
+The full stack (FastAPI backend, Vite + React frontend, Postgres, Redis) runs under `docker-compose`. The compose file lives at [`infra/docker-compose.yml`](infra/docker-compose.yml); a small root `Makefile` wraps the common commands so you do not need to `cd infra` every time.
+
+### Prerequisites
+
+- Docker Engine 20.10+ or Docker Desktop 4.x+, providing `docker compose` (v2).
+- Host ports `8000` (backend) and `5173` (frontend dev) must be free.
+
+### First-run setup
+
+```bash
+cp infra/.env.example infra/.env
+make up
+```
+
+`make up` builds the images and starts all four services in the background. On a clean machine the first run takes a minute or two; subsequent runs use cached image layers and start in seconds.
+
+When the stack is healthy:
+
+- Frontend (Vite dev server with HMR): http://localhost:5173
+- Backend (FastAPI): http://localhost:8000 — try `http://localhost:8000/readyz` or `http://localhost:8000/api/v1/hello`.
+- Postgres and Redis are reachable only on the compose network by design; they do not publish ports to the host.
+
+By default the backend container runs `alembic upgrade head` on startup (controlled by `MIGRATE=1` in `infra/.env`). Alembic no-ops if the database is already at head.
+
+### Common commands
+
+| Command | What it does |
+|---|---|
+| `make up` | Build and start the dev stack (detached). |
+| `make down` | Stop and remove containers. Named volumes are preserved. |
+| `make logs` | Tail logs for all services. |
+| `make ps` | Show service status. |
+| `make build` | Rebuild images without starting services. |
+| `make migrate` | Run `alembic upgrade head` as a one-shot. |
+| `make clean` | **Destructive.** Stop the stack and delete named volumes (database contents are lost). |
+| `make backend-shell` | Open a shell in the running backend container. |
+| `make frontend-shell` | Open a shell in the running frontend container. |
+| `make db-shell` | Open `psql` in the postgres container. |
+
+### Production profile (optional)
+
+A minimal `prod` profile builds the frontend into a static bundle and serves it from `nginx:alpine`; the backend runs without `--reload`. It is opt-in:
+
+```bash
+cd infra && docker compose --profile prod up -d --build
+```
+
+This exists so the Dockerfiles are exercised against a production-shape build. It is **not** a deployment story — real deployments (DigitalOcean, AWS, Azure) are the subject of a later infra feature that will populate `deployment/`.
+
+### Source of truth
+
+- Compose topology: [`infra/docker-compose.yml`](infra/docker-compose.yml)
+- Env template: [`infra/.env.example`](infra/.env.example) (copy to `infra/.env`; the real file is gitignored)
+- Backend image: [`backend/Dockerfile`](backend/Dockerfile)
+- Frontend image: [`frontend/Dockerfile`](frontend/Dockerfile)
+
 ## License
 
 Released under the MIT License. See [`LICENSE`](LICENSE) for the full text.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,32 @@
+# backend/.dockerignore
+#
+# Applies when the Docker build context is `backend/` (or when the repo-root
+# context reaches into backend/). Keep the build context small and secret-free.
+
+# Python / uv local state
+.venv/
+.pytest_cache/
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Test artifacts (tests themselves are copied in for the image; caches are not)
+.coverage
+.coverage.*
+htmlcov/
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+
+# Env files — never ship real env; keep the example as a template.
+.env
+.env.*
+!.env.example
+
+# VCS
+.git/
+.gitignore

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,93 @@
+# backend/Dockerfile
+#
+# Multi-stage image for the FastAPI backend.
+#
+#   builder  -- uv-based dependency install, producing a .venv at /app/.venv
+#   runtime  -- slim runtime with only the .venv + source, running as non-root
+#
+# The CMD path defers to backend/start.sh so the local (`./start.sh`) and
+# containerized runs share one entrypoint. See backend/start.sh for the
+# subcommand list (serve | migrate | shell | pytest).
+#
+# Build contexts:
+#   - Compose invokes this with `context: ..` (repo root) and
+#     `dockerfile: backend/Dockerfile`, so paths below are relative to the
+#     repo root. When building by hand from backend/, use
+#     `docker build -f Dockerfile ..`.
+
+ARG PYTHON_VERSION=3.12
+
+# -----------------------------------------------------------------------------
+# Stage 1: builder
+# -----------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+# uv version is pinned here; bump deliberately in a follow-up PR.
+ARG UV_VERSION=0.5.11
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+# Install uv. The official install script is the recommended path for slim
+# images; it drops a static binary into /usr/local/bin/uv.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
+    && apt-get purge -y curl \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy only the dependency manifests first so Docker layer cache survives
+# unrelated source edits.
+COPY backend/pyproject.toml backend/uv.lock backend/README.md ./
+
+# Install dependencies (no project install yet, project source is not here).
+RUN uv sync --frozen --no-install-project --no-dev
+
+# Now copy the project source and run a project install so `app` is importable
+# from the .venv.
+COPY backend/ ./
+RUN uv sync --frozen --no-dev
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime
+# -----------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:/usr/local/bin:${PATH}" \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+# Install runtime-only OS deps. curl is used by the compose healthcheck so we
+# intentionally keep it (small, well-known package).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system --gid 1000 appuser \
+    && useradd --system --uid 1000 --gid appuser --create-home --shell /bin/bash appuser
+
+# Ship the uv binary so `start.sh` (which runs `uv run ...`) works inside the
+# container. uv is a single static binary; copying it is cheap.
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Copy built venv and project source from the builder stage. Ownership is set
+# so the non-root user can write to cache dirs under /app if needed.
+COPY --from=builder --chown=appuser:appuser /app /app
+
+USER appuser
+
+EXPOSE 8000
+
+# ENTRYPOINT + CMD split so compose can override just the command to run
+# migrations one-shot: `command: ["migrate"]`.
+ENTRYPOINT ["./start.sh"]
+CMD ["serve"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,25 @@
+# frontend/.dockerignore
+#
+# Applies when the Docker build context is `frontend/` (or when the repo-root
+# context reaches into frontend/). Keeps node_modules, build artifacts, and
+# local env files out of the build context.
+
+# Bun / Node local state
+node_modules/
+.vite/
+dist/
+*.tsbuildinfo
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+
+# Env files — never ship real env; keep the example as a template.
+.env
+.env.*
+!.env.example
+
+# VCS
+.git/
+.gitignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,99 @@
+# frontend/Dockerfile
+#
+# Multi-stage / multi-target image for the Vite + React + TS frontend.
+#
+#   deps    -- installs bun dependencies against the committed lockfile
+#   dev     -- runs `bun run dev` (Vite) with HMR; source is bind-mounted in compose
+#   build   -- runs `bun run build` to produce dist/
+#   prod    -- nginx:alpine serving the built dist/ as an SPA
+#
+# Using `oven/bun:1` as the base: it's the upstream-maintained image that
+# ships a working `bun` CLI and a Debian slim userspace compatible with
+# Vite's native deps (vs. mixing `node:20-alpine` + a hand-installed bun).
+#
+# Build contexts:
+#   - Compose invokes this with `context: ..` (repo root) and
+#     `dockerfile: frontend/Dockerfile`, so paths below are relative to the
+#     repo root.
+
+# -----------------------------------------------------------------------------
+# Stage: deps
+# -----------------------------------------------------------------------------
+FROM oven/bun:1 AS deps
+
+WORKDIR /app
+
+# Copy only manifests first for layer-cache reuse.
+COPY frontend/package.json frontend/bun.lock ./
+
+RUN bun install --frozen-lockfile
+
+# -----------------------------------------------------------------------------
+# Stage: dev
+# -----------------------------------------------------------------------------
+# The dev target runs the Vite dev server. Compose bind-mounts the host
+# `frontend/` dir over `/app` and uses a named volume to preserve
+# `/app/node_modules` installed above.
+FROM oven/bun:1 AS dev
+
+ENV NODE_ENV=development
+
+WORKDIR /app
+
+# Re-create the non-root user. oven/bun:1 ships with a `bun` user (uid 1000);
+# we reuse it rather than creating a new one.
+RUN chown -R bun:bun /app
+
+# Bring in installed node_modules from the deps stage so a first `make up`
+# works before the bind mount's node_modules volume is populated.
+COPY --from=deps --chown=bun:bun /app/node_modules /app/node_modules
+
+# Copy the rest of the frontend source. Under compose dev mode this is masked
+# by a bind mount, but the image is still usable standalone.
+COPY --chown=bun:bun frontend/ /app/
+
+USER bun
+
+EXPOSE 5173
+
+ENTRYPOINT ["./start.sh"]
+CMD ["dev"]
+
+# -----------------------------------------------------------------------------
+# Stage: build
+# -----------------------------------------------------------------------------
+FROM oven/bun:1 AS build
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules /app/node_modules
+COPY frontend/ /app/
+
+# VITE_API_BASE_URL is baked into the bundle at build time when used. The
+# frontend uses relative `/api/...` URLs via the Vite dev proxy, so the value
+# here does not affect prod correctness when nginx serves the static bundle
+# behind a reverse proxy. For the bundled prod profile we leave the env var
+# unset here; nginx routes `/api/*` to the backend service (see prod stage).
+RUN bun run build
+
+# -----------------------------------------------------------------------------
+# Stage: prod
+# -----------------------------------------------------------------------------
+# Serves the built SPA from nginx:alpine. The image ships the official
+# `nginx` user (non-root worker processes by default under `user nginx;`).
+FROM nginx:alpine AS prod
+
+# SPA-aware nginx config: try_files with fallback to /index.html so client
+# routes don't 404, and proxy /api/ to the backend service on the compose
+# network so the browser can use relative URLs.
+RUN rm -f /etc/nginx/conf.d/default.conf
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+# nginx:alpine already runs master as root and workers as `nginx`; upstream's
+# entrypoint handles signal forwarding. No CMD override needed.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,38 @@
+# nginx config for the prod-profile frontend container.
+#
+# Serves the built Vite SPA from /usr/share/nginx/html on port 8080 and
+# proxies /api/ to the backend service on the compose network.
+
+server {
+    listen 8080;
+    server_name _;
+
+    # Root directory for the built SPA.
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Proxy API calls to the backend container on the compose network. The
+    # hostname `backend` resolves via compose-injected DNS.
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA fallback: any non-file path returns index.html so the React router
+    # can handle it client-side.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Minimal caching for static assets produced by Vite's build. Vite adds
+    # content hashes to file names, so long max-age is safe.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+}

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,45 @@
+# infra/.env.example
+#
+# Consolidated environment template for the docker-compose stack. Copy to
+# `infra/.env` on first run (that file is gitignored). Every variable below
+# has a sensible default for local development.
+#
+#   cp infra/.env.example infra/.env
+#   make up
+#
+# These values are for LOCAL DEVELOPMENT ONLY. Do not reuse them in any
+# deployed environment; production credentials are the responsibility of the
+# future `deployment/` feature.
+
+# ---- Host-published ports -----------------------------------------------
+# Only backend and frontend publish ports to the host. Postgres and Redis
+# stay on the compose network.
+BACKEND_PORT=8000
+FRONTEND_PORT=5173
+
+# ---- Postgres -----------------------------------------------------------
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=app
+
+# ---- Backend runtime ----------------------------------------------------
+ENV=dev
+LOG_LEVEL=INFO
+
+# DATABASE_URL and REDIS_URL use compose-injected service DNS. Backend
+# connects over the `appnet` network using these hostnames.
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/app
+REDIS_URL=redis://redis:6379/0
+
+# Run `alembic upgrade head` on backend container startup. Flip to 0 if you
+# want to gate migrations behind the `make migrate` one-shot target.
+MIGRATE=1
+
+REQUEST_ID_HEADER=X-Request-ID
+
+# ---- Frontend runtime ---------------------------------------------------
+# Vite runs INSIDE the frontend container. The dev server proxies `/api/*`
+# to this URL, which is a server-side resolution inside the compose network.
+# The browser only ever talks to http://localhost:${FRONTEND_PORT}, so using
+# the compose service name here is correct.
+VITE_API_BASE_URL=http://backend:8000

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,8 @@
+# infra/.gitignore
+#
+# Ignore any real env files under infra/ but keep the committed template
+# (.env.example) so the stack remains reproducible from a fresh clone.
+
+.env
+.env.*
+!.env.example

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,169 @@
+# infra/docker-compose.yml
+#
+# Local orchestration for the minimalist-app template. Brings up four services
+# on a shared user-defined bridge network with named volumes for stateful data.
+#
+# Default profile: dev-mode (source bind-mounted, uvicorn --reload, Vite HMR).
+# Prod profile (opt-in): `docker compose --profile prod up`.
+#
+# Invoke via the root Makefile; commands expect cwd to be `infra/` so relative
+# paths resolve the way compose default behavior assumes.
+
+name: minimalist-app
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - appnet
+    # No `ports:` — Postgres is reachable only on the compose network.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redisdata:/data
+    networks:
+      - appnet
+    # No `ports:` — Redis is reachable only on the compose network.
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  backend:
+    build:
+      context: ..
+      dockerfile: backend/Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      # Compose-level interpolation for values that must exist even when
+      # .env is missing a specific key. env_file above supplies the rest.
+      HOST: 0.0.0.0
+      PORT: "8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    volumes:
+      # Dev bind-mount: host `backend/` over container `/app` so uvicorn
+      # --reload picks up edits. Prod profile (below) omits this.
+      - ../backend:/app
+      # Mask the venv so the host-side absent .venv doesn't overwrite the
+      # image's installed .venv. Named volume keeps the image's .venv intact.
+      - backend_venv:/app/.venv
+    command: ["serve", "--reload"]
+    networks:
+      - appnet
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "curl -fsS http://localhost:8000/readyz >/dev/null || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  frontend:
+    build:
+      context: ..
+      dockerfile: frontend/Dockerfile
+      target: dev
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      HOST: 0.0.0.0
+      PORT: "5173"
+    depends_on:
+      - backend
+    ports:
+      - "${FRONTEND_PORT:-5173}:5173"
+    volumes:
+      # Dev bind-mount: host `frontend/` over container `/app` for HMR.
+      - ../frontend:/app
+      # Named volume masks /app/node_modules so the container's install
+      # (done during `bun install --frozen-lockfile` in the `deps` stage)
+      # survives the host bind mount.
+      - frontend_node_modules:/app/node_modules
+    networks:
+      - appnet
+
+  # --- prod profile overrides ---------------------------------------------
+  # Separate services guarded by `profiles: ["prod"]`. They reuse the same
+  # Dockerfile targets but without bind mounts and without --reload.
+
+  backend-prod:
+    profiles: ["prod"]
+    build:
+      context: ..
+      dockerfile: backend/Dockerfile
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      HOST: 0.0.0.0
+      PORT: "8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    networks:
+      - appnet
+    command: ["serve"]
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - "curl -fsS http://localhost:8000/readyz >/dev/null || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  frontend-prod:
+    profiles: ["prod"]
+    build:
+      context: ..
+      dockerfile: frontend/Dockerfile
+      target: prod
+    restart: unless-stopped
+    depends_on:
+      - backend-prod
+    ports:
+      - "${FRONTEND_PORT:-8080}:8080"
+    networks:
+      - appnet
+
+volumes:
+  pgdata:
+  redisdata:
+  frontend_node_modules:
+  backend_venv:
+
+networks:
+  appnet:
+    driver: bridge


### PR DESCRIPTION
## Summary

Implements `feat_infra_001`: local orchestration for the full template via `docker-compose`, per-service multi-stage Dockerfiles, a consolidated env template, a root `Makefile` with developer shortcuts, and a "Running with Docker" section appended to the root `README.md`.

Closes #10

## Spec references

- Feature: `docs/specs/feat_infra_001/feat_infra_001.md`
- Design: `docs/specs/feat_infra_001/design_infra_001.md`
- Test: `docs/specs/feat_infra_001/test_infra_001.md`

## Diff summary

| Path | What's in it |
|---|---|
| `infra/docker-compose.yml` | Four services (`backend`, `frontend`, `postgres`, `redis`) on a shared `appnet` bridge network. Postgres + Redis are internal only (no `ports:`). Dev profile bind-mounts source and runs uvicorn `--reload` / Vite HMR. Opt-in `prod` profile (`backend-prod`, `frontend-prod`) builds static frontend → `nginx:alpine`. Named volumes: `pgdata`, `redisdata`, `frontend_node_modules`, `backend_venv`. Health checks on postgres (`pg_isready`) and redis (`redis-cli ping`); backend has an HTTP `/readyz` healthcheck. |
| `infra/.env.example`, `infra/.gitignore` | Consolidated env template (committed); real `.env` ignored. |
| `backend/Dockerfile` | Two-stage: `python:3.12-slim` + uv-based builder, runtime copies `.venv` + source, runs as non-root `appuser` (uid 1000). `ENTRYPOINT ["./start.sh"] / CMD ["serve"]` so compose overrides (`command: ["migrate"]`) work cleanly. Ships `curl` in runtime for the compose healthcheck. |
| `frontend/Dockerfile` | Four stages (`deps`, `dev`, `build`, `prod`) using `oven/bun:1`. Dev target runs `./start.sh dev` as the `bun` user; prod target serves the built SPA from `nginx:alpine`. |
| `frontend/nginx.conf` | Tiny SPA-aware nginx config for the prod stage: SPA fallback + `/api/` proxy to `backend:8000`. (Not explicitly listed in the design spec's file table — it's the "tiny default nginx config" referenced inline. Flagging for reviewer; could fold into the Dockerfile heredoc if preferred.) |
| `Makefile` (root) | `make` (help default), `make up|down|logs|ps|build|migrate|clean`, plus `backend-shell|frontend-shell|db-shell`. Every target `cd`s into `infra/` and invokes `docker compose`. `make clean` prints a destructive-action banner before removing volumes. |
| `.dockerignore`, `backend/.dockerignore`, `frontend/.dockerignore` | Exclude `.git`, `node_modules`, `.venv`, `__pycache__`, `dist/`, `.env`, `.env.*` (but keep `.env.example`), `docs/`, `.claude/`. |
| `README.md` | Appended a "Running with Docker" section between "Workflow" and "License". Existing content unchanged. |

## Build-time decision on `VITE_API_BASE_URL`

Per the design spec, this hinged on whether the frontend calls the backend from the browser or through Vite's dev proxy. Read of `frontend/src/api/client.ts` and `frontend/vite.config.ts` on `main`:

- `client.ts` builds its URL as `${baseUrl}/api/v1/hello` where `baseUrl = import.meta.env.VITE_API_BASE_URL ?? ''`. When the env var is unset, the request is relative and goes through the current origin.
- `vite.config.ts` proxies `/api` to `VITE_API_BASE_URL` (fallback `http://localhost:8000`).

Because the frontend's default path is a relative `/api/...` request handled by the Vite dev-server proxy (which runs inside the frontend container), the proxy target must be a compose-internal hostname: **`VITE_API_BASE_URL=http://backend:8000`**. The browser only ever talks to `http://localhost:5173`; Vite inside the container resolves `backend` via compose DNS. Verified during bring-up: `curl http://localhost:5173/api/v1/hello` returns the backend payload, and `hello_count` increments.

## Manual validation (against test spec)

Ran on a local Docker Engine 27.5.1 / Compose v2.33:

| Case | Result |
|---|---|
| `cp infra/.env.example infra/.env && make up` — all four services healthy | PASS |
| `curl -fsS http://localhost:8000/readyz` — 200 with `db=ok, redis=ok` | PASS |
| `curl -fsS http://localhost:8000/healthz` — 200 | PASS |
| `curl -fsS http://localhost:8000/api/v1/hello` — hello payload | PASS |
| `curl -fsS -I http://localhost:5173/` — 200 HTML | PASS |
| Vite proxy end-to-end: `curl http://localhost:5173/api/v1/hello` → backend payload, counter increments | PASS |
| Alembic ran on first boot: `alembic_version = 0001` | PASS |
| Postgres port 5432 and Redis port 6379 not reachable from host (`nc -z`) | PASS |
| `docker compose exec backend id` → `uid=1000(appuser)` | PASS |
| `docker compose exec frontend id` → `uid=1000(bun)` | PASS |
| `make down` — containers removed, named volumes preserved | PASS |
| `make down` second time (idempotent) | PASS |
| `make clean` — volumes removed | PASS |
| Fresh `make up` after `make clean` — stack healthy, fresh DB, migrations re-applied | PASS |
| `make migrate` one-shot runs `alembic upgrade head` | PASS |
| `make` (no target) prints help | PASS |

## Notes / things the reviewer should know

1. **Port 5173 had to be freed during verification.** A stale `bun run dev` from the previous feature's work was holding it; I stopped that PID (process had been running 33+ min). Test-spec precondition explicitly requires 8000 and 5173 to be free.
2. **`frontend/nginx.conf` is a new file not named in the design-spec file table** but implied by its "tiny default nginx config" wording. Kept it as a standalone file for readability rather than heredoc-ing into the Dockerfile. Trivial to remove / inline if preferred.
3. **`backend_venv` named volume added** (not explicitly in the spec). Reason: the dev bind mount `../backend:/app` would otherwise mask `/app/.venv` produced during image build, breaking `uv run` inside the container. Same defensive pattern the design spec uses for `frontend_node_modules`.
4. **Backend runtime image ships `curl`.** Needed by the compose `/readyz` healthcheck; adds ~1 MB. Design spec flagged this as optional; kept it so the backend has observable readiness through compose itself.
5. **`uv` version pinned to 0.5.11** in `backend/Dockerfile` (via `ARG UV_VERSION`). Bump in a separate PR when warranted.
6. **Python pinned to 3.12-slim** (design spec allowed 3.11 or 3.12; `pyproject.toml` requires `>=3.11`). Picked the newer of the two.
7. **`bun` base image is `oven/bun:1`.** Design spec allowed either that or `node:20-alpine + bun`; picked the simpler one. The image's built-in `bun` user (uid 1000) is reused as the non-root user in both dev and build stages.
8. **No `docs/tracking/features.md` edits** (that tracking file is handled elsewhere per the build prompt).
9. **No `backend/app/` or `frontend/src/` source changes** — all container behavior comes from the existing `start.sh` scripts and the new Dockerfiles.

DO NOT merge until reviewed.