### PR TITLE
spec(feat_auth_001): auth foundation — users, roles, identities, sessions

### DIFF
--- a/conventions.md
+++ b/conventions.md
@@ -22,6 +22,7 @@ feat_<domain>_<NNN>
 | `frontend`    | Web UI (Vite + React + TypeScript).                                      |
 | `infra`       | Docker images, `docker-compose`, local orchestration, environment files. |
 | `testing`     | Test harness (`test.sh`), test tooling, cross-cutting test utilities.    |
+| `auth`        | Identity, authentication flows (OAuth + OTP), sessions, roles, authorization primitives. |
 
 ### Adding a new domain
 

--- a/docs/design/auth-login-and-roles.md
+++ b/docs/design/auth-login-and-roles.md
@@ -1,0 +1,683 @@
+# Design: Auth — Google OAuth + Email OTP Login with Roles
+
+- **Status:** Approved (brainstorming complete — implementation plans not yet written)
+- **Date:** 2026-04-16
+- **Scope:** Adds password-less authentication (Google OAuth + email OTP), a user/role/identity data model, Redis-backed sessions, and the two external-service deployment guides.
+- **Introduces new domain:** `auth` (per `conventions.md` §1 — approved during brainstorming).
+- **Delivers as four features:** `feat_auth_001`, `feat_auth_002`, `feat_auth_003`, `feat_frontend_002`.
+
+This spec captures the agreed design. Each of the four features will get its own `feat_*.md`, `design_*.md`, and `test_*.md` trio under `docs/specs/` when Atlas plans them; those will consume this design as their source of truth.
+
+---
+
+## 1. Feature roster
+
+New domain to add to `conventions.md` §1:
+
+| Domain | Scope |
+|---|---|
+| `auth` | Identity, authentication flows (OAuth + OTP), sessions, roles, authorization primitives. |
+
+Four features, strict ordering — each merges before the next starts:
+
+| Feature ID | Scope | What merges in |
+|---|---|---|
+| `feat_auth_001` | **Foundation.** Users + roles + identities schema, Alembic migration, session middleware (Redis-backed httpOnly cookie, 1-day absolute TTL, AOF on), `GET /api/v1/auth/me`, `POST /api/v1/auth/logout`, role-gate FastAPI dependency, seeded `admin`+`user` roles, `ADMIN_EMAILS` bootstrap hook. Conventions edit folded in. | Schema + session plumbing. Exercised by a temporary test-only "mint a session" endpoint enabled only when `env=test`. |
+| `feat_auth_002` | **Email OTP.** `EmailSender` abstraction, `ConsoleEmailSender` + `ResendEmailSender`, `POST /auth/otp/request`, `POST /auth/otp/verify`, Redis-backed rate limiting + OTP storage (hashed), `docs/deployment/email-otp-setup.md`. | First real login path. Removes the temp test-mint endpoint from 001. |
+| `feat_auth_003` | **Google OAuth.** `GET /auth/google/start`, `GET /auth/google/callback`, state + PKCE in Redis, ID-token verification via Google JWKS, auto-link on verified email, `docs/deployment/google-oauth-setup.md`. | Second login path. |
+| `feat_frontend_002` | **Login UI.** Login page with "Sign in with Google" button + OTP request/verify form, `AuthContext`, protected-route wrapper, "signed in as Alice (admin)" header, logout button. | User-facing flow. |
+
+The `auth` domain addition and the two new `conventions.md` rows land **inside `feat_auth_001`** rather than as a separate conventions PR.
+
+---
+
+## 2. Session & token model (the foundational choice)
+
+**Decision: server-side sessions in Redis, opaque session ID in an httpOnly cookie.** Not JWT.
+
+**Why:**
+- Already run Redis — no new infra.
+- Revocation is instant (`DEL session:<id>` on logout or role change).
+- httpOnly cookie defends against XSS; `SameSite=Lax` defends against CSRF. Browser apps are usually more exposed to XSS than CSRF, so this is the stronger default than JWT-in-localStorage.
+- No signing-key management.
+- Per-request check is a single Redis GET (sub-millisecond, in-memory) — **no Postgres hit per request**. Role data lives in the session payload.
+
+**Session TTL:** 1 day **absolute** (not sliding). Set once at login, same value on both the Redis key (`EX 86400`) and the cookie (`Max-Age=86400`).
+
+**Redis durability:** `appendonly yes`, `appendfsync everysec` — routine restart loses at most ~1 second of session writes. A wiped Redis just logs everyone out; users click a login link and get a fresh session. No data loss (users/roles/identities live in Postgres).
+
+**No-DB-per-request property:** the session payload in Redis includes `user_id`, `email`, `roles[]`. `SessionMiddleware` reads the cookie, does one Redis GET, attaches `AuthContext` to `request.state`. Route handlers read from there — no DB call. Stale-role correction is handled by `revoke_sessions_for_user()` on role change.
+
+---
+
+## 3. Role model
+
+**Decision: many-to-many `users` ↔ `roles` via `user_roles`.**
+
+**Seeded roles:** `admin`, `user` (only two, intentionally minimal for a template).
+
+**New-user default:** every new user auto-gets the `user` role. If their email (case-insensitive) is in `ADMIN_EMAILS` they additionally get `admin` on first login. `ADMIN_EMAILS` is **not** a live sync — demoting an admin requires both removing from the env var *and* `DELETE FROM user_roles WHERE user_id=X AND role_id=<admin>`.
+
+**Authorization primitive:** FastAPI dependency `require_roles("admin")` (accepts multiple; OR semantics). Raises 403 on missing role. No per-request DB hit — reads from the session payload.
+
+Future role-permission expansion (RBAC) can layer on top by adding a `permissions` table and extending the dependency. Not in scope.
+
+---
+
+## 4. Identity model
+
+**Decision: `users` + `auth_identities` (one user, N identities).**
+
+A user has one canonical row in `users`. Each login method — Google, email OTP — is an independent row in `auth_identities`. Two identities for the same user represent two independent proofs of that identity (Google's vouching + our OTP's mailbox-control proof). Removing one doesn't affect the other.
+
+**Auto-linking rule:** when a Google login's verified email (`email_verified=true`) matches an existing `users.email`, the new Google identity is attached to that existing user automatically. Without auto-linking, users would end up with duplicate accounts if they switched methods. Auto-linking on **unverified** Google emails is **refused** (attacker could register an unverified Google account with your email and hijack).
+
+### 4.1 Worked example — same email, both methods
+
+**Day 1: Alice signs in with Google.**
+
+Google returns `sub=111222333`, `email=alice@x.com`, `email_verified=true`, `name="Alice Smith"`.
+
+Lookup identity `(google, 111222333)` → none. Lookup `users.email=alice@x.com` → none. Create:
+
+```
+users
+ id | email       | display_name
+ 42 | alice@x.com | Alice Smith
+
+auth_identities
+ id | user_id | provider | provider_user_id | email_at_identity
+  1 |    42   | google   | 111222333        | alice@x.com
+```
+
+**Day 2: Alice requests an OTP for `alice@x.com` and verifies it.**
+
+Lookup identity `(email, alice@x.com)` → none. Lookup `users.email=alice@x.com` → user 42 found. OTP proved mailbox control, so auto-link:
+
+```
+auth_identities (after day 2)
+ id | user_id | provider | provider_user_id | email_at_identity
+  1 |    42   | google   | 111222333        | alice@x.com  ← day 1, untouched
+  2 |    42   | email    | alice@x.com      | alice@x.com  ← day 2, new row
+```
+
+`users` still has one row. The email appears in three places:
+- `users.email` (canonical, current)
+- `auth_identities[1].email_at_identity` (what Google said)
+- `auth_identities[2].email_at_identity` (what OTP verified)
+
+### 4.2 Worked example — different emails per method (edge case)
+
+Alice's Google account is `alice@gmail.com`; her work mailbox is `alice@company.com`.
+
+**Day 1 Google** → `users(42, alice@gmail.com)` + `auth_identities(1, 42, google, sub, alice@gmail.com)`.
+
+**Day 2 OTP for alice@company.com** → identity lookup miss, user lookup by `alice@company.com` miss → **new user 43** is created.
+
+This is the safe outcome. "Link my accounts" requires explicit, authenticated proof of both mailboxes and is deferred to a future feature. The template spec documents this edge case clearly so operators are not surprised.
+
+### 4.3 Identity lifecycle
+
+- Revoke Google access → delete identity row 1. User can still log in via OTP (row 2).
+- Drop email OTP → delete identity row 2. User can still log in via Google.
+- Delete user → `ON DELETE CASCADE` removes both identity rows and all `user_roles` entries.
+
+---
+
+## 5. Backend architecture
+
+### 5.1 Module layout
+
+```
+backend/app/
+  auth/
+    __init__.py
+    models.py          # User, Role, UserRole, AuthIdentity
+    schemas.py         # Pydantic: OtpRequest, OtpVerify, MeResponse, etc.
+    router.py          # /auth/me, /auth/logout, /auth/otp/*, /auth/google/*
+    service.py         # Session create/revoke, OTP gen/verify, OAuth code exchange
+    sessions.py        # Redis session store (get/put/delete/extend, reverse index)
+    otp.py             # OTP code generation, hashing, rate limit keys
+    google.py          # OAuth state/PKCE helpers, JWKS verification
+    email/
+      __init__.py
+      base.py          # EmailSender protocol
+      console.py       # ConsoleEmailSender  (dev-only)
+      resend.py        # ResendEmailSender   (prod)
+      factory.py       # select by EMAIL_PROVIDER env var
+    dependencies.py    # current_user, require_roles, require_authenticated
+    bootstrap.py       # ADMIN_EMAILS grant-on-first-login hook
+  middleware.py        # + SessionMiddleware
+```
+
+Email senders live under `app/auth/email/` since OTP is currently the only consumer. If a later feature needs transactional email for other purposes, the package hoists to `app/email/` with no other refactor.
+
+### 5.2 Endpoint inventory
+
+| Method + path | Feature | Purpose | Auth required |
+|---|---|---|---|
+| `POST /api/v1/auth/otp/request` | 002 | Send OTP to email | no |
+| `POST /api/v1/auth/otp/verify` | 002 | Verify OTP → session | no |
+| `GET /api/v1/auth/google/start` | 003 | Redirect to Google | no |
+| `GET /api/v1/auth/google/callback` | 003 | Google redirect back → session | no |
+| `GET /api/v1/auth/me` | 001 | Current user + roles | yes |
+| `POST /api/v1/auth/logout` | 001 | Revoke session | yes |
+
+### 5.3 FastAPI dependency examples (verbatim in spec)
+
+```python
+from app.auth.dependencies import current_user, require_roles
+
+@router.get("/me")
+async def me(user: User = Depends(current_user)) -> MeResponse: ...
+
+@router.get("/admin/users")
+async def list_users(user: User = Depends(require_roles("admin"))) -> ...: ...
+
+@router.get("/public/hello")   # no Depends — public
+async def hello(): ...
+```
+
+### 5.4 Middleware order (in `app/main.py`)
+
+```
+RequestIDMiddleware   (existing)
+LoggingMiddleware     (existing)
+SessionMiddleware     (new)
+```
+
+`SessionMiddleware` runs before the route, attaches `request.state.auth = AuthContext(...) | None`.
+
+---
+
+## 6. Data model
+
+### 6.1 Postgres schema (Alembic migration in `feat_auth_001/versions/0002_create_auth.py`)
+
+```sql
+CREATE EXTENSION IF NOT EXISTS citext;
+
+users (
+  id              bigserial PRIMARY KEY,
+  email           citext NOT NULL UNIQUE,
+  display_name    varchar(255),
+  is_active       boolean NOT NULL DEFAULT true,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  last_login_at   timestamptz
+)
+
+roles (
+  id    serial PRIMARY KEY,
+  name  varchar(64) NOT NULL UNIQUE
+)
+-- seeded by migration: INSERT INTO roles (name) VALUES ('admin'), ('user');
+
+user_roles (
+  user_id    bigint   NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role_id    integer  NOT NULL REFERENCES roles(id) ON DELETE RESTRICT,
+  granted_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, role_id)
+)
+
+auth_identities (
+  id                  bigserial PRIMARY KEY,
+  user_id             bigint NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider            varchar(32) NOT NULL,   -- 'email' | 'google'
+  provider_user_id    varchar(255) NOT NULL,  -- Google 'sub' | email-itself
+  email_at_identity   citext NOT NULL,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  last_used_at        timestamptz,
+  UNIQUE (provider, provider_user_id)
+)
+CREATE INDEX ON auth_identities (user_id);
+```
+
+**Choice notes:**
+- `citext` for case-insensitive email uniqueness.
+- `ON DELETE CASCADE` user → identities, user → user_roles. `RESTRICT` on role deletion to prevent accidental nuking of `admin`.
+- `email_at_identity` records what the provider saw at linking time; `users.email` is the canonical current email. They can drift over time (e.g., Google email changes after a rebrand). No auto-sync; user edits are a future feature.
+
+### 6.2 Redis keyspaces (all TTL'd, no manual cleanup)
+
+| Key pattern | Value | TTL | Set by | Feature |
+|---|---|---|---|---|
+| `session:<32-byte-hex>` | JSON `{user_id, email, roles[], created_at}` | 86400 | login success | 001 |
+| `user_sessions:<user_id>` | SET of session ids | matches longest session | login success | 001 |
+| `otp:<email_hash>` | JSON `{code_hash, attempts, created_at}` | 600 | OTP request | 002 |
+| `otp_rate:<email_hash>:minute` | counter | 60 | OTP request | 002 |
+| `otp_rate:<email_hash>:hour` | counter | 3600 | OTP request | 002 |
+| `oauth_state:<state>` | JSON `{pkce_verifier, created_at, redirect_after}` | 600 | `/google/start` | 003 |
+
+`<email_hash>` = `sha256(lower(email))` hex. Prevents plaintext emails leaking into Redis keys.
+
+Session ID = `secrets.token_hex(32)` — 256 bits, opaque.
+
+OTP codes stored as bcrypt hashes; work factor tuned for ~10ms verify (low because the search space is only 1M).
+
+`oauth_state` consumed via `GETDEL` — single-use, prevents replay.
+
+### 6.3 Alembic migrations across features
+
+- `feat_auth_001`: `0002_create_auth.py` — all four tables at once, role seed, `citext` extension.
+- `feat_auth_002`: no migration (everything lives in Redis).
+- `feat_auth_003`: no migration (identities table exists).
+
+---
+
+## 7. Data flow — worked scenarios
+
+### 7.1 Email OTP: request → verify → session
+
+**Request.**
+
+```
+POST /api/v1/auth/otp/request   { "email": "alice@x.com" }
+```
+
+1. Normalize email, compute `h = sha256(lower(email))`.
+2. Rate-limit check: `INCR otp_rate:<h>:minute` (>1 → 429); `INCR otp_rate:<h>:hour` (>10 → 429).
+3. Generate `code = f"{secrets.randbelow(10**6):06d}"` → `"482913"`. Bcrypt-hash.
+4. `SET otp:<h> '{"code_hash":"...","attempts":0,"created_at":...}' EX 600`.
+5. Send email (`console` or `resend` provider).
+6. Respond `204 No Content`. **Same response for known and unknown emails** — prevents account enumeration.
+
+**Verify.**
+
+```
+POST /api/v1/auth/otp/verify   { "email": "alice@x.com", "code": "482913" }
+```
+
+1. `GET otp:<h>`. Missing → 400 `invalid_or_expired_code`.
+2. `attempts >= 5` → 400 AND `DEL otp:<h>` (one-shot lockout).
+3. `bcrypt.verify(code, code_hash)`:
+   - Mismatch → increment `attempts`, preserve TTL, 400 `invalid_or_expired_code`.
+   - Match → proceed.
+4. `DEL otp:<h>` (one-shot, prevents replay).
+5. Find-or-create user:
+   - Identity `(email, alice@x.com)` → if found, `user = identity.user`.
+   - Else user-by-email → if found, create identity (auto-link).
+   - Else create user + identity + grant `user` role (+`admin` if in `ADMIN_EMAILS`).
+6. `last_login_at = now()`; `last_used_at = now()` on identity.
+7. Create session (§7.4).
+8. `200` with `Set-Cookie: session=...` and body `{ "user": {...} }`.
+
+**Failure matrix.**
+
+| Condition | Code | Body |
+|---|---|---|
+| Rate limit hit | 429 | `{"detail": "too_many_requests", "retry_after": 42}` |
+| Code expired / never requested | 400 | `{"detail": "invalid_or_expired_code"}` |
+| Wrong code | 400 | `{"detail": "invalid_or_expired_code"}` |
+| Attempts exhausted | 400 | `{"detail": "invalid_or_expired_code"}` |
+| Deactivated user | 403 | `{"detail": "account_disabled"}` |
+
+All four bad-code conditions return the same body string so an attacker can't distinguish "never requested" from "wrong code."
+
+### 7.2 Google OAuth: start → callback → session
+
+**Start.**
+
+```
+GET /api/v1/auth/google/start?redirect_after=/dashboard
+```
+
+1. `state = secrets.token_urlsafe(32)`, `pkce_verifier = secrets.token_urlsafe(64)`, `pkce_challenge = base64url(sha256(pkce_verifier))`.
+2. `SET oauth_state:<state> '{"pkce_verifier":"...","redirect_after":"/dashboard"}' EX 600`.
+3. Build Google auth URL and `302` redirect:
+
+```
+https://accounts.google.com/o/oauth2/v2/auth?
+  client_id=<GOOGLE_OAUTH_CLIENT_ID>
+  &redirect_uri=<GOOGLE_OAUTH_REDIRECT_URI>
+  &response_type=code
+  &scope=openid%20email%20profile
+  &state=<state>
+  &code_challenge=<pkce_challenge>
+  &code_challenge_method=S256
+  &prompt=select_account
+```
+
+**Callback.**
+
+```
+GET /api/v1/auth/google/callback?code=4/0Adeu5...&state=<state>
+```
+
+1. `GETDEL oauth_state:<state>` — atomic single-use. Missing → 400.
+2. Parse `pkce_verifier` and `redirect_after` from the retrieved blob.
+3. POST to `https://oauth2.googleapis.com/token` with `grant_type=authorization_code`, `code`, `client_id`, `client_secret`, `redirect_uri`, `code_verifier=<pkce_verifier>`.
+4. Verify the returned `id_token`:
+   - Fetch Google JWKS from `https://www.googleapis.com/oauth2/v3/certs` (in-process cache, 10 min).
+   - Verify RS256 signature against matching `kid`.
+   - `iss` ∈ `{"https://accounts.google.com", "accounts.google.com"}`.
+   - `aud == GOOGLE_OAUTH_CLIENT_ID`.
+   - `exp > now()`.
+   - Extract `sub`, `email`, `email_verified`, `name`.
+5. **If `email_verified != true` → 400 `unverified_google_email`.** Never auto-link an unverified email.
+6. Find-or-create user:
+   - Identity `(google, sub)` → if found, `user = identity.user`.
+   - Else user-by-email → if found, create identity (auto-link).
+   - Else create user + identity + grant `user` role (+`admin` if in `ADMIN_EMAILS`).
+7. Update `last_login_at`, `last_used_at`.
+8. Create session (§7.4).
+9. `302` redirect to `FRONTEND_URL + redirect_after` (defaulting to `/`), with `Set-Cookie: session=...`.
+
+**Failure matrix.**
+
+| Condition | Response |
+|---|---|
+| `state` missing or already consumed | `400 invalid_or_expired_state` + redirect to `FRONTEND_URL/login?error=expired` |
+| Google token exchange fails | `400 google_token_exchange_failed` |
+| ID token signature/claims invalid | `400 invalid_id_token` |
+| `email_verified=false` | `400 unverified_google_email` |
+| Account deactivated | `403 account_disabled` |
+
+### 7.3 `/auth/me` on every subsequent request
+
+```
+GET /api/v1/auth/me
+Cookie: session=abc123...
+```
+
+`SessionMiddleware` (every request, pre-route):
+1. Read cookie. Absent → `request.state.auth = None`.
+2. `GET session:abc123...`. Missing → clear cookie (`Max-Age=0`), `request.state.auth = None`.
+3. Parse JSON → `request.state.auth = AuthContext(user_id=42, email='alice@x.com', roles=['user','admin'], session_id='abc123')`.
+4. **No DB hit.**
+
+`current_user` returns `request.state.auth` or raises 401. Response:
+
+```json
+{
+  "user_id": 42,
+  "email": "alice@x.com",
+  "display_name": "Alice Smith",
+  "roles": ["user", "admin"]
+}
+```
+
+### 7.4 Session creation (shared helper)
+
+```python
+session_id = secrets.token_hex(32)
+payload = {
+    "user_id": user.id,
+    "email": user.email,
+    "roles": [r.name for r in user.roles],
+    "created_at": now_iso(),
+}
+pipeline = redis.pipeline()
+pipeline.set(f"session:{session_id}", json.dumps(payload), ex=86400)
+pipeline.sadd(f"user_sessions:{user.id}", session_id)
+pipeline.expire(f"user_sessions:{user.id}", 86400)
+pipeline.execute()
+
+response.set_cookie(
+    settings.session_cookie_name,
+    session_id,
+    max_age=settings.session_ttl_seconds,
+    httponly=True,
+    secure=settings.session_cookie_secure,
+    samesite="lax",
+    path="/",
+)
+```
+
+`SESSION_COOKIE_SECURE=true` in staging/prod; `false` in local dev so http://localhost works. All three values (`name`, `ttl`, `secure`) come from `Settings` — no duplicated constants.
+
+### 7.5 Logout
+
+```
+POST /api/v1/auth/logout   (authenticated)
+```
+
+1. `session_id = request.state.auth.session_id`.
+2. `DEL session:<session_id>`.
+3. `SREM user_sessions:<user_id> <session_id>`.
+4. `204 No Content` with `Set-Cookie: session=; Max-Age=0`.
+
+### 7.6 Role-change session revocation
+
+Not a user-facing endpoint in the MVP. Service helper exists from day one:
+
+```python
+def revoke_sessions_for_user(user_id: int) -> None:
+    session_ids = redis.smembers(f"user_sessions:{user_id}")
+    if session_ids:
+        redis.delete(*[f"session:{sid}" for sid in session_ids])
+    redis.delete(f"user_sessions:{user_id}")
+```
+
+**We revoke, not update.** Simpler, predictable, no race conditions. User re-logs in with fresh roles.
+
+### 7.7 `ADMIN_EMAILS` bootstrap
+
+Parse once at startup into a lower-cased set. On user creation:
+
+```python
+if user.email.lower() in settings.admin_emails_set:
+    user.roles.append(role_admin)
+```
+
+Empty env var → empty set → never grants admin. That is the normal state for a dev-only clone.
+
+Demoting an admin: remove from the env var **and** `DELETE FROM user_roles WHERE user_id=X AND role_id=<admin>`. The env var is a first-login convenience, not a live sync. Documented explicitly in the deployment guide.
+
+---
+
+## 8. Security posture
+
+### 8.1 In-scope defenses
+
+| Threat | Mitigation |
+|---|---|
+| Session theft via XSS | httpOnly cookie — JS can't read |
+| CSRF on auth endpoints | `SameSite=Lax` + JSON-only content-type check |
+| Session replay after logout | Redis `DEL` on logout revokes instantly |
+| Session hijack survives role change | `revoke_sessions_for_user` helper |
+| OTP brute force | bcrypt-hashed codes, 5-attempt lockout, 10-min TTL, rate limits |
+| OTP enumeration | Same 204 response for known and unknown emails |
+| OAuth code replay | `state` consumed via `GETDEL` |
+| OAuth MITM on code exchange | PKCE (S256) — attacker can't exchange intercepted code |
+| Unverified Google email hijack | Reject `email_verified=false` |
+| Admin privilege escalation | `ADMIN_EMAILS` env-gated, no self-service admin endpoint |
+| Cookie over plaintext | `Secure=True` in non-dev envs |
+| Redis session leak via `KEYS *` | Emails hashed in keys; session payloads minimal |
+| Stored OTP compromise | Codes stored as bcrypt hash, not plaintext |
+
+### 8.2 Out of scope (document, don't build)
+
+- MFA / TOTP beyond OTP email.
+- Password login (passwordless by design).
+- Account recovery beyond "request another OTP."
+- Anti-CSRF tokens on non-auth routes (add when first mutating non-auth route lands).
+- Full audit log. `last_login_at` + `last_used_at` + structured logs are the MVP trail.
+- Account linking UI.
+- User profile editing, admin dashboard, second OAuth provider, email templating, session "devices" view, password reset, account self-deletion.
+
+---
+
+## 9. Testing strategy
+
+### 9.1 Backend unit tests (`backend/tests/`)
+
+| Area | Sample cases |
+|---|---|
+| `otp.generate_code` / `otp.verify_code` | 6 digits, bcrypt roundtrip, attempt increment, TTL preserved after mismatch, one-shot delete on success |
+| `sessions.create` / `get` / `delete` | Payload round-trip, reverse index updated, `delete` wipes both keys |
+| `google.verify_id_token` | Valid signed token passes; expired rejected; wrong `aud` rejected; wrong `iss` rejected; `email_verified=false` rejected — using a fixture JWKS + signed tokens, not the real Google |
+| `bootstrap.grant_admin_if_listed` | Matching email grants admin; non-matching doesn't; empty list no-op |
+| `dependencies.current_user` | Missing cookie → 401; valid → user; expired session → 401 |
+| `dependencies.require_roles` | Role present → pass; role missing → 403; multiple roles OR semantics |
+| OTP rate limiter | 2nd request within 60s blocked; 61s later allowed; 11th within hour blocked |
+
+### 9.2 Backend integration tests (real Postgres + Redis)
+
+| Flow | Assertions |
+|---|---|
+| OTP request → verify → `/me` → logout → `/me` 401 | Full session lifecycle |
+| OTP with wrong code 5× → 6th is locked even with correct code → new request works | Lockout semantics |
+| Google callback with stubbed token endpoint + test-keypair JWKS | Full OAuth happy path end-to-end |
+| Same email via Google then OTP (§4.1) | Two identity rows, one user |
+| `ADMIN_EMAILS=alice@x.com` → Alice's first login grants admin | Bootstrap works |
+
+### 9.3 External REST suite (`test.sh` extensions)
+
+- `POST /auth/otp/request` → 204; `POST /auth/otp/verify` → 200 with `Set-Cookie`.
+- Cookie-bearing `GET /auth/me` → 200; no-cookie → 401.
+- `POST /auth/logout` → 204; follow-up `/auth/me` → 401.
+- Google flow: mock Google server run inside the test container verifies `302 → callback → 302 FRONTEND_URL` shape.
+
+### 9.4 Frontend tests (`feat_frontend_002`)
+
+- Login page renders both options.
+- OTP form — submit, receive code (dev pulls from backend log), verify, land on home with user state.
+- Protected-route wrapper redirects unauthenticated to `/login`.
+- Logout button clears state and redirects.
+
+---
+
+## 10. Observability
+
+Structured log events emitted via the existing structlog chain from `feat_backend_002`. Event names are stable; fields are consistent across all auth flows.
+
+```
+auth.otp.requested     email_hash=<h>   rate_bucket_minute=1  provider=email
+auth.otp.verified      user_id=42       email_hash=<h>        new_user=false
+auth.otp.failed        email_hash=<h>   reason=invalid_code   attempts=2
+auth.google.started    state_hash=<h>
+auth.google.callback   user_id=42       email_hash=<h>        new_user=true   linked=google
+auth.google.failed     reason=email_unverified
+auth.session.created   user_id=42       session_id_hash=<h>
+auth.session.revoked   user_id=42       session_id_hash=<h>   reason=logout
+auth.role.granted      user_id=42       role=admin            source=admin_emails_bootstrap
+```
+
+**Rules:**
+- Never log full emails or session IDs — always `sha256(x)[:16]` as `*_hash`. Consistent across events for the same principal. Log-trace-able without PII.
+- Never log OTP codes or Google tokens (except the `ConsoleEmailSender`, which is the intentional dev-only exception).
+- Every failure carries a `reason` field with a short, stable enum value. Greppable.
+- Every flow terminator emits exactly one success or one failure event. No silent successes.
+
+---
+
+## 11. Environment variables
+
+Added to `infra/.env.example`:
+
+```ini
+# ---- Auth (feat_auth_001) ----
+SESSION_COOKIE_NAME=session
+SESSION_TTL_SECONDS=86400
+SESSION_COOKIE_SECURE=false          # override to true in staging/prod
+ADMIN_EMAILS=                        # comma-separated; empty = no bootstrap admin
+
+# ---- Email / OTP (feat_auth_002) ----
+EMAIL_PROVIDER=console               # 'console' | 'resend'
+EMAIL_FROM="minimalist-app <noreply@example.com>"
+RESEND_API_KEY=                      # required when EMAIL_PROVIDER=resend
+OTP_CODE_TTL_SECONDS=600
+OTP_MAX_ATTEMPTS=5
+OTP_RATE_PER_MINUTE=1
+OTP_RATE_PER_HOUR=10
+
+# ---- Google OAuth (feat_auth_003) ----
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:8000/api/v1/auth/google/callback
+FRONTEND_URL=http://localhost:5173
+```
+
+All parsed into `app/settings.py` via Pydantic Settings. Defaults are chosen so `make up` on a clean clone **works out of the box for OTP-via-console** — no external signups required to develop. Google requires the three `GOOGLE_OAUTH_*` fields populated per the deployment guide.
+
+---
+
+## 12. Redis persistence (compose edit)
+
+`infra/docker-compose.yml` — `redis` service (edit lands in `feat_auth_001`):
+
+```yaml
+redis:
+  image: redis:7-alpine
+  command: >
+    redis-server
+    --appendonly yes
+    --appendfsync everysec
+  volumes:
+    - redis-data:/data
+```
+
+Plus the `redis-data` named volume. Survives routine restarts. Session continuity across `make down && make up` within a second or two of the last write.
+
+---
+
+## 13. Deployment documentation
+
+New directory: `docs/deployment/`. Separate from the top-level `deployment/` path (reserved by `conventions.md` §8 for Helm/Terraform artifacts).
+
+**`docs/deployment/README.md`** — one-screen index:
+
+> External services that need manual setup before production. Each guide is self-contained and lists the env vars it populates.
+>
+> - [Google OAuth](google-oauth-setup.md) — required for `feat_auth_003` (Sign in with Google).
+> - [Email / OTP](email-otp-setup.md) — required for `feat_auth_002` in non-dev envs (Sign in with email OTP).
+
+**`docs/deployment/google-oauth-setup.md`** (lands with `feat_auth_003`):
+
+- Prerequisites.
+- Step 1: Create or select GCP project.
+- Step 2: Configure OAuth consent screen (user type, scopes, test users).
+- Step 3: Create OAuth 2.0 Client ID (web application type, redirect URIs for dev + prod).
+- Step 4: Populate `.env` — copy Client ID + Client Secret; exact var names.
+- Step 5: Verify — `make up`, navigate to `/api/v1/auth/google/start`, confirm redirect dance.
+- Troubleshooting table: redirect URI mismatch; test user 403; consent screen in Testing mode expired; token exchange fail; client secret rotation.
+- Rotating credentials.
+
+**`docs/deployment/email-otp-setup.md`** (lands with `feat_auth_002`):
+
+- Provider comparison table (Resend / SendGrid / SES / Postmark — 4 rows × price/ease/region).
+- Why the template defaults to Resend (simplest API, free tier).
+- Step 1: Create Resend account, verify sending domain (DKIM + SPF DNS records).
+- Step 2: Generate API key.
+- Step 3: Populate `.env` — `EMAIL_PROVIDER=resend`, `RESEND_API_KEY=...`, `EMAIL_FROM="..."`.
+- Step 4: Verify — hit `/auth/otp/request`, confirm email lands, check DKIM pass in headers.
+- Troubleshooting table: email in spam; DKIM fail; sender-not-verified; Resend rate limit; switching to SendGrid.
+- Rotating credentials.
+
+---
+
+## 14. Convention updates (inside `feat_auth_001`)
+
+- `conventions.md` §1 — add the `auth` row to the domains table.
+- `conventions.md` §8 — **no** change to `deployment/` reservation (we're using `docs/deployment/` instead).
+- `conventions.md` §10 — leave the "initial feature roster" label alone; the four new features live under `docs/tracking/features.md` instead.
+- `docs/tracking/features.md` — one row per feature, statuses advance through the usual `Planned → In Spec → Ready → In Build → Merged` lifecycle.
+
+---
+
+## 15. Explicit non-goals
+
+The following are deliberately **not** in this four-feature sequence. Raising any of them mid-implementation → push back and propose as a future feature.
+
+- User profile editing (change email, display name).
+- Account linking UI (§4.2 edge case).
+- Admin dashboard or admin UI.
+- Second OAuth provider (GitHub, Apple, Microsoft).
+- Email templating system — OTP body is a string literal.
+- Session "devices" view.
+- Password reset / passwords generally.
+- Account self-deletion.
+- MFA / TOTP.
+- Full audit log.
+
+---
+
+## 16. Implementation sequencing reminder
+
+Per `conventions.md` §§3–5 and the existing AutoDev workflow:
+
+1. **Atlas** plans `feat_auth_001` first — writes the three spec files on `spec/feat_auth_001`, opens spec PR. Merges to `main`.
+2. **Vulcan** implements on `build/feat_auth_001`. Merges.
+3. Repeat for `feat_auth_002`, then `feat_auth_003`, then `feat_frontend_002`.
+
+This design document serves as the stable source of truth across all four planning cycles. If any of the four atlas sessions wants to deviate from this design, that deviation is a revision of this document first, spec second.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -42,5 +42,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_infra_001`        | Planned    | Dockerfiles, `docker-compose.yml`, `.env` templates, local orchestration.   |
 | `feat_testing_001`      | Planned    | `test.sh` driver, test conventions, minimal backend + frontend test examples.|
 | `feat_backend_002`      | In Build   | Backend rules (`backend/RULES.md`), logging callsite + redaction, items domain move. |
+| `feat_auth_001`         | In Spec    | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_auth_001/design_auth_001.md
+++ b/docs/specs/feat_auth_001/design_auth_001.md
@@ -1,0 +1,326 @@
+# Design: Auth foundation — users, roles, identities, sessions
+
+## Source of truth
+
+The architectural decisions — why server-side sessions over JWT, why opaque cookie, why role data in the session payload, why `citext` on email, why auto-link on verified email, why `ADMIN_EMAILS` is not a live sync — live in **`docs/design/auth-login-and-roles.md`**. This design spec does **not** repeat that reasoning. It describes the concrete file-level work that lands in `feat_auth_001` and references:
+
+- **§5** — module layout, endpoint inventory, middleware order.
+- **§6** — Postgres schema and Redis keyspaces (001 lands only the `session:*` and `user_sessions:*` keys; the `otp:*` and `oauth_state:*` keys are defined but written by 002/003).
+- **§7** — data-flow narratives (this feature covers §7.3 `/auth/me`, §7.4 session creation, §7.5 logout, §7.6 revocation, §7.7 `ADMIN_EMAILS`). §§7.1 and 7.2 are out of scope.
+- **§12** — Redis persistence in compose.
+
+When this spec says "per §6.1" it means "see the design doc, section 6.1 — don't duplicate."
+
+## Approach
+
+Five disjoint pieces of work, one build:
+
+1. **Check in the design doc.** Move `docs/design/auth-login-and-roles.md` from untracked into the tree verbatim. All four auth features reference it.
+2. **Schema.** One Alembic migration `0002_create_auth.py` creating `citext`, `users`, `roles`, `user_roles`, `auth_identities`, seeding two role rows. SQLAlchemy models under `app/auth/models.py`.
+3. **Session plumbing.** `app/auth/sessions.py` (Redis store), `SessionMiddleware` in `app/middleware.py`, `AuthContext` dataclass.
+4. **Authorization primitives.** `app/auth/dependencies.py` with `current_user`, `require_authenticated`, `require_roles(*names)`. `app/auth/bootstrap.py` for `ADMIN_EMAILS`. `app/auth/service.py` for `revoke_sessions_for_user`.
+5. **Endpoints + test-only mint.** `GET /api/v1/auth/me`, `POST /api/v1/auth/logout`, and `POST /api/v1/_test/session` (env-gated). Config additions and the compose redis durability tweak round it out.
+
+Nothing in this feature calls Google, reads email, or sends a message. The only external surface is the `/auth/me` + `/auth/logout` pair plus the env-gated mint. That is deliberate: it lets the session plumbing be fully tested before the real login paths land.
+
+## Files to Create
+
+| Path | Purpose |
+|---|---|
+| `docs/design/auth-login-and-roles.md` | Move from untracked into the tree. Byte-identical to the existing working-tree file. |
+| `backend/alembic/versions/0002_create_auth.py` | Migration: `citext` + four tables + role seeds. |
+| `backend/app/auth/__init__.py` | Package marker; re-exports `router`. |
+| `backend/app/auth/models.py` | `User`, `Role`, `UserRole`, `AuthIdentity` SQLAlchemy 2.x models. |
+| `backend/app/auth/schemas.py` | `MeResponse`, `AuthContext` (pydantic/dataclass), `TestSessionRequest`. |
+| `backend/app/auth/sessions.py` | Redis session store: `create`, `get`, `delete`, `revoke_all_for_user`. |
+| `backend/app/auth/dependencies.py` | `current_user`, `require_authenticated`, `require_roles`. |
+| `backend/app/auth/bootstrap.py` | `ADMIN_EMAILS` parsing, `grant_admin_if_listed`. |
+| `backend/app/auth/service.py` | `revoke_sessions_for_user`, thin find-or-create helpers used by the test-only mint. |
+| `backend/app/auth/router.py` | `GET /me`, `POST /logout`, plus the env-gated `/_test/session` mounted on a separate router. |
+| `backend/tests/test_auth_sessions.py` | Unit tests for the Redis session store. |
+| `backend/tests/test_auth_middleware.py` | Integration tests for `SessionMiddleware` behavior. |
+| `backend/tests/test_auth_dependencies.py` | Unit tests for `current_user`, `require_roles`. |
+| `backend/tests/test_auth_bootstrap.py` | Unit tests for `ADMIN_EMAILS` grant-on-first-login. |
+| `backend/tests/test_auth_me_logout.py` | End-to-end tests for `/me` + `/logout` using the test-only mint. |
+| `backend/tests/test_auth_test_mint_gating.py` | Verifies `_test/session` is 404 when `env != "test"`. |
+| `docs/specs/feat_auth_001/feat_auth_001.md` | Feature spec. |
+| `docs/specs/feat_auth_001/design_auth_001.md` | This file. |
+| `docs/specs/feat_auth_001/test_auth_001.md` | Test spec. |
+
+## Files to Modify
+
+| Path | Change |
+|---|---|
+| `conventions.md` | §1 domains table — add `auth` row (verbatim text in requirement 1 of the feature spec). |
+| `backend/app/middleware.py` | Add `SessionMiddleware` class. No change to existing middleware. |
+| `backend/app/main.py` | Install `SessionMiddleware` per §5.4 of the design doc. Mount auth router at `/api/v1/auth`. When `settings.env == "test"`, additionally mount the test-only router at `/api/v1/_test`. |
+| `backend/app/api/v1/__init__.py` | `include_router(auth_router, prefix="/auth", tags=["auth"])` alongside the existing items router. |
+| `backend/app/settings.py` | Add four new fields: `session_cookie_name`, `session_ttl_seconds`, `session_cookie_secure`, `admin_emails` (raw string). Plus a computed property `admin_emails_set` returning `frozenset[str]` of lower-cased addresses. |
+| `infra/.env.example` | Add the four new lines under an `# ---- Auth (feat_auth_001) ----` heading, as laid out in §11 of the design doc. |
+| `infra/docker-compose.yml` | `redis.command` becomes `["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]`. `redisdata` volume is preserved. |
+| `docs/specs/README.md` | Roster table gains a row for `feat_auth_001`. |
+| `docs/tracking/features.md` | One new row; `Status=Specced` with Spec PR and Issues backfilled. |
+
+## Files to Delete
+
+None. This feature only adds.
+
+## Middleware order (per §5.4 of the design doc)
+
+```
+RequestIDMiddleware          (existing; outermost)
+ExceptionEnvelopeMiddleware  (existing)
+SessionMiddleware            (NEW — inserted between the above and the route)
+FastAPI routing
+```
+
+`app.add_middleware` prepends to the stack (LIFO). Current order in `main.py` adds `ExceptionEnvelopeMiddleware` first, then `RequestIDMiddleware`. To land `SessionMiddleware` strictly between `RequestIDMiddleware` and route dispatch, add it **between** the two existing `add_middleware` calls, in this order:
+
+```python
+app.add_middleware(ExceptionEnvelopeMiddleware)       # innermost
+app.add_middleware(SessionMiddleware)                 # NEW
+app.add_middleware(RequestIDMiddleware, header_name=...)  # outermost
+```
+
+This keeps `RequestIDMiddleware` outermost (so request IDs are bound before session work, matching the bind-ordering invariant `feat_backend_002` established) and runs `SessionMiddleware` before the exception envelope wraps errors. Any 401 raised by a route dependency still flows through the envelope normally.
+
+## Data flow
+
+### Request lifecycle with a valid cookie
+
+```
+client  (Cookie: session=abc123...)
+  → RequestIDMiddleware        (binds request_id into structlog contextvars)
+  → SessionMiddleware          (NEW)
+      ├── read settings.session_cookie_name from request.cookies
+      ├── GET session:abc123... (one Redis hop; sub-ms; NO DB)
+      ├── parse JSON → AuthContext(user_id, email, roles, session_id)
+      └── request.state.auth = ctx
+  → ExceptionEnvelopeMiddleware
+  → FastAPI dispatch
+  → current_user dep: returns request.state.auth or raises HTTPException(401)
+  → route handler
+```
+
+### No cookie, expired session, malformed payload
+
+All three collapse to the same outcome: `request.state.auth = None`. If the cookie was present but the Redis key was missing or malformed, the middleware **also** appends a `Set-Cookie: <name>=; Max-Age=0` to the response so the browser stops sending it. Log event: `auth.session.expired_cookie_cleared` (reason field distinguishes `missing_key`, `malformed_payload`, `malformed_cookie`).
+
+### Session creation (shared helper, used by the test-only mint here and by OTP/OAuth in 002/003)
+
+```python
+session_id = secrets.token_hex(32)                          # 64 hex chars
+payload = {
+    "user_id": user.id,
+    "email": user.email,
+    "roles": [r.name for r in user.roles],
+    "created_at": now_iso(),
+}
+pipe = redis.pipeline()
+pipe.set(f"session:{session_id}", json.dumps(payload), ex=settings.session_ttl_seconds)
+pipe.sadd(f"user_sessions:{user.id}", session_id)
+pipe.expire(f"user_sessions:{user.id}", settings.session_ttl_seconds)
+await pipe.execute()
+
+response.set_cookie(
+    settings.session_cookie_name,
+    session_id,
+    max_age=settings.session_ttl_seconds,
+    httponly=True,
+    secure=settings.session_cookie_secure,
+    samesite="lax",
+    path="/",
+)
+```
+
+### Logout
+
+```
+POST /api/v1/auth/logout  (Cookie: session=abc123...)
+  → SessionMiddleware populates request.state.auth
+  → route sees ctx.session_id = "abc123..."
+  → sessions.delete("abc123...", ctx.user_id, redis=...)
+      ├── DEL session:abc123...
+      └── SREM user_sessions:<uid> abc123...
+  → response.delete_cookie(name, path="/")
+  → 204 No Content
+```
+
+### Role-change revocation
+
+```python
+# backend/app/auth/service.py
+async def revoke_sessions_for_user(user_id: int, *, redis) -> None:
+    session_ids = await redis.smembers(f"user_sessions:{user_id}")
+    if session_ids:
+        keys = [f"session:{sid.decode() if isinstance(sid, bytes) else sid}" for sid in session_ids]
+        await redis.delete(*keys)
+    await redis.delete(f"user_sessions:{user_id}")
+```
+
+`DEL`-based, not update-based — predictable, no races. Not wired to a user-facing endpoint in 001; it exists so 002 and 003 can call it without introducing new infra.
+
+## Postgres schema — per §6.1 of the design doc
+
+The SQL shape is specified in the design doc; the migration file is a faithful translation. Key properties (re-stated only as acceptance hooks for `test_auth_001.md`, not as design):
+
+- `email` is `CITEXT NOT NULL UNIQUE` on `users`; `citext` extension created in the same migration, **before** the `users` table.
+- `roles.name` is `VARCHAR(64) NOT NULL UNIQUE`. Seeds `('admin')`, `('user')` inline in the migration.
+- `user_roles` composite PK `(user_id, role_id)`. FK `user_id → users(id)` is `ON DELETE CASCADE`; FK `role_id → roles(id)` is `ON DELETE RESTRICT`.
+- `auth_identities.provider` is `VARCHAR(32)`; `provider_user_id` is `VARCHAR(255)`; unique index on `(provider, provider_user_id)`. Regular index on `user_id`. `email_at_identity` is `CITEXT NOT NULL`.
+- All timestamp columns are `TIMESTAMPTZ`.
+- Alembic naming convention (wired in `feat_backend_002`) produces deterministic constraint names: `pk_users`, `uq_roles_name`, `fk_auth_identities_user_id_users`, `uq_auth_identities_provider`, etc.
+
+The `downgrade()` drops in reverse order — `auth_identities`, `user_roles`, `roles`, `users` — and `DROP EXTENSION citext`.
+
+## Redis keyspaces used by this feature
+
+Per §6.2 of the design doc. Only two are written here; the other two are reserved for 002 and 003.
+
+| Key | TTL | Written by | In this feature? |
+|---|---|---|---|
+| `session:<64-hex>` | `SESSION_TTL_SECONDS` | session creation | YES — test-mint endpoint + OTP/OAuth later |
+| `user_sessions:<user_id>` | matches above | session creation | YES |
+| `otp:<email_hash>` | 600 | OTP request | NO — 002 |
+| `otp_rate:<email_hash>:*` | 60 / 3600 | OTP request | NO — 002 |
+| `oauth_state:<state>` | 600 | `/google/start` | NO — 003 |
+
+## `AuthContext` shape
+
+```python
+# backend/app/auth/schemas.py
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class AuthContext:
+    user_id: int
+    email: str
+    roles: tuple[str, ...]
+    session_id: str
+```
+
+Frozen + slotted → cheap, hashable, explicitly immutable. Roles is a tuple (not a list) so the context can be cached safely across handlers if anyone ever wants to; for now it only lives on `request.state`.
+
+## Test-only session-mint endpoint
+
+The endpoint's job is to let `test_auth_001.md` exercise the middleware, the `/auth/me` + `/auth/logout` pair, `require_roles`, and `ADMIN_EMAILS` bootstrap before OTP verify (`feat_auth_002`) becomes the real path.
+
+Shape:
+
+```python
+# backend/app/auth/router.py — guarded registration
+if settings.env == "test":
+    test_router = APIRouter(prefix="/_test", tags=["_test"])
+
+    @test_router.post("/session", status_code=200)
+    async def mint_test_session(
+        body: TestSessionRequest,
+        response: Response,
+        session: AsyncSession = Depends(get_session),
+        redis: Redis = Depends(get_redis),
+    ) -> MeResponse:
+        user = await service.find_or_create_user_for_test(
+            session, email=body.email, display_name=body.display_name,
+            extra_roles=body.roles or [],
+        )
+        session_id = await sessions.create(user, redis=redis)
+        response.set_cookie(...)   # same helper as the real flows will use
+        return MeResponse(user_id=user.id, email=user.email,
+                          display_name=user.display_name,
+                          roles=[r.name for r in user.roles])
+```
+
+Gating happens in `app/main.py`:
+
+```python
+if resolved.env == "test":
+    from app.auth.router import test_router
+    app.include_router(test_router, prefix="/api/v1")
+```
+
+Three consequences:
+- In `dev` and `prod` builds the symbol is imported only when `env == "test"`, so production images never register the route.
+- When Vulcan ships `feat_auth_002`, the file-level delete is three lines plus one import removal.
+- The `env_gating` test in `test_auth_test_mint_gating.py` hits the endpoint under both `env=dev` and `env=test` by rebuilding the app via `create_app(Settings(env=...))`.
+
+## Settings additions
+
+```python
+# backend/app/settings.py (additions)
+
+class Settings(BaseSettings):
+    # ... existing fields ...
+
+    # Auth (feat_auth_001)
+    session_cookie_name: str = "session"
+    session_ttl_seconds: int = 86400
+    session_cookie_secure: bool = False
+    admin_emails: str = ""   # raw comma-separated; parse via property
+
+    @property
+    def admin_emails_set(self) -> frozenset[str]:
+        return frozenset(
+            e.strip().lower()
+            for e in self.admin_emails.split(",")
+            if e.strip()
+        )
+```
+
+Raw string field + computed `frozenset` property mirrors how pydantic-settings prefers env-fed comma-lists (no custom validator, no JSON parsing surprise). Empty `ADMIN_EMAILS` → empty set → `grant_admin_if_listed` always returns `False`.
+
+## `infra/.env.example` addition
+
+Append, preserving the existing file's tone and section headings:
+
+```ini
+# ---- Auth (feat_auth_001) -----------------------------------------------
+# Session cookie and role-bootstrap controls for the auth foundation.
+SESSION_COOKIE_NAME=session
+SESSION_TTL_SECONDS=86400
+SESSION_COOKIE_SECURE=false        # flip to true in staging/prod
+ADMIN_EMAILS=                      # comma-separated; empty = no bootstrap admin
+```
+
+The 002 and 003 env blocks from §11 of the design doc are **not** added here. They land with their own features.
+
+## Deviations from the design doc
+
+The design doc is authoritative. The deviations below are small enough to surface in the spec rather than re-opening the doc.
+
+1. **Redis volume name.** §12 of the design doc names `redis-data` as the volume; the existing `infra/docker-compose.yml` already declares `redisdata` (no hyphen) as a top-level volume and it is populated on existing developer machines. Renaming would require a manual `docker volume rm`. We keep `redisdata`. The durability change (`--appendfsync everysec` added to the existing `--appendonly yes`) stands. If the human prefers the design-doc name, we rename in this PR and flag the disposable-local-data consequence.
+2. **`models.py` file scope.** §5.1 of the design doc lists a flat `app/auth/{models.py, schemas.py, ...}`. That matches the package layout we are shipping. No deviation — called out only because `feat_backend_002` uses per-domain folders for business resources (`app/items/`); `app/auth/` is the second such folder, consistent with the rule, not exception to it.
+
+## Edge cases and risks
+
+- **`citext` extension permissions.** `CREATE EXTENSION citext` needs superuser (or a role with the `CREATE` privilege on the database). The dev-compose Postgres user is `postgres` (superuser) so local `alembic upgrade head` works. Production deploys are the operator's problem, documented later. Migration uses `CREATE EXTENSION IF NOT EXISTS citext` to stay idempotent.
+- **Stale roles in an active session.** Covered by `revoke_sessions_for_user` — by design. The session payload is a cache; the rule is "revoke, not update." See §7.6 of the design doc.
+- **Cookie-clear on malformed payload.** A corrupted Redis value (human-edit, partial write, Redis bug) must not hang the request. `SessionMiddleware` catches the JSON-decode error, logs `auth.session.expired_cookie_cleared reason=malformed_payload`, clears the cookie, sets `request.state.auth = None`, and continues.
+- **Cookie signed vs unsigned.** Opaque session IDs are unguessable (256 bits from `secrets.token_hex(32)`). No HMAC on the cookie value — unnecessary when the cookie value is a random ID and the lookup-side is the check. Per §2 of the design doc.
+- **`SameSite` and local dev.** `samesite="lax"` with `secure=False` works on `http://localhost`. Browsers do not require Secure on localhost. Staging/prod override: `SESSION_COOKIE_SECURE=true` + HTTPS.
+- **Test-only mint left in a non-test build.** Guarded both at import time (`if env == "test"`) and at mount time (`if env == "test"`). A deployment that accidentally shipped `ENV=test` would expose the route — but that same deployment would also have wrong log levels and test-mode behavior throughout. Not a unique risk of the mint endpoint. `feat_auth_002` removes it entirely anyway.
+- **Session-list-size unboundedness.** `user_sessions:<uid>` is a Redis `SET`. A pathological user who logs in from many devices accumulates entries. With a 1-day TTL on every session and the reverse-index key, the set bounds itself at "however many logins in the last 24h" — realistic bound. No cleanup job needed.
+- **Pre-existing `RequestIDMiddleware` and structlog contextvars.** `SessionMiddleware` binds nothing into contextvars in this feature (no `session_id` in every log line), because doing so would leak session IDs (raw) or require a hashing hook. Logs that want the session principal emit `session_id_hash=...` explicitly per §10 of the design doc. 001 does not introduce new log events beyond the expired-cookie-clear one; 002 and 003 introduce the rest.
+- **`/auth/logout` with no session.** If the middleware produced `request.state.auth = None`, `current_user` raises 401 before the handler runs. Callers who want "clear client state even if server state is gone" use `response.delete_cookie` client-side. No change to server semantics.
+- **Pytest async-session fixture.** Existing `conftest.py` already provides an `AsyncClient` against `create_app`. New tests add a fixture that overrides `Settings(env="test")` and tears down the session store between tests (`FLUSHDB` on a test-only Redis DB index, same pattern as the existing tests).
+- **Alembic downgrade leaves `CITEXT` installed if shared.** The migration's `downgrade()` drops the extension; if another migration in the future also needs `citext`, that migration must re-create it (or declare a no-op for already-installed case via `IF NOT EXISTS`). Documented inline in the migration file.
+
+## Security considerations
+
+Full posture table lives at §8 of the design doc. For this feature specifically:
+
+- **Session ID entropy:** `secrets.token_hex(32)` → 256 bits. Brute force infeasible.
+- **Cookie flags:** `HttpOnly=True`, `SameSite=Lax`, `Secure` controlled by env. XSS cannot read the cookie; CSRF on `/auth/logout` is blunted by `SameSite=Lax` (lax lets top-level GETs ride but blocks cross-site POSTs).
+- **No per-request DB read** means a compromised Redis could silently issue tokens; the mitigation is operator-side Redis isolation (no public exposure, TLS in prod). `infra/docker-compose.yml` leaves Redis on the internal `appnet` only — no host port publish.
+- **Test-only mint endpoint:** `env == "test"` guard. Can be invoked only in the test container. If someone exports `ENV=test` in a production shell, that is the same footgun as setting `LOG_LEVEL=DEBUG`. Rely on env-var hygiene; do not add a second guard.
+- **`ADMIN_EMAILS` bootstrap**: lives in the env, not in the repo. Granted once on user creation. Demotion requires both env edit **and** a DB write. Documented in the deployment guide when `feat_auth_003` ships.
+- **Session hashing in logs:** the one log event this feature emits (`auth.session.expired_cookie_cleared`) uses `session_id_hash=sha256(id)[:16]` per §10. Never logs the raw cookie value.
+
+## Open questions
+
+None blocking. Decisions already closed in brainstorming and re-anchored by this spec:
+
+- Atlas-only PR for this feature; Vulcan in a later session.
+- Test-only mint endpoint lives in 001, removed in 002 — human approved during brainstorming.
+- Deployment docs deferred to the feature that introduces the external dependency — confirmed.
+- `conventions.md` §1 edit folds into this PR rather than a dedicated `feat_conventions_NNN` — human approved during brainstorming.
+- `redisdata` volume name preserved (spec-local deviation from the design doc; see "Deviations" above).

--- a/docs/specs/feat_auth_001/feat_auth_001.md
+++ b/docs/specs/feat_auth_001/feat_auth_001.md
@@ -1,0 +1,112 @@
+# Feature: Auth foundation — users, roles, identities, sessions
+
+## Problem Statement
+
+The backend today has no concept of "who is calling." `feat_backend_001` shipped a runnable FastAPI scaffold; `feat_backend_002` tightened its logging and layout discipline. Neither of them introduces a user, a role, or a session. Every subsequent feature — an admin-only endpoint, a per-user record, a rate-limited action — needs "who is this request?" to be a one-line dependency, not a design question.
+
+The four-feature auth sequence is specified in full at `docs/design/auth-login-and-roles.md` (approved in brainstorming). This feature, `feat_auth_001`, is the **foundation**: the data model, the session plumbing, the authorization primitives, and the `GET /auth/me` + `POST /auth/logout` pair. It ships **no login paths of its own**. OTP login lands in `feat_auth_002`; Google OAuth lands in `feat_auth_003`; the UI lands in `feat_frontend_002`. This feature's sole job is to put the rails down so the next three features can be short.
+
+Because real login flows do not land until `feat_auth_002`, this feature also ships a **temporary test-only endpoint** (`POST /api/v1/_test/session`) guarded to mount only when `settings.env == "test"`. It exists so the middleware, dependencies, and `/auth/me` + `/auth/logout` pair can be exercised end-to-end now, and is removed by `feat_auth_002` once OTP verify is the real session minter.
+
+The full design rationale — session-vs-JWT trade-off, role model shape, identity auto-linking rule, security posture — is in §§1, 2, 3, 4, 6, 11, 14, 15 of the design doc. This spec does **not** restate that reasoning; it pulls only the parts that land in this feature.
+
+## Requirements
+
+### Functional
+
+1. **Domain addition in `conventions.md` §1.** A new row `auth` — "Identity, authentication flows (OAuth + OTP), sessions, roles, authorization primitives." — is added to the approved-domains table. Folded in here per §14 of the design doc, not carved out as a separate `feat_conventions_NNN`. The human confirmed this folding during brainstorming.
+2. **Design doc committed.** `docs/design/auth-login-and-roles.md` is currently untracked on `main`; it rides in on this spec PR so that all four auth planning cycles reference a committed file. No edits to its content — verbatim check-in.
+3. **Postgres schema** — one new Alembic migration `backend/alembic/versions/0002_create_auth.py`. Creates the `citext` extension and the four tables `users`, `roles`, `user_roles`, `auth_identities` per §6.1 of the design doc. Seeds two rows into `roles` — `admin` and `user`. Uses the alembic naming convention that `feat_backend_002` wired onto `Base.metadata`.
+4. **SQLAlchemy models** under `backend/app/auth/models.py` — `User`, `Role`, `UserRole`, `AuthIdentity`. Relationships match the schema. `User` exposes `.roles` as a collection loaded via the association table.
+5. **Redis session store** — `backend/app/auth/sessions.py`. Exposes:
+   - `create(user, *, redis) -> session_id` — pipelined `SET session:<id>` + `SADD user_sessions:<user_id>` + `EXPIRE user_sessions:<user_id>`, all with TTL `SESSION_TTL_SECONDS`.
+   - `get(session_id, *, redis) -> AuthContext | None` — single `GET`, JSON-parsed.
+   - `delete(session_id, user_id, *, redis) -> None` — `DEL session:<id>` + `SREM user_sessions:<user_id>`.
+   - `revoke_all_for_user(user_id, *, redis) -> None` — §7.6 of the design doc.
+   The `oauth_state:<state>` key is designed for single-use via `GETDEL` (per §6.2); the write side lands in `feat_auth_003`, but the helper's shape is fixed here.
+6. **Session middleware** — `backend/app/middleware.py` gains a `SessionMiddleware` class. Installed in `app/main.py` between `RequestIDMiddleware` and the route. Reads the cookie, does one Redis `GET`, populates `request.state.auth: AuthContext | None`. **No DB hit per request.** On a valid cookie whose session has expired, clears the cookie.
+7. **FastAPI dependencies** — `backend/app/auth/dependencies.py`:
+   - `current_user(request) -> AuthContext` — raises 401 `not_authenticated` when `request.state.auth` is `None`.
+   - `require_authenticated` — alias of `current_user` for readability at call sites that do not need the payload.
+   - `require_roles(*names: str)` — factory that returns a dependency; OR semantics across names; raises 403 `forbidden` on miss.
+8. **Endpoints (v1)**:
+   - `GET /api/v1/auth/me` — authenticated; returns `{ "user_id", "email", "display_name", "roles" }`. Payload shape exactly matches §7.3 of the design doc.
+   - `POST /api/v1/auth/logout` — authenticated; deletes the session in Redis, clears the cookie, returns `204 No Content`.
+9. **Bootstrap hook** — `backend/app/auth/bootstrap.py`. Parses `ADMIN_EMAILS` once at startup (lower-cased set). Exposes `grant_admin_if_listed(user, db_session) -> bool`. The hook is wired into the user-creation path, but the user-creation path itself lives in 002 and 003. In this feature, the hook is exercised by the `_test/session` endpoint (which creates a user on first call) so `test_auth_001.md` can cover it.
+10. **Service helper** — `revoke_sessions_for_user(user_id)` exported from `backend/app/auth/service.py`. Thin wrapper over `sessions.revoke_all_for_user`.
+11. **Test-only session-mint endpoint** — `POST /api/v1/_test/session` mounts **only when `settings.env == "test"`**. Body: `{ "email": "...", "display_name": "...", "roles": ["admin"]? }`. Does find-or-create user, applies `ADMIN_EMAILS` bootstrap, optionally grants extra roles if passed, creates a session, sets the cookie, returns `200`. Removed by `feat_auth_002`.
+12. **New environment variables** (added to `infra/.env.example` and to `app/settings.py`):
+    - `SESSION_COOKIE_NAME=session`
+    - `SESSION_TTL_SECONDS=86400`
+    - `SESSION_COOKIE_SECURE=false`
+    - `ADMIN_EMAILS=` (empty; comma-separated list, case-insensitive)
+13. **Redis durability** — `infra/docker-compose.yml` `redis.command` extended from `--appendonly yes` to `--appendonly yes --appendfsync everysec`. No volume rename. (§12 of the design doc uses `redis-data`; we preserve the existing `redisdata` name — see "Deviations from the design doc" in `design_auth_001.md`.)
+14. **Tracking** — `docs/tracking/features.md` gets a new row for `feat_auth_001`. `docs/specs/README.md` feature roster gains a row for `feat_auth_001`.
+
+### Non-functional
+
+15. **No new top-level dependencies.** Session JSON uses stdlib `json`. Session IDs use stdlib `secrets`. `citext` is a Postgres extension, not a Python dependency.
+16. **No DB hit per request.** Role checks read from the session payload — `AuthContext.roles` — exactly as §2 of the design doc promises.
+17. **No frontend changes.** The login UI is `feat_frontend_002`.
+18. **No OTP code, no Google OAuth code, no `EmailSender` abstraction.** Those belong to 002 and 003.
+19. **No deployment docs** (`docs/deployment/*`). Those land with the features that introduce the external dependencies.
+20. **No linting, formatting, or pre-commit tooling** (per `conventions.md` §11).
+21. **Backward-compatible with existing routes.** `GET /api/v1/hello`, `/healthz`, `/readyz` are untouched. No existing middleware ordering changes except the insertion of `SessionMiddleware` per §5.4 of the design doc.
+
+## User Stories
+
+- As **Vulcan** (builder of `feat_auth_002` and `feat_auth_003`), I want the `users` / `roles` / `auth_identities` tables, the Redis session helpers, the bootstrap hook, and the `current_user` dependency to already exist, so the OTP and OAuth features can focus on their provider-specific code and not reinvent session plumbing.
+- As a **human operator bringing this repo up locally**, I want `make up && make test` to keep passing after this feature lands, with the new auth tables migrated and the session cookie round-trip verified by the test-only mint endpoint. I do not want to have to configure Google or Resend to see green tests.
+- As a **reader of the four-feature auth sequence**, I want one committed design doc (`docs/design/auth-login-and-roles.md`) that all four features' specs reference, so the architectural decisions live in one place and the per-feature specs stay focused on their slice.
+- As a **security-minded reviewer**, I want role data to ride in the session payload (no per-request DB hit), role-change revocation to be a single helper call, and `ADMIN_EMAILS` to be documented as bootstrap-only (not a live sync) so the privilege model is legible without reading the code.
+
+## Scope
+
+### In Scope
+
+- `docs/design/auth-login-and-roles.md` — verbatim commit of the already-written brainstorming artifact.
+- `conventions.md` §1 — one-row addition for the `auth` domain.
+- `backend/alembic/versions/0002_create_auth.py` — single migration: `citext`, four tables, role seeds.
+- `backend/app/auth/__init__.py`, `models.py`, `schemas.py`, `sessions.py`, `dependencies.py`, `bootstrap.py`, `service.py`, `router.py`.
+- `backend/app/middleware.py` — `SessionMiddleware` class added; existing classes untouched.
+- `backend/app/main.py` — install `SessionMiddleware`; mount auth router at `/api/v1/auth`; mount the test-only router at `/api/v1/_test` when `env == "test"`.
+- `backend/app/api/v1/__init__.py` — include the new `auth` router.
+- `backend/app/settings.py` — four new fields (§11 of the design doc).
+- `infra/.env.example` — four new variables with defaults.
+- `infra/docker-compose.yml` — redis `command` adds `--appendfsync everysec`.
+- `backend/tests/` — new tests per `test_auth_001.md`.
+- `docs/specs/feat_auth_001/{feat,design,test}_auth_001.md` — the three spec files themselves.
+- `docs/specs/README.md`, `docs/tracking/features.md` — tracking rows.
+
+### Out of Scope
+
+- `POST /auth/otp/request`, `POST /auth/otp/verify`, `EmailSender`, `ConsoleEmailSender`, `ResendEmailSender`, `backend/app/auth/otp.py`, `backend/app/auth/email/` — all belong to `feat_auth_002`.
+- `GET /auth/google/start`, `GET /auth/google/callback`, Google JWKS verification, PKCE helpers, `backend/app/auth/google.py` — all belong to `feat_auth_003`.
+- Any frontend work: login page, `AuthContext`, protected-route wrapper — `feat_frontend_002`.
+- `docs/deployment/google-oauth-setup.md` (→ 003), `docs/deployment/email-otp-setup.md` (→ 002), `docs/deployment/README.md` (→ whichever of 002/003 ships first).
+- User profile editing, account-linking UI, admin dashboard, second OAuth provider, MFA, password reset, account self-deletion (non-goals per §15 of the design doc).
+- Live sync of `ADMIN_EMAILS` — documented explicitly as bootstrap-only.
+- Per-request DB hit / stale-role correction beyond `revoke_sessions_for_user`.
+
+## Acceptance Criteria
+
+- [ ] `conventions.md` §1 domains table contains a row `auth | Identity, authentication flows (OAuth + OTP), sessions, roles, authorization primitives.`
+- [ ] `docs/design/auth-login-and-roles.md` is committed under this PR with content byte-identical to the existing untracked working-tree file.
+- [ ] `backend/alembic/versions/0002_create_auth.py` creates the four tables with columns, types, nullability, FKs, cascade behavior, and the `(provider, provider_user_id)` unique constraint exactly as §6.1 specifies. The migration installs the `citext` extension and seeds two role rows (`admin`, `user`).
+- [ ] `alembic upgrade head` against a clean Postgres creates the schema; `alembic downgrade base` removes the four tables and the extension cleanly.
+- [ ] `backend/app/auth/models.py` exposes `User`, `Role`, `UserRole`, `AuthIdentity`; `User.roles` is a SQLAlchemy relationship returning `list[Role]`.
+- [ ] `backend/app/auth/sessions.py` exposes `create`, `get`, `delete`, `revoke_all_for_user` with the contract in requirement 5.
+- [ ] `SessionMiddleware` populates `request.state.auth` without any DB call. A log of the DB query log during a `GET /api/v1/auth/me` call shows zero queries.
+- [ ] `GET /api/v1/auth/me` with a valid session cookie returns HTTP 200 and the payload shape of §7.3.
+- [ ] `GET /api/v1/auth/me` without a cookie returns HTTP 401 with body `{"detail": "not_authenticated"}`.
+- [ ] `POST /api/v1/auth/logout` with a valid session cookie returns HTTP 204, `DEL`s the session key in Redis, removes the session ID from the `user_sessions:<uid>` set, and sets `Set-Cookie: <name>=; Max-Age=0`.
+- [ ] `require_roles("admin")` on a session whose payload does not contain `"admin"` in `roles` returns HTTP 403 `{"detail": "forbidden"}` without touching the DB.
+- [ ] `require_roles("admin", "user")` passes when **either** role is present (OR semantics).
+- [ ] `ADMIN_EMAILS=alice@x.com` and a first-time mint for `alice@x.com` grants both `user` and `admin` roles. With `ADMIN_EMAILS=""` (empty), only `user` is granted.
+- [ ] `revoke_sessions_for_user(42)` wipes every `session:<id>` key whose ID was present in `user_sessions:42`, then wipes `user_sessions:42` itself. A subsequent `GET /api/v1/auth/me` with a previously-valid cookie returns 401.
+- [ ] `POST /api/v1/_test/session` is **not** registered when `env == "dev"` (HTTP 404). It **is** registered when `env == "test"`.
+- [ ] `infra/.env.example` contains the four new lines under an `# ---- Auth (feat_auth_001) ----` heading with the defaults specified in requirement 12.
+- [ ] `infra/docker-compose.yml` `redis.command` is `redis-server --appendonly yes --appendfsync everysec`. `redisdata` volume name is unchanged.
+- [ ] `docs/tracking/features.md` contains a row for `feat_auth_001` whose status advances `Planned → In Spec` (this PR) → `Ready` (on merge). `docs/specs/README.md` roster table contains the same row.
+- [ ] `uv run pytest` from `backend/` with `ENV=test` passes, including every new test file named in `test_auth_001.md`.
+- [ ] `test.sh` continues to pass.

--- a/docs/specs/feat_auth_001/test_auth_001.md
+++ b/docs/specs/feat_auth_001/test_auth_001.md
@@ -1,0 +1,177 @@
+# Test: Auth foundation — users, roles, identities, sessions
+
+## Scope
+
+This feature lands schema, session plumbing, and authorization primitives. It introduces **no real login path** — the only way to mint a session in this feature is `POST /api/v1/_test/session`, which is gated to `env == "test"`. Tests therefore:
+
+1. Unit-test every helper in isolation (sessions, dependencies, bootstrap).
+2. Integration-test the middleware + `/auth/me` + `/auth/logout` pair end-to-end using the test-only mint.
+3. Verify the test-only mint is absent when `env != "test"`.
+4. Verify the Alembic migration stands up a clean schema and tears it down cleanly.
+
+Coverage of the OTP flow (§9.1/§9.2 of the design doc, OTP rows) and the Google OAuth flow (Google rows of §9.2) is **out of scope** — those land with `feat_auth_002` and `feat_auth_003`. Only tests that exercise this feature's actual endpoints and dependencies are listed here.
+
+## New test files
+
+### `backend/tests/test_auth_sessions.py`
+
+Unit-tests `backend/app/auth/sessions.py` against a real Redis (existing test fixture provides one; tests skip with a clear reason when Redis is unreachable).
+
+| # | Case | Arrangement | Assertion |
+|---|---|---|---|
+| 1 | `create` round-trip | Mint a session for `user(id=42, email=a@x.com, roles=[user])`. | Returned `session_id` is 64 hex chars. `GET session:<id>` exists in Redis with the same payload. `user_sessions:42` contains `session_id`. Both keys TTL > 86300 and ≤ 86400. |
+| 2 | `get` returns `AuthContext` | Given a session minted by case 1. | `sessions.get(session_id, redis=...)` returns an `AuthContext(user_id=42, email='a@x.com', roles=('user',), session_id=session_id)`. |
+| 3 | `get` missing key | No mint; random session_id. | Returns `None`. |
+| 4 | `get` malformed payload | Manually write a non-JSON string to `session:<id>`. | Returns `None`. No exception propagates. |
+| 5 | `delete` wipes both keys | Mint, then `delete`. | `GET session:<id>` returns `None`. Session id is no longer in `user_sessions:42`. |
+| 6 | `revoke_all_for_user` | Mint two sessions for the same user_id. | After call, both `session:*` keys are gone. `user_sessions:42` is gone. |
+| 7 | `revoke_all_for_user` when reverse-index is empty | Never-logged-in user id. | Call completes without error; no keys touched. |
+| 8 | TTL is exactly `SESSION_TTL_SECONDS` | Mint with settings.session_ttl_seconds=10. | `TTL session:<id>` ∈ [9, 10]. `TTL user_sessions:<uid>` ∈ [9, 10]. |
+
+### `backend/tests/test_auth_middleware.py`
+
+Integration tests against `create_app(Settings(env="test"))` with `SessionMiddleware` installed. Uses `httpx.AsyncClient`.
+
+| # | Case | Arrangement | Assertion |
+|---|---|---|---|
+| 1 | No cookie, public endpoint | `GET /healthz` with no cookie. | HTTP 200. No `Set-Cookie` emitted by the middleware. `request.state.auth` is `None` (inspected via a test-only introspection route that returns the string `None` or the type name — see "Introspection helper" below). |
+| 2 | Valid cookie populates context | Mint a session via `/api/v1/_test/session` then `GET` a route that echoes `request.state.auth.roles`. | HTTP 200. Body contains the minted user's `user_id`, `email`, and `roles`. No DB queries recorded during the `/auth/me`-equivalent call (see "Zero-DB-hit assertion" below). |
+| 3 | Expired session clears cookie | Mint; then manually `DEL session:<id>` in Redis. Call `GET /api/v1/auth/me`. | HTTP 401. Response `Set-Cookie` header has `Max-Age=0` for `SESSION_COOKIE_NAME`. Log event `auth.session.expired_cookie_cleared reason=missing_key` emitted. |
+| 4 | Malformed payload clears cookie | Mint; manually overwrite `session:<id>` with the bytes `not json`. Call `GET /api/v1/auth/me`. | HTTP 401. `Set-Cookie` clears the cookie. Log event `auth.session.expired_cookie_cleared reason=malformed_payload` emitted. |
+| 5 | Cookie with impossible characters | Send `Cookie: session=<60 hex>` (wrong length). | HTTP 401. Cookie cleared. Log event `auth.session.expired_cookie_cleared reason=malformed_cookie` emitted. |
+| 6 | Middleware runs after RequestID | Inspect log line from case 3; confirm it carries `request_id`. | `request_id` present in the JSON — proves `RequestIDMiddleware` is still outermost. |
+
+**Introspection helper:** tests that need to verify `request.state.auth` contents without shipping a production "inspect my session" route use `GET /api/v1/auth/me` (which exists in this feature). The middleware behavior is fully observable through the public endpoint; no debug route is added.
+
+**Zero-DB-hit assertion:** wrap the test's `AsyncClient` call in a context manager that records SQLAlchemy query events on the test engine. `events.listen(engine.sync_engine, "before_cursor_execute", ...)` collects fired statements. `/auth/me` must show zero. `POST /auth/logout` is also zero.
+
+### `backend/tests/test_auth_dependencies.py`
+
+Unit tests for `current_user`, `require_authenticated`, `require_roles`. Uses FastAPI's `dependency_overrides` to inject a fabricated `request.state.auth` via a stub middleware-equivalent.
+
+| # | Case | `request.state.auth` | Dependency | Expected |
+|---|---|---|---|---|
+| 1 | Authenticated | `AuthContext(user_id=1, email='a@x', roles=('user',), session_id='...')` | `current_user` | returns the context |
+| 2 | Unauthenticated | `None` | `current_user` | HTTPException(401, `not_authenticated`) |
+| 3 | `require_authenticated` is an alias | `None` | `require_authenticated` | HTTPException(401, `not_authenticated`) |
+| 4 | Single required role — match | roles=`('user',)` | `require_roles("user")` | returns the context |
+| 5 | Single required role — miss | roles=`('user',)` | `require_roles("admin")` | HTTPException(403, `forbidden`) |
+| 6 | Multiple roles — OR semantics, first matches | roles=`('admin',)` | `require_roles("admin", "user")` | returns |
+| 7 | Multiple roles — OR semantics, second matches | roles=`('user',)` | `require_roles("admin", "user")` | returns |
+| 8 | Multiple roles — neither | roles=`('guest',)` | `require_roles("admin", "user")` | 403 `forbidden` |
+| 9 | `require_roles` with no cookie | `request.state.auth = None` | `require_roles("admin")` | 401 `not_authenticated` (not 403 — unauth precedes auth-z) |
+
+### `backend/tests/test_auth_bootstrap.py`
+
+Unit tests for `backend/app/auth/bootstrap.py`.
+
+| # | Case | `ADMIN_EMAILS` | User email | Expected |
+|---|---|---|---|---|
+| 1 | Empty list never grants | `""` | `alice@x.com` | `grant_admin_if_listed` returns `False`; user's role collection unchanged. |
+| 2 | Exact match grants | `"alice@x.com"` | `alice@x.com` | Returns `True`; user gains an `admin` role row. |
+| 3 | Case-insensitive match | `"ALICE@x.com"` | `alice@x.com` | Returns `True`; user gains `admin`. |
+| 4 | Whitespace-tolerant | `" alice@x.com , bob@x.com "` | `bob@x.com` | Returns `True`. |
+| 5 | Non-member | `"alice@x.com,bob@x.com"` | `carol@x.com` | Returns `False`. |
+| 6 | Settings cache reflects env | Set env var via monkeypatch, call `reset_settings_cache()`, re-read. | lookup reflects new value | Confirms no stale cache. |
+| 7 | Idempotent | Apply twice in sequence for a match. | `user.roles` contains exactly one `admin`, not two. |
+
+### `backend/tests/test_auth_me_logout.py`
+
+End-to-end tests against `create_app(Settings(env="test"))`. Exercises the full mint → `/me` → `/logout` → `/me` lifecycle via the test-only endpoint.
+
+| # | Flow | Steps | Assertion |
+|---|---|---|---|
+| 1 | Happy path | POST `/_test/session` `{email: a@x.com, display_name: Alice}` → carry cookie → GET `/auth/me` → POST `/auth/logout` → GET `/auth/me` | Mint: 200 + `Set-Cookie`. `/auth/me` (1): 200 with payload `{user_id, email: 'a@x.com', display_name: 'Alice', roles: ['user']}`. `/auth/logout`: 204 + cookie cleared. `/auth/me` (2): 401. |
+| 2 | ADMIN_EMAILS bootstrap | Settings with `ADMIN_EMAILS="alice@x.com"`. POST `/_test/session` `{email: alice@x.com}`. GET `/auth/me`. | Response `roles` contains both `user` and `admin`. |
+| 3 | Non-bootstrap user | Same settings, mint `bob@x.com`. | Roles is exactly `["user"]`. |
+| 4 | Extra roles parameter | POST `/_test/session` `{email: a@x.com, roles: ["admin"]}`. GET `/auth/me`. | Roles contains `admin` **and** `user` (user always granted as the default). |
+| 5 | Existing user — idempotent mint | Mint twice with the same email and no extra roles. | Both calls succeed. DB `users` has exactly one row for that email. `auth_identities` has zero rows (the test-mint skips identity creation — documented behavior, since identities are created only by real login paths in 002/003). |
+| 6 | `revoke_sessions_for_user` end-to-end | Mint session A for user. Mint session B for the same user. Call `service.revoke_sessions_for_user(user.id, redis=...)`. GET `/auth/me` with cookie A → 401. GET `/auth/me` with cookie B → 401. | Both sessions dead. `user_sessions:<uid>` is gone. |
+| 7 | No cookie → `/auth/me` | GET `/auth/me` with no cookie. | 401 `not_authenticated`. |
+| 8 | Logout without session | GET `/auth/me` with no cookie → 401. Then POST `/auth/logout` with no cookie. | 401 `not_authenticated`. No Redis delete was attempted (verified by a Redis-command recorder). |
+| 9 | Cookie attributes | Mint; inspect the `Set-Cookie` header. | Contains `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age=86400`. Does **not** contain `Secure` when `SESSION_COOKIE_SECURE=false`. Does contain `Secure` when `SESSION_COOKIE_SECURE=true`. |
+
+### `backend/tests/test_auth_test_mint_gating.py`
+
+Verifies the test-only mint endpoint is present only under `env == "test"`.
+
+| # | Case | Build with | Expected |
+|---|---|---|---|
+| 1 | Not mounted in dev | `create_app(Settings(env="dev"))` | POST `/api/v1/_test/session` returns 404. |
+| 2 | Not mounted in prod | `create_app(Settings(env="prod"))` | POST `/api/v1/_test/session` returns 404. |
+| 3 | Mounted in test | `create_app(Settings(env="test"))` | POST `/api/v1/_test/session` with a valid body returns 200. |
+| 4 | Real `/auth/me` always mounted | Build under each of dev/test/prod. | `GET /api/v1/auth/me` with no cookie returns 401 in all three — endpoint is registered regardless of env. |
+
+### Alembic migration test — `backend/tests/test_migration_0002_auth.py`
+
+Verifies the new migration stands up and tears down cleanly against a real Postgres. Existing tests already depend on Alembic at session scope; this adds one focused test.
+
+| # | Case | Steps | Assertion |
+|---|---|---|---|
+| 1 | Clean upgrade | `alembic downgrade base`; `alembic upgrade head`. | `users`, `roles`, `user_roles`, `auth_identities` all exist. `roles` contains exactly two rows, `admin` and `user`. `citext` extension is present. |
+| 2 | Clean downgrade | After case 1, `alembic downgrade -1`. | All four tables absent. `citext` extension absent (or still present if another migration needed it — 001 is the first, so absent). |
+| 3 | Email case-insensitivity | After upgrade, `INSERT users(email='Alice@X.com'); INSERT users(email='alice@x.com')`. | Second insert fails with a `citext` uniqueness violation. |
+| 4 | `ON DELETE CASCADE` on user deletion | Insert user, `user_roles` row, `auth_identities` row. DELETE user. | `user_roles` row and `auth_identities` row are both gone. |
+| 5 | `ON DELETE RESTRICT` on role deletion | Attempt to DELETE the `admin` role while it is referenced. | Fails with an FK violation. |
+| 6 | Auto-generated names use convention | Inspect pg_catalog for constraint names. | `pk_users`, `uq_users_email`, `pk_roles`, `uq_roles_name`, `fk_user_roles_user_id_users`, `fk_user_roles_role_id_roles`, `pk_user_roles`, `pk_auth_identities`, `fk_auth_identities_user_id_users`, `uq_auth_identities_provider` — i.e., the names the naming convention installed in `feat_backend_002` should produce. |
+
+## External REST tests — `test.sh` extensions
+
+The existing external suite (`feat_testing_001`) hits the compose-brought-up backend. Add one flow:
+
+| # | Case | Steps | Assertion |
+|---|---|---|---|
+| 1 | `/auth/me` requires a cookie (prod build, no mint) | `curl -sS -o /dev/null -w '%{http_code}' http://localhost:8000/api/v1/auth/me` | 401. |
+| 2 | `/auth/logout` without a cookie | `curl -sS -o /dev/null -w '%{http_code}' -X POST http://localhost:8000/api/v1/auth/logout` | 401. |
+
+Mint-bearing flows belong in the pytest integration suite (where the test-only endpoint exists). `test.sh` runs against the default dev-compose build (ENV=dev) where the mint endpoint is absent by design.
+
+## Boundary conditions
+
+| Condition | Expected behavior |
+|---|---|
+| `SESSION_TTL_SECONDS=1` | Mint + immediate `/auth/me` succeed. `sleep 2` + `/auth/me` returns 401 and clears cookie. |
+| `ADMIN_EMAILS=alice@x.com,,,` (empty fragments) | Parses to `{'alice@x.com'}` — empty fragments skipped. |
+| `ADMIN_EMAILS` with 1000 entries | Parses once at startup into a frozenset; lookup is O(1). No perf test, but no linear scan. |
+| `user_sessions:<uid>` set grows to 1000 entries | `revoke_all_for_user` still wipes all of them in one `DELETE *keys` call. |
+| `email` column with very long address (300 chars) | `citext` column has no length cap; insert succeeds. `users.email` is `CITEXT NOT NULL UNIQUE`, not `VARCHAR`. |
+| `provider_user_id` at max length (255 chars) | Accepted. 256 chars rejected by the column definition. |
+| `role.name` max length (64 chars) | Accepted. 65 chars rejected. |
+| Two simultaneous mint calls for a new user | Both succeed without duplicating the `users` row. The `find_or_create_user_for_test` helper uses an `INSERT ... ON CONFLICT (email) DO NOTHING RETURNING` pattern, then re-reads on conflict. |
+
+## Security considerations
+
+The design doc §8 table is the full posture. This test spec verifies the slice of it that 001 actually implements.
+
+- **Cookie flags verified in response headers** — case 9 of `test_auth_me_logout.py`.
+- **Session opaqueness** — `test_auth_sessions.py` case 1 asserts `len(session_id) == 64` and all hex. A weaker ID would fail that check.
+- **Unauth precedes auth-z in dependency ordering** — `test_auth_dependencies.py` case 9. If `require_roles` were to 403 a request with no session (instead of 401), a scanner would learn that the route exists as a protected route.
+- **`ADMIN_EMAILS` empty is a no-op** — `test_auth_bootstrap.py` case 1. Default `.env.example` ships `ADMIN_EMAILS=` so a fresh clone grants admin to nobody.
+- **Test-only mint absent outside `env=test`** — `test_auth_test_mint_gating.py`. Defense-in-depth against a misconfigured deploy.
+- **Malformed Redis payload does not leak** — `test_auth_middleware.py` case 4. The JSON decode exception is caught; the cookie is cleared; the request proceeds as unauthenticated. A corrupted Redis value is treated the same as a missing key.
+- **Email uniqueness is case-insensitive** — `test_migration_0002_auth.py` case 3. Without `citext`, `Alice@X.com` and `alice@x.com` could create duplicate accounts that look distinct in the identity table — defeating the auto-link rule 002 and 003 depend on.
+- **Session logs never contain raw IDs** — verified by the middleware tests (cases 3, 4, 5): the log event `auth.session.expired_cookie_cleared` carries `session_id_hash` not `session_id`.
+
+## What is intentionally not tested
+
+- **Real OTP or Google flow.** No code for it exists in 001. Tests for those land in `test_auth_002.md` and `test_auth_003.md`.
+- **Frontend AuthContext or protected-route behavior.** Ships in `feat_frontend_002`.
+- **`docs/design/auth-login-and-roles.md` content.** It is a committed design artifact; proofreading is part of PR review.
+- **`conventions.md` §1 table format.** Covered transitively: if the table is malformed, the next spec session (Atlas reading conventions.md) will fail to parse the domains list, which surfaces as a visible review issue on the next PR.
+- **Alembic `file_template` behavior.** Exercised the next time `alembic revision` is run; not a runtime code path.
+- **Settings property `admin_emails_set` as a stand-alone unit.** Covered transitively by `test_auth_bootstrap.py` cases 1–5; no separate test.
+
+## Regression surface
+
+| Regression | What fails |
+|---|---|
+| `SessionMiddleware` moves above `RequestIDMiddleware` | `test_auth_middleware.py` case 6 (no `request_id` in log) |
+| Session TTL not set or infinite | `test_auth_sessions.py` case 8 (TTL range check) |
+| `require_roles` swaps 401/403 precedence | `test_auth_dependencies.py` case 9 |
+| Bootstrap grants admin on every login (not just first) | `test_auth_bootstrap.py` case 7 (idempotent check) |
+| `/auth/logout` tries Redis DEL with no session | `test_auth_me_logout.py` case 8 (no Redis command recorded) |
+| Migration missing `ON DELETE CASCADE` | `test_migration_0002_auth.py` case 4 |
+| Migration missing `citext` | `test_migration_0002_auth.py` case 3 |
+| Test-mint endpoint leaks into prod | `test_auth_test_mint_gating.py` case 2 |
+| Cookie missing `HttpOnly` | `test_auth_me_logout.py` case 9 |
+| `revoke_sessions_for_user` misses reverse-index key | `test_auth_me_logout.py` case 6 (later mint accumulates stale IDs) |

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -8,3 +8,4 @@
 | feat_infra_001 | docker-compose stack + dockerfiles | Merged | #11 | #10 | #12 | - |
 | feat_testing_001 | external REST functional test suite | Merged | #14 | #13 | #15 | - |
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
+| feat_auth_001 | auth foundation: users, roles, identities, sessions | Specced | #20 | #19 | - | - |


### PR DESCRIPTION
## Specifications for `feat_auth_001`

Closes #19.

First of four features delivering password-less login (Google OAuth + email OTP) with roles. This PR ships **only the three spec files plus the design doc check-in and one conventions row** — no implementation. Vulcan picks it up on `build/feat_auth_001` once merged.

### What `feat_auth_001` builds (foundation only)
- Postgres schema: `users`, `roles`, `user_roles`, `auth_identities` — one migration (`0002_create_auth.py`), `citext` extension, role seeds.
- SQLAlchemy models under `backend/app/auth/models.py`.
- Redis-backed session store (`backend/app/auth/sessions.py`) + `SessionMiddleware` — 1-day TTL, reverse-index per user, no DB hit per request.
- Authorization primitives: `current_user`, `require_authenticated`, `require_roles(*names)` (OR semantics).
- `GET /api/v1/auth/me`, `POST /api/v1/auth/logout`.
- `ADMIN_EMAILS` bootstrap hook + `revoke_sessions_for_user` helper.
- Temp `POST /api/v1/_test/session` (mounted only when `env=test`) so the plumbing is testable before OTP/OAuth land; removed by `feat_auth_002`.
- Env vars: `SESSION_COOKIE_NAME`, `SESSION_TTL_SECONDS`, `SESSION_COOKIE_SECURE`, `ADMIN_EMAILS`.
- Redis AOF durability edit: `--appendonly yes --appendfsync everysec`.

### Folded-in changes (per brainstorming, not a separate PR)
- `conventions.md` §1: adds the `auth` domain row.
- `docs/design/auth-login-and-roles.md`: checks in the architectural source of truth (currently untracked on main) so all four auth features reference one committed file.
- `docs/tracking/features.md`, `docs/specs/README.md`: one new row each.

### Spec files
- Feature: `docs/specs/feat_auth_001/feat_auth_001.md`
- Design: `docs/specs/feat_auth_001/design_auth_001.md`
- Test: `docs/specs/feat_auth_001/test_auth_001.md`
- Cross-feature design: `docs/design/auth-login-and-roles.md`

### Explicitly out of scope
- OTP, `EmailSender`, Resend → `feat_auth_002`.
- Google OAuth, JWKS, PKCE → `feat_auth_003`.
- Login UI, `AuthContext`, protected-route wrapper → `feat_frontend_002`.
- Deployment docs (`docs/deployment/*.md`) → land with 002 / 003.

### Deviations flagged in `design_auth_001.md`
- `redisdata` volume name is preserved (design doc §12 says `redis-data`). Preserving avoids a local-data wipe; content and durability flags match the design. Rename on request.