### PR TITLE
build(feat_testing_001): external rest functional test suite

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test.sh -- external REST functional test driver for the minimalist-app stack.
+#
+# Responsibilities:
+#   1. Parse flags (--down, --no-up, -h/--help).
+#   2. Probe TEST_BASE_URL/readyz; if not healthy and --no-up is not set,
+#      invoke `make up` from the repo root, then wait for readiness.
+#   3. Invoke `uv run pytest` inside tests/.
+#   4. If --down is set, invoke `make down` after tests return (regardless
+#      of pass/fail). Teardown errors never overwrite pytest's exit code.
+#
+# Environment:
+#   TEST_BASE_URL       base URL of the backend (default http://localhost:8000)
+#   READINESS_TIMEOUT   seconds to wait for /readyz before giving up (default 60)
+#
+# Exit code: pytest's exit code on pass/fail; 1 on readiness timeout; 2 on
+# unknown flags.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")" && pwd)"
+base_url="${TEST_BASE_URL:-http://localhost:8000}"
+readiness_timeout="${READINESS_TIMEOUT:-60}"
+do_up=1
+do_down=0
+
+usage() {
+  cat <<'EOF'
+Usage: ./test.sh [--down] [--no-up] [-h|--help]
+
+Flags:
+  --no-up    Skip bringing the stack up; fail fast if /readyz is unreachable.
+  --down     After tests, run `make down`. Pytest's exit code is preserved.
+  -h,--help  Print this message and exit.
+
+Environment:
+  TEST_BASE_URL       Base URL for the backend. Default: http://localhost:8000
+  READINESS_TIMEOUT   Seconds to wait for /readyz. Default: 60
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-up) do_up=0 ;;
+    --down)  do_down=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[test.sh] unknown argument: $arg" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+probe_ready() {
+  curl -fsS -o /dev/null -m 2 "${base_url}/readyz"
+}
+
+wait_for_ready() {
+  local waited=0
+  while ! probe_ready; do
+    if [ "$waited" -ge "$readiness_timeout" ]; then
+      echo "[test.sh] readiness timeout after ${readiness_timeout}s waiting for ${base_url}/readyz" >&2
+      return 1
+    fi
+    echo "[test.sh] waiting for ${base_url}/readyz... ${waited}s"
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 0
+}
+
+if probe_ready; then
+  echo "[test.sh] stack already healthy at ${base_url}"
+else
+  if [ "$do_up" -eq 1 ]; then
+    echo "[test.sh] stack not ready at ${base_url}; running 'make up'..."
+    (cd "$repo_root" && make up)
+  else
+    echo "[test.sh] stack not ready at ${base_url}; --no-up set, not bringing it up" >&2
+  fi
+
+  if ! wait_for_ready; then
+    exit 1
+  fi
+fi
+
+echo "[test.sh] stack ready at ${base_url}; running tests..."
+rc=0
+(cd "${repo_root}/tests" && TEST_BASE_URL="${base_url}" uv run pytest) || rc=$?
+
+if [ "$do_down" -eq 1 ]; then
+  echo "[test.sh] --down set; running 'make down'..."
+  # Teardown failure must not overwrite pytest rc; swallow it intentionally.
+  (cd "$repo_root" && make down) || echo "[test.sh] warning: 'make down' exited non-zero; preserving pytest rc=${rc}" >&2
+fi
+
+exit "$rc"

--- a/test.sh
+++ b/test.sh
@@ -49,7 +49,10 @@ for arg in "$@"; do
 done
 
 probe_ready() {
-  curl -fsS -o /dev/null -m 2 "${base_url}/readyz"
+  # -f: fail on HTTP errors; -s: silent; -m 2: 2s per-request timeout.
+  # Deliberately omit -S so curl stays quiet on retries — the [test.sh]
+  # waiting lines already communicate progress without the noise.
+  curl -fs -o /dev/null -m 2 "${base_url}/readyz"
 }
 
 wait_for_ready() {

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.uv-cache/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,93 @@
+# minimalist-app — external REST test suite
+
+A black-box functional test suite that hits the compose stack's public HTTP
+API and asserts the documented contract. The suite lives in a **separate**
+`uv` project (not a workspace member of `backend/`) because, semantically,
+these tests are an external consumer of the backend — the same role a
+third-party SDK's tests would play.
+
+For the full rationale see
+[`docs/specs/feat_testing_001/`](../docs/specs/feat_testing_001/).
+
+## Prerequisites
+
+- Docker Engine 20.10+ or Docker Desktop 4.x with `docker compose` v2.
+- [`uv`](https://docs.astral.sh/uv/) on `PATH`. Install with:
+  `curl -LsSf https://astral.sh/uv/install.sh | sh`
+- `make` and `curl` (both ubiquitous).
+- A populated `infra/.env` (one-time: `cp infra/.env.example infra/.env`).
+- Host port `8000` free for the backend (or point `TEST_BASE_URL` elsewhere).
+
+The compose stack itself is owned by
+[`feat_infra_001`](../docs/specs/feat_infra_001/) and brought up with
+`make up` from the repo root.
+
+## Running the suite
+
+From the repo root:
+
+```bash
+./test.sh                # bring up stack if needed, run tests, leave stack up
+./test.sh --no-up        # skip bring-up; fail fast if /readyz isn't reachable
+./test.sh --down         # run tests, then `make down` (preserves pytest exit code)
+```
+
+Directly, without the driver (stack must already be up):
+
+```bash
+cd tests && uv run pytest
+cd tests && uv run pytest -v          # verbose
+cd tests && uv run pytest tests/test_hello.py::test_hello_count_increments_by_one
+```
+
+## Configuration
+
+| Variable            | Default                   | Purpose                                              |
+|---------------------|---------------------------|------------------------------------------------------|
+| `TEST_BASE_URL`     | `http://localhost:8000`   | Backend base URL the suite points at.                |
+| `READINESS_TIMEOUT` | `60`                      | Seconds `test.sh` will wait for `/readyz` to return 200. Bump this on slow cold starts (e.g. `READINESS_TIMEOUT=180`). |
+
+Both are read from the environment. The suite never reads `infra/.env` or any
+other secret file — only `TEST_BASE_URL`.
+
+## What the suite covers
+
+- `GET /healthz` returns `200` with `{"status": "ok"}`.
+- `GET /readyz` returns `200` with `status=="ready"` and both `checks.db=="ok"`
+  and `checks.redis=="ok"` (proves Postgres and Redis are reachable from the
+  backend over the compose network).
+- `GET /api/v1/hello` returns `200` with the documented JSON shape
+  (`message: str`, `item_name: str`, `hello_count: int`); two consecutive calls
+  increment `hello_count` by exactly 1 (proves the Redis round-trip is live).
+- A request to an unknown path returns `404` with the documented error
+  envelope: `{"error": {"code": str, "message": str, "request_id": str}}`.
+- `X-Request-ID` propagation: a client-supplied value is echoed back verbatim;
+  when the client omits the header, the server generates a non-empty one.
+
+Assertions about `hello_count` are **relative** (`second == first + 1`), so
+the suite is idempotent on re-runs against a long-lived stack — no Redis
+flush required between invocations.
+
+## What is explicitly *not* covered
+
+- **Frontend.** No Vitest, no Playwright, no visual/snapshot tests. Deferred.
+- **Backend unit tests.** Those live in `backend/tests/` and are owned by
+  `feat_backend_001`.
+- **Load, performance, stress, or soak testing.**
+- **CI / GitHub Actions.** `test.sh` is CI-friendly but no workflow file is
+  added by this feature.
+- **Lint / format configuration.** Deferred per `conventions.md` §11.
+
+## Troubleshooting
+
+- **`readiness timeout after 60s`** — the stack did not become healthy within
+  the window. Common causes: `infra/.env` missing (`cp infra/.env.example
+  infra/.env`), port `8000` bound by another process, first-run image build
+  still in progress (bump `READINESS_TIMEOUT`), or Postgres/Redis failing to
+  start (check `make logs`).
+- **`uv: command not found`** — install `uv` (see Prerequisites).
+- **Tests pass locally but fail after a backend change** — you are likely
+  running against a stale container. Rebuild: `./test.sh --down && ./test.sh`.
+- **Connection refused on `TEST_BASE_URL=http://localhost:9999`** — readiness
+  probe will loop until timeout, then exit non-zero. Use the default URL or
+  point at a valid backend.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Shared pytest fixtures for the external REST functional test suite.
+
+The suite connects to a running minimalist-app compose stack via HTTP only.
+It imports nothing from ``backend/`` — this is deliberate. See
+``docs/specs/feat_testing_001/design_testing_001.md`` for the rationale.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+
+DEFAULT_BASE_URL = "http://localhost:8000"
+CLIENT_TIMEOUT = 10.0
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Return the backend base URL, configurable via ``TEST_BASE_URL``."""
+
+    return os.environ.get("TEST_BASE_URL", DEFAULT_BASE_URL)
+
+
+@pytest.fixture(scope="session")
+def client(base_url: str) -> Iterator[httpx.Client]:
+    """Yield a session-scoped :class:`httpx.Client` bound to ``base_url``."""
+
+    with httpx.Client(base_url=base_url, timeout=CLIENT_TIMEOUT) as c:
+        yield c
+
+
+@pytest.fixture(scope="session", autouse=True)
+def readiness_check(base_url: str) -> None:
+    """Fail fast with a readable message if the stack is not reachable.
+
+    ``test.sh`` already waits for ``/readyz`` before invoking pytest, but a
+    developer running ``uv run pytest`` directly skips that gate; this fixture
+    gives them the same friendly diagnostic.
+    """
+
+    try:
+        response = httpx.get(f"{base_url}/readyz", timeout=5.0)
+    except httpx.HTTPError as exc:
+        raise pytest.UsageError(
+            f"stack not reachable at {base_url}; "
+            "did you run ./test.sh or `make up`? "
+            f"(underlying error: {exc!r})"
+        ) from exc
+
+    if response.status_code != 200:
+        raise pytest.UsageError(
+            f"stack at {base_url} returned {response.status_code} from /readyz; "
+            "did you run ./test.sh or `make up`?"
+        )

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "minimalist-app-tests"
+version = "0.1.0"
+description = "External REST functional test suite for the minimalist-app compose stack."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]

--- a/tests/tests/test_errors.py
+++ b/tests/tests/test_errors.py
@@ -1,0 +1,32 @@
+"""Black-box check for the 404 error envelope shape.
+
+Asserts the keys and types of the documented envelope, not the specific
+``code`` or ``message`` strings — those are backend-owned and may evolve
+without breaking the external contract.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+def test_unknown_path_returns_error_envelope(client: httpx.Client) -> None:
+    """An unknown path returns 404 with ``{"error": {code, message, request_id}}``."""
+
+    response = client.get("/__does_not_exist__")
+
+    assert response.status_code == 404, response.text
+    body = response.json()
+
+    assert isinstance(body, dict), body
+    assert "error" in body, body
+
+    error = body["error"]
+    assert isinstance(error, dict), error
+    assert set(error.keys()) >= {"code", "message", "request_id"}, error
+
+    assert isinstance(error["code"], str) and error["code"], error
+    assert isinstance(error["message"], str) and error["message"], error
+    # ``request_id`` may be empty string if the server somehow could not bind
+    # one, but the key must be present and the value a string.
+    assert isinstance(error["request_id"], str), error

--- a/tests/tests/test_health.py
+++ b/tests/tests/test_health.py
@@ -1,0 +1,29 @@
+"""Black-box checks for ``/healthz`` and ``/readyz``."""
+
+from __future__ import annotations
+
+import httpx
+
+
+def test_healthz_returns_ok(client: httpx.Client) -> None:
+    """``GET /healthz`` is a liveness probe; it should be 200 + ``status=ok``."""
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body == {"status": "ok"}
+
+
+def test_readyz_reports_db_and_redis_ok(client: httpx.Client) -> None:
+    """``GET /readyz`` must prove both Postgres and Redis are reachable."""
+
+    response = client.get("/readyz")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body.get("status") == "ready", body
+    checks = body.get("checks")
+    assert isinstance(checks, dict), body
+    assert checks.get("db") == "ok", checks
+    assert checks.get("redis") == "ok", checks

--- a/tests/tests/test_hello.py
+++ b/tests/tests/test_hello.py
@@ -1,0 +1,49 @@
+"""Black-box checks for ``GET /api/v1/hello``."""
+
+from __future__ import annotations
+
+import httpx
+
+
+HELLO_PATH = "/api/v1/hello"
+
+
+def test_hello_shape(client: httpx.Client) -> None:
+    """Response must match ``{message: str, item_name: str, hello_count: int}``."""
+
+    response = client.get(HELLO_PATH)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert isinstance(body, dict), body
+    assert set(body.keys()) >= {"message", "item_name", "hello_count"}, body
+
+    assert isinstance(body["message"], str) and body["message"], body
+    assert isinstance(body["item_name"], str) and body["item_name"], body
+    # ``bool`` is a subclass of ``int`` in Python; exclude it explicitly so a
+    # regression that returns ``True``/``False`` would be caught.
+    assert isinstance(body["hello_count"], int), body
+    assert not isinstance(body["hello_count"], bool), body
+
+
+def test_hello_count_increments_by_one(client: httpx.Client) -> None:
+    """Two consecutive calls must increase ``hello_count`` by exactly 1.
+
+    This is a *relative* assertion — it does not depend on the absolute
+    starting value, so it is correct on a fresh stack, on a re-run, and on
+    a stack that has served other traffic.
+    """
+
+    first = client.get(HELLO_PATH)
+    second = client.get(HELLO_PATH)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+
+    first_count = first.json()["hello_count"]
+    second_count = second.json()["hello_count"]
+
+    assert isinstance(first_count, int) and not isinstance(first_count, bool)
+    assert isinstance(second_count, int) and not isinstance(second_count, bool)
+    assert second_count == first_count + 1, (first_count, second_count)

--- a/tests/tests/test_request_id.py
+++ b/tests/tests/test_request_id.py
@@ -1,0 +1,35 @@
+"""Black-box checks for ``X-Request-ID`` propagation."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import httpx
+
+
+HEADER = "X-Request-ID"
+
+
+def test_request_id_echoed_when_client_sends_one(client: httpx.Client) -> None:
+    """A client-supplied ``X-Request-ID`` must be echoed verbatim."""
+
+    supplied = str(uuid4())
+    response = client.get("/healthz", headers={HEADER: supplied})
+
+    assert response.status_code == 200, response.text
+    # ``httpx`` headers are case-insensitive on lookup; use the canonical name.
+    echoed = response.headers.get(HEADER)
+    assert echoed == supplied, (supplied, echoed)
+
+
+def test_request_id_generated_when_client_omits_header(
+    client: httpx.Client,
+) -> None:
+    """Absent a client header, the server must generate a non-empty value."""
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200, response.text
+    generated = response.headers.get(HEADER)
+    assert generated is not None, dict(response.headers)
+    assert generated, "server-generated X-Request-ID was empty"

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -1,0 +1,156 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "minimalist-app-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary

Delivers the final bootstrap feature: an external, black-box REST functional test suite for the compose stack, plus the `test.sh` driver called out in `conventions.md` §8.

Closes #13

## Spec references

- Feature spec: `docs/specs/feat_testing_001/feat_testing_001.md`
- Design spec: `docs/specs/feat_testing_001/design_testing_001.md`
- Test spec: `docs/specs/feat_testing_001/test_testing_001.md`

## Diff summary

- **`test.sh`** — POSIX-ish bash driver at repo root. Probes `/readyz`, runs `make up` if needed, waits (1s tick, 60s timeout, `READINESS_TIMEOUT` override), invokes `uv run pytest` in `tests/`, optionally runs `make down` with `--down`. Flags: `--down`, `--no-up`, `-h`/`--help`. Unknown flags exit 2.
- **`tests/pyproject.toml` + `tests/uv.lock`** — standalone uv project (NOT a workspace member of `backend/`). Deps: `pytest>=8.0`, `httpx>=0.27`. Python `>=3.11`.
- **`tests/conftest.py`** — session-scoped `base_url` (reads `TEST_BASE_URL`, default `http://localhost:8000`) and `httpx.Client` fixtures, plus an autouse `readiness_check` that fails fast with a readable `pytest.UsageError` if the stack isn't up (defence-in-depth for direct `uv run pytest` invocations).
- **`tests/tests/test_health.py`** — `GET /healthz` shape; `GET /readyz` status/checks.db/checks.redis.
- **`tests/tests/test_hello.py`** — `GET /api/v1/hello` shape (str/str/int, non-empty, rejects `bool`); two-call `hello_count` **relative** increment (`second == first + 1`).
- **`tests/tests/test_errors.py`** — `/__does_not_exist__` → 404 + `{error: {code, message, request_id}}` shape (keys + types; doesn't pin strings).
- **`tests/tests/test_request_id.py`** — client-supplied `X-Request-ID` echoed; server-generated when absent.
- **`tests/README.md`** — how to run, prerequisites, env vars, troubleshooting.
- **`tests/.gitignore`** — standard Python/uv.

No files under `backend/`, `frontend/`, `infra/`, or `docs/` (outside the feature's own spec dir) were modified.

## Verification performed

All against `reach.sriharsha@gmail.com`'s local Docker/WSL2 environment on 2026-04-15:

- [x] Cold start: `make down` → `./test.sh` → stack comes up, readiness loops ~6s, 7/7 tests pass, exit 0.
- [x] Warm re-run: `./test.sh` → probe succeeds first try (no `make up`), 7/7 pass, exit 0.
- [x] `./test.sh --no-up` against healthy stack → 7/7 pass, exit 0.
- [x] `./test.sh --down` → 7/7 pass, then `make down` tears stack cleanly, exit 0. `docker compose ps` confirms no services.
- [x] `TEST_BASE_URL=http://127.0.0.1:8000 ./test.sh --no-up` → 7/7 pass, exit 0.
- [x] `cd tests && uv run pytest -v` → all seven named tests PASSED.
- [x] Idempotency: two back-to-back `./test.sh --no-up` runs on a long-lived stack → both pass (`hello_count` relative assertion holds).
- [x] Failure path: `docker compose stop redis` → `READINESS_TIMEOUT=3 ./test.sh --no-up` → emits "waiting…" lines, then "readiness timeout after 3s", exit 1. No Python stack trace.
- [x] Reversibility: `docker compose start redis` → `./test.sh --no-up` → 7/7 pass.
- [x] `./test.sh --froboz` → prints "unknown argument: --froboz" + usage, exit 2.
- [x] `./test.sh --help` → prints usage, exit 0.

## Self-review notes

- `curl` invocation uses `-fs -m 2` (deliberately omits `-S`) so retries during the readiness wait don't spray `curl: (28)` errors into the output. The `[test.sh] waiting for …` lines already communicate state.
- `hello_count` test explicitly excludes `bool` (subclass of `int`) from the type check — a backend regression returning `True`/`False` would be caught.
- Error envelope test asserts keys/types only; `code` and `message` strings are intentionally backend-owned and not pinned here.
- No backend/frontend imports; no direct Postgres/Redis access — pure HTTP, as designed.