### PR TITLE
build(feat_auth_001): auth foundation — users, roles, sessions, /me, /logout

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -19,6 +19,7 @@ from app.db import Base
 # alembic reads ``target_metadata``. Importing the domain ``models`` module
 # is a deliberate side-effect import: autogenerate diffs depend on it.
 import app.items.models  # noqa: F401
+import app.auth.models  # noqa: F401
 from app.settings import get_settings
 
 config = context.config

--- a/backend/alembic/versions/0002_create_auth.py
+++ b/backend/alembic/versions/0002_create_auth.py
@@ -1,0 +1,166 @@
+"""create auth tables (users, roles, user_roles, auth_identities) and citext
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-16
+
+Per ``docs/specs/feat_auth_001/design_auth_001.md`` and §6.1 of
+``docs/design/auth-login-and-roles.md``:
+
+- Installs the ``citext`` Postgres extension (idempotent).
+- Creates ``users``, ``roles``, ``user_roles``, ``auth_identities``.
+- Seeds two role rows, ``admin`` and ``user``.
+- Uses the naming convention wired onto ``Base.metadata`` in
+  ``feat_backend_002`` (``app/db.py``), so constraint names are
+  deterministic (``pk_users``, ``uq_users_email``, etc.).
+
+Note: ``downgrade`` drops the ``citext`` extension because this migration
+is the first to install it. A future migration that also needs ``citext``
+must use ``CREATE EXTENSION IF NOT EXISTS`` (as this file does) so it is
+safe to run after a partial downgrade that left the extension around.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CITEXT = sa.dialects.postgresql.CITEXT  # type: ignore[attr-defined]
+
+
+def upgrade() -> None:
+    # 1. Install the CITEXT extension. Idempotent so re-running the migration
+    #    against a database that already has it (e.g., some future 0003 also
+    #    needs it) is a no-op.
+    op.execute("CREATE EXTENSION IF NOT EXISTS citext")
+
+    # 2. users
+    op.create_table(
+        "users",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("email", CITEXT(), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+    )
+
+    # 3. roles
+    roles = op.create_table(
+        "roles",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("name", name="uq_roles_name"),
+    )
+    # Seed the two bootstrap roles. Order is deterministic so the IDs are
+    # predictable in a fresh database: admin=1, user=2. Tests should not
+    # depend on those IDs directly; they look up by name.
+    op.bulk_insert(
+        roles,
+        [
+            {"name": "admin"},
+            {"name": "user"},
+        ],
+    )
+
+    # 4. user_roles (association)
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("role_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "granted_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "user_id", "role_id", name="pk_user_roles"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_user_roles_user_id_users",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["roles.id"],
+            name="fk_user_roles_role_id_roles",
+            ondelete="RESTRICT",
+        ),
+    )
+
+    # 5. auth_identities
+    op.create_table(
+        "auth_identities",
+        sa.Column(
+            "id", sa.BigInteger(), primary_key=True, autoincrement=True
+        ),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column(
+            "provider_user_id", sa.String(length=255), nullable=False
+        ),
+        sa.Column("email_at_identity", CITEXT(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_auth_identities_user_id_users",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "provider",
+            "provider_user_id",
+            name="uq_auth_identities_provider",
+        ),
+    )
+    op.create_index(
+        "ix_auth_identities_user_id",
+        "auth_identities",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    # Drop in reverse creation order so FKs unwind cleanly.
+    op.drop_index("ix_auth_identities_user_id", table_name="auth_identities")
+    op.drop_table("auth_identities")
+    op.drop_table("user_roles")
+    op.drop_table("roles")
+    op.drop_table("users")
+    # Drop the CITEXT extension last. If another migration in the future
+    # needs citext, it must CREATE EXTENSION IF NOT EXISTS on upgrade so it
+    # is safe whether or not this downgrade has run.
+    op.execute("DROP EXTENSION IF EXISTS citext")

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.auth import router as auth_router
 from app.items import router as items_router
 
 api_v1_router = APIRouter(prefix="/api/v1")
 api_v1_router.include_router(items_router)
+api_v1_router.include_router(auth_router, prefix="/auth")
 
 __all__ = ["api_v1_router"]

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -1,0 +1,11 @@
+"""``auth`` domain: users, roles, identities, sessions, authorization primitives.
+
+Re-exports :data:`router` so the versioned API aggregator can include it
+with a single import, mirroring the layout established by
+:mod:`app.items`. See ``docs/design/auth-login-and-roles.md`` and
+``docs/specs/feat_auth_001/`` for the full design.
+"""
+
+from app.auth.router import router
+
+__all__ = ["router"]

--- a/backend/app/auth/bootstrap.py
+++ b/backend/app/auth/bootstrap.py
@@ -1,0 +1,89 @@
+"""``ADMIN_EMAILS`` bootstrap hook.
+
+Design reference: §7.7 of ``docs/design/auth-login-and-roles.md``.
+
+Controls the *first time a user is created*, not every login and not on
+settings reload. Demotion requires a DB write; promotion after launch
+requires a DB write. The env var is a bootstrap seed, deliberately not
+a live sync — see §15 of the design doc.
+
+This module is intentionally small. It:
+
+1. Parses :attr:`Settings.admin_emails` into a lower-cased set (the
+   settings property already does this, but we expose a helper so call
+   sites do not have to remember the attribute name).
+2. Grants an ``admin`` role to a freshly-created user whose email
+   appears in that set, idempotently.
+
+The user-creation code path itself lives in the test-only mint
+(``POST /api/v1/_test/session``) and will later live in
+``feat_auth_002`` (OTP verify) and ``feat_auth_003`` (OAuth callback).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.models import Role, User
+from app.settings import Settings
+
+
+def admin_emails_from_settings(settings: Settings) -> frozenset[str]:
+    """Return the lower-cased set of bootstrap-admin addresses.
+
+    Thin accessor for the settings property; exposed so callers do not
+    have to know where the parsing lives. Empty settings produces an
+    empty set.
+    """
+
+    return settings.admin_emails_set
+
+
+async def grant_admin_if_listed(
+    user: User,
+    *,
+    session: AsyncSession,
+    settings: Settings,
+) -> bool:
+    """Grant the ``admin`` role to ``user`` if their email is listed.
+
+    Returns ``True`` when a grant actually happened (the email matched
+    and the user did not already have the role), ``False`` otherwise.
+
+    The check is case-insensitive: the settings side lower-cases the
+    listed addresses and we lower-case ``user.email`` here. Idempotent:
+    calling twice in sequence never adds a second ``admin`` row to
+    ``user.roles``.
+
+    The caller is responsible for committing the transaction. This
+    helper flushes so the new association is visible to subsequent
+    reads within the same session.
+    """
+
+    admins = admin_emails_from_settings(settings)
+    if not admins:
+        return False
+
+    normalised = (user.email or "").strip().lower()
+    if normalised not in admins:
+        return False
+
+    if any(role.name == "admin" for role in user.roles):
+        # Already an admin — nothing to do. Preserves idempotency.
+        return False
+
+    result = await session.execute(select(Role).where(Role.name == "admin"))
+    admin_role = result.scalar_one_or_none()
+    if admin_role is None:
+        # The migration seeds ``admin``; if it is missing, the database
+        # is not in the expected state. Refuse silently rather than
+        # creating a role row here, which belongs to the migration.
+        return False
+
+    user.roles.append(admin_role)
+    await session.flush()
+    return True
+
+
+__all__ = ["admin_emails_from_settings", "grant_admin_if_listed"]

--- a/backend/app/auth/bootstrap.py
+++ b/backend/app/auth/bootstrap.py
@@ -18,14 +18,23 @@ This module is intentionally small. It:
 The user-creation code path itself lives in the test-only mint
 (``POST /api/v1/_test/session``) and will later live in
 ``feat_auth_002`` (OTP verify) and ``feat_auth_003`` (OAuth callback).
+
+Implementation note: all role-set manipulation goes through explicit
+SELECT/INSERT on the association table, not through the ORM relationship
+accessor :attr:`app.auth.models.User.roles`. Touching that attribute on a
+freshly-created, async-session-bound :class:`User` raises
+``MissingGreenlet`` because SQLAlchemy's implicit lazy-load path is not
+bridged to ``await`` when you access it as a plain attribute. See
+``backend/app/auth/service.py`` for the same pattern.
 """
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import insert, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.models import Role, User
+from app.auth.models import Role, User, UserRole
 from app.settings import Settings
 
 
@@ -53,8 +62,7 @@ async def grant_admin_if_listed(
 
     The check is case-insensitive: the settings side lower-cases the
     listed addresses and we lower-case ``user.email`` here. Idempotent:
-    calling twice in sequence never adds a second ``admin`` row to
-    ``user.roles``.
+    calling twice in sequence never adds a second ``admin`` row.
 
     The caller is responsible for committing the transaction. This
     helper flushes so the new association is visible to subsequent
@@ -69,20 +77,39 @@ async def grant_admin_if_listed(
     if normalised not in admins:
         return False
 
-    if any(role.name == "admin" for role in user.roles):
-        # Already an admin — nothing to do. Preserves idempotency.
+    # Look up the ``admin`` role by name. Migration seeds it, so the
+    # row exists on a healthy database.
+    admin_row = (
+        await session.execute(select(Role.id).where(Role.name == "admin"))
+    ).scalar_one_or_none()
+    if admin_row is None:
         return False
 
-    result = await session.execute(select(Role).where(Role.name == "admin"))
-    admin_role = result.scalar_one_or_none()
-    if admin_role is None:
-        # The migration seeds ``admin``; if it is missing, the database
-        # is not in the expected state. Refuse silently rather than
-        # creating a role row here, which belongs to the migration.
+    # Check idempotency via a direct query on the association table —
+    # avoids triggering a lazy-load on ``user.roles`` from an async
+    # session.
+    existing = (
+        await session.execute(
+            select(UserRole.role_id).where(
+                UserRole.user_id == user.id,
+                UserRole.role_id == admin_row,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
         return False
 
-    user.roles.append(admin_role)
-    await session.flush()
+    try:
+        await session.execute(
+            insert(UserRole).values(user_id=user.id, role_id=admin_row)
+        )
+        await session.flush()
+    except IntegrityError:
+        # Race: someone else just inserted the same row. Treat as a
+        # no-op grant (the caller wanted admin, admin is now present).
+        await session.rollback()
+        return False
+
     return True
 
 

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -1,0 +1,97 @@
+"""FastAPI dependencies for authentication and authorization.
+
+These are the only call sites that need to know how auth data gets onto
+``request.state``. Route handlers use them like any other dependency:
+
+.. code-block:: python
+
+    @router.get("/me")
+    async def me(ctx: AuthContext = Depends(current_user)) -> MeResponse:
+        ...
+
+All three helpers are zero-DB: they read from
+``request.state.auth``, which :class:`app.middleware.SessionMiddleware`
+populates from a single Redis ``GET``. See §2 of
+``docs/design/auth-login-and-roles.md``.
+
+Precedence rule: **authentication before authorization**. Even when a
+route uses ``require_roles(...)``, a request with no session returns
+``401 not_authenticated``, not ``403 forbidden``. That is the right
+default — a 403 on an unauthenticated request leaks "this is a
+protected endpoint" to a scanner.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from fastapi import HTTPException, Request, status
+
+from app.auth.schemas import AuthContext
+
+
+def current_user(request: Request) -> AuthContext:
+    """Return the authenticated principal or raise ``401``.
+
+    Reads :attr:`request.state.auth`, which
+    :class:`app.middleware.SessionMiddleware` has already populated in
+    this request's lifecycle. No DB hit.
+    """
+
+    ctx = getattr(request.state, "auth", None)
+    if ctx is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="not_authenticated",
+        )
+    return ctx
+
+
+# Same behaviour as :func:`current_user`; exported under a more readable
+# name for routes that only need "must be logged in" semantics without
+# using the context value.
+require_authenticated = current_user
+
+
+def require_roles(*names: str) -> Callable[[Request], AuthContext]:
+    """Build a dependency that enforces OR semantics across ``names``.
+
+    Usage::
+
+        @router.get(..., dependencies=[Depends(require_roles("admin"))])
+        ...
+
+    Semantics:
+
+    - If there is no session, raise ``401 not_authenticated``
+      (authentication precedes authorization).
+    - Otherwise, if **any** of the required role names appears in the
+      session payload's ``roles``, the request is allowed.
+    - Otherwise, raise ``403 forbidden``.
+    """
+
+    required = frozenset(names)
+
+    def _dependency(request: Request) -> AuthContext:
+        ctx = getattr(request.state, "auth", None)
+        if ctx is None:
+            # Unauthenticated takes precedence over unauthorized.
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="not_authenticated",
+            )
+        if required and required.isdisjoint(ctx.roles):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="forbidden",
+            )
+        return ctx
+
+    return _dependency
+
+
+__all__ = [
+    "current_user",
+    "require_authenticated",
+    "require_roles",
+]

--- a/backend/app/auth/models.py
+++ b/backend/app/auth/models.py
@@ -1,0 +1,166 @@
+"""SQLAlchemy ORM models for the ``auth`` domain.
+
+Mirrors the migration in ``alembic/versions/0002_create_auth.py``.
+
+The schema is specified in §6.1 of ``docs/design/auth-login-and-roles.md``:
+
+- ``User``: opaque numeric id, case-insensitive email (``CITEXT``), optional
+  display name, timestamps.
+- ``Role``: small lookup table; seeded with ``admin`` and ``user``.
+- ``UserRole``: association table with a composite PK and cascade
+  behavior matching the migration (``CASCADE`` on user delete, ``RESTRICT``
+  on role delete).
+- ``AuthIdentity``: provider-specific identity linked to a user; unique
+  on ``(provider, provider_user_id)``.
+
+``User.roles`` is loaded via the association table so call sites can
+write ``[r.name for r in user.roles]`` without touching ``UserRole``
+directly. Session-creation code uses that list to build the session
+payload.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    BigInteger,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import CITEXT, TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.db import Base
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    pass
+
+
+class User(Base):
+    """Application user identified by a case-insensitive email."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    email: Mapped[str] = mapped_column(CITEXT(), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(
+        String(255), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (UniqueConstraint("email", name="uq_users_email"),)
+
+    # ``secondary`` association keeps the relationship a plain ``list[Role]``
+    # so callers do not need to know about ``UserRole``. ``lazy="selectin"``
+    # issues one extra SELECT per query on load; it is cheap at scaffold
+    # scale and removes a surprise N+1 when callers iterate ``user.roles``.
+    roles: Mapped[list["Role"]] = relationship(
+        "Role",
+        secondary="user_roles",
+        lazy="selectin",
+    )
+
+    identities: Mapped[list["AuthIdentity"]] = relationship(
+        "AuthIdentity",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class Role(Base):
+    """Named role; the small lookup table for ``user_roles``."""
+
+    __tablename__ = "roles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (UniqueConstraint("name", name="uq_roles_name"),)
+
+
+class UserRole(Base):
+    """Association between :class:`User` and :class:`Role`.
+
+    Composite primary key ``(user_id, role_id)`` matches the migration.
+    """
+
+    __tablename__ = "user_roles"
+
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    role_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("roles.id", ondelete="RESTRICT"),
+        primary_key=True,
+    )
+    granted_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class AuthIdentity(Base):
+    """Provider-specific identity (Google, email-OTP, ...) linked to a user.
+
+    Unique on ``(provider, provider_user_id)`` so a single provider account
+    maps to exactly one internal user. ``email_at_identity`` records the
+    email the provider returned at link time — not kept in sync with
+    :attr:`User.email`, so account-linking decisions can be audited later.
+    """
+
+    __tablename__ = "auth_identities"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    provider_user_id: Mapped[str] = mapped_column(
+        String(255), nullable=False
+    )
+    email_at_identity: Mapped[str] = mapped_column(CITEXT(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "provider",
+            "provider_user_id",
+            name="uq_auth_identities_provider",
+        ),
+    )
+
+    user: Mapped[User] = relationship("User", back_populates="identities")
+
+
+__all__ = ["User", "Role", "UserRole", "AuthIdentity"]

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -16,9 +16,11 @@ And one env-gated route mounted under ``/api/v1/_test`` **only when**
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Response, status
+from fastapi import APIRouter, Depends, Request, Response, status
 from redis.asyncio import Redis
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from types import SimpleNamespace
 
 from app.auth import service, sessions
 from app.auth.dependencies import current_user
@@ -26,9 +28,33 @@ from app.auth.models import User
 from app.auth.schemas import AuthContext, MeResponse, TestSessionRequest
 from app.db import get_session
 from app.redis_client import get_redis
-from app.settings import Settings, get_settings
+from app.settings import Settings
+
+
+def _settings(request: Request) -> Settings:
+    """Pull the live :class:`Settings` off ``app.state``.
+
+    ``create_app`` installs the exact :class:`Settings` instance the
+    caller passed (or the env-derived default) onto ``app.state``; tests
+    that build an app with a synthetic :class:`Settings` want *that*
+    value flowing into every handler, not the lru-cached env default
+    that ``app.settings.get_settings`` returns. See
+    ``docs/specs/feat_auth_001/design_auth_001.md`` → "Settings
+    additions".
+    """
+
+    return request.app.state.settings
 
 router = APIRouter(tags=["auth"])
+
+
+# Lightweight adapter so :func:`app.auth.sessions.create` — which reads
+# ``user.id``, ``user.email``, and iterates ``user.roles``-with-``.name``
+# — works with the ``(user, role_names)`` tuple returned by the service
+# layer, without triggering an async lazy-load on :attr:`User.roles`.
+def _UserLike(*, id: int, email: str, role_names: list[str]):  # noqa: N802
+    roles = [SimpleNamespace(name=n) for n in role_names]
+    return SimpleNamespace(id=id, email=email, roles=roles)
 
 
 @router.get("/me", response_model=MeResponse)
@@ -68,7 +94,7 @@ async def logout(
     response: Response,
     ctx: AuthContext = Depends(current_user),
     redis: Redis = Depends(get_redis),
-    settings: Settings = Depends(get_settings),
+    settings: Settings = Depends(_settings),
 ) -> Response:
     """Invalidate the current session and clear the cookie."""
 
@@ -104,7 +130,7 @@ async def mint_test_session(
     response: Response,
     db: AsyncSession = Depends(get_session),
     redis: Redis = Depends(get_redis),
-    settings: Settings = Depends(get_settings),
+    settings: Settings = Depends(_settings),
 ) -> MeResponse:
     """Mint a session for the given email. ``env == "test"`` only.
 
@@ -114,7 +140,7 @@ async def mint_test_session(
     same schema in both places.
     """
 
-    user = await service.find_or_create_user_for_test(
+    user, role_names = await service.find_or_create_user_for_test(
         db,
         email=body.email,
         display_name=body.display_name,
@@ -123,7 +149,7 @@ async def mint_test_session(
     )
 
     session_id = await sessions.create(
-        user,
+        _UserLike(id=user.id, email=user.email, role_names=role_names),
         redis=redis,
         ttl_seconds=settings.session_ttl_seconds,
     )
@@ -142,7 +168,7 @@ async def mint_test_session(
         user_id=user.id,
         email=user.email,
         display_name=user.display_name,
-        roles=[r.name for r in user.roles],
+        roles=list(role_names),
     )
 
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -1,0 +1,149 @@
+"""HTTP routes for the ``auth`` domain.
+
+Exposes two production routes mounted under ``/api/v1/auth``:
+
+- ``GET /me`` — returns the authenticated principal.
+- ``POST /logout`` — deletes the current session and clears the cookie.
+
+And one env-gated route mounted under ``/api/v1/_test`` **only when**
+``settings.env == "test"``:
+
+- ``POST /session`` — mints a session for testing. Created in
+  ``feat_auth_001`` so the middleware and ``/me`` + ``/logout`` pair can
+  be exercised end-to-end before real login flows land. Will be removed
+  by ``feat_auth_002`` when OTP verify becomes the real session minter.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Response, status
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import service, sessions
+from app.auth.dependencies import current_user
+from app.auth.models import User
+from app.auth.schemas import AuthContext, MeResponse, TestSessionRequest
+from app.db import get_session
+from app.redis_client import get_redis
+from app.settings import Settings, get_settings
+
+router = APIRouter(tags=["auth"])
+
+
+@router.get("/me", response_model=MeResponse)
+async def me(
+    ctx: AuthContext = Depends(current_user),
+    db: AsyncSession = Depends(get_session),
+) -> MeResponse:
+    """Return the authenticated user's profile.
+
+    The session payload already carries ``user_id``, ``email``, and
+    ``roles``; ``display_name`` is the only field that isn't in the
+    payload today, so we load it from the database. We intentionally
+    keep ``display_name`` *off* the session payload to keep that blob
+    small and stable across profile edits.
+
+    This DB read happens only on ``/me``, not on every request — and
+    fetching a single row by primary key is cheap. The zero-DB-hit
+    invariant in the design doc is specifically about the middleware
+    (and therefore every request-gated dependency), not about the
+    ``/me`` endpoint, which is the place a caller explicitly asks for
+    profile data.
+    """
+
+    user = await db.get(User, ctx.user_id)
+    display_name = user.display_name if user is not None else None
+
+    return MeResponse(
+        user_id=ctx.user_id,
+        email=ctx.email,
+        display_name=display_name,
+        roles=list(ctx.roles),
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(
+    response: Response,
+    ctx: AuthContext = Depends(current_user),
+    redis: Redis = Depends(get_redis),
+    settings: Settings = Depends(get_settings),
+) -> Response:
+    """Invalidate the current session and clear the cookie."""
+
+    await sessions.delete(ctx.session_id, ctx.user_id, redis=redis)
+
+    response.delete_cookie(
+        settings.session_cookie_name,
+        path="/",
+        httponly=True,
+        samesite="lax",
+        secure=settings.session_cookie_secure,
+    )
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Test-only mint endpoint (env-gated)
+# ---------------------------------------------------------------------------
+#
+# Mounted by ``app/main.py`` only when ``settings.env == "test"``. Importing
+# this symbol is safe in any environment — the route is registered on a
+# separate ``APIRouter`` that ``main.py`` chooses to include or not.
+#
+# Removed entirely by ``feat_auth_002``.
+
+test_router = APIRouter(prefix="/_test", tags=["_test"])
+
+
+@test_router.post("/session", response_model=MeResponse, status_code=200)
+async def mint_test_session(
+    body: TestSessionRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_session),
+    redis: Redis = Depends(get_redis),
+    settings: Settings = Depends(get_settings),
+) -> MeResponse:
+    """Mint a session for the given email. ``env == "test"`` only.
+
+    Find-or-create the user, apply ``ADMIN_EMAILS`` bootstrap, optionally
+    grant extra roles, create a session, set the cookie, and return the
+    same payload shape as ``GET /auth/me`` so tests can assert on the
+    same schema in both places.
+    """
+
+    user = await service.find_or_create_user_for_test(
+        db,
+        email=body.email,
+        display_name=body.display_name,
+        extra_roles=body.roles or (),
+        settings=settings,
+    )
+
+    session_id = await sessions.create(
+        user,
+        redis=redis,
+        ttl_seconds=settings.session_ttl_seconds,
+    )
+
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=session_id,
+        max_age=settings.session_ttl_seconds,
+        path="/",
+        httponly=True,
+        samesite="lax",
+        secure=settings.session_cookie_secure,
+    )
+
+    return MeResponse(
+        user_id=user.id,
+        email=user.email,
+        display_name=user.display_name,
+        roles=[r.name for r in user.roles],
+    )
+
+
+__all__ = ["router", "test_router"]

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -1,0 +1,70 @@
+"""Schemas and in-memory shapes used by the ``auth`` domain.
+
+Design references:
+
+- ``AuthContext``: frozen dataclass describing the authenticated principal
+  for a single request. Lives on ``request.state.auth`` (or is ``None`` if
+  the request is anonymous) and is consumed by :mod:`app.auth.dependencies`.
+  See ``docs/specs/feat_auth_001/design_auth_001.md`` → "``AuthContext``
+  shape" and §2 of ``docs/design/auth-login-and-roles.md`` (role data in
+  the session payload, no per-request DB hit).
+- ``MeResponse``: payload shape for ``GET /api/v1/auth/me`` per §7.3 of
+  the design doc.
+- ``TestSessionRequest``: request body for the env-gated test-only mint
+  endpoint. Removed in ``feat_auth_002``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+@dataclass(frozen=True, slots=True)
+class AuthContext:
+    """Authenticated principal for a single request.
+
+    Frozen + slotted → cheap, hashable, explicitly immutable. ``roles`` is
+    a tuple (not a list) so the context can be shared across dependency
+    calls without concern for mutation.
+    """
+
+    user_id: int
+    email: str
+    roles: tuple[str, ...]
+    session_id: str
+
+
+class MeResponse(BaseModel):
+    """Response body for ``GET /api/v1/auth/me``.
+
+    Shape fixed by §7.3 of the design doc.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: int
+    email: EmailStr
+    display_name: str | None = None
+    roles: list[str] = Field(default_factory=list)
+
+
+class TestSessionRequest(BaseModel):
+    """Request body for the test-only ``POST /api/v1/_test/session`` endpoint.
+
+    Only mounted when ``settings.env == "test"``. See
+    ``docs/specs/feat_auth_001/feat_auth_001.md`` requirement 11.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailStr
+    display_name: str | None = None
+    # Additional roles to grant beyond the default ``user`` role and any
+    # bootstrap ``admin`` grant from ``ADMIN_EMAILS``. Names are matched
+    # against :class:`Role.name` — unknown names are silently skipped.
+    roles: list[str] | None = None
+
+
+__all__ = ["AuthContext", "MeResponse", "TestSessionRequest"]

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +36,22 @@ class AuthContext:
     session_id: str
 
 
+# Minimal email sanity check. We deliberately do not pull in
+# ``email-validator`` (pydantic's ``EmailStr`` backing) because requirement
+# 15 of the feature spec forbids new top-level dependencies, and because
+# the real login paths (OTP in 002, OAuth in 003) do provider-side
+# verification anyway. This check only guards the test-only mint and
+# the response body shape.
+_EMAIL_SHAPE = "@"
+
+
+def _validate_email_shape(value: str) -> str:
+    value = value.strip()
+    if _EMAIL_SHAPE not in value or len(value) < 3:
+        raise ValueError("not a valid email")
+    return value
+
+
 class MeResponse(BaseModel):
     """Response body for ``GET /api/v1/auth/me``.
 
@@ -45,7 +61,7 @@ class MeResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     user_id: int
-    email: EmailStr
+    email: str
     display_name: str | None = None
     roles: list[str] = Field(default_factory=list)
 
@@ -59,12 +75,17 @@ class TestSessionRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    email: EmailStr
+    email: str
     display_name: str | None = None
     # Additional roles to grant beyond the default ``user`` role and any
     # bootstrap ``admin`` grant from ``ADMIN_EMAILS``. Names are matched
     # against :class:`Role.name` — unknown names are silently skipped.
     roles: list[str] | None = None
+
+    @field_validator("email")
+    @classmethod
+    def _email_must_look_like_one(cls, v: str) -> str:
+        return _validate_email_shape(v)
 
 
 __all__ = ["AuthContext", "MeResponse", "TestSessionRequest"]

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -1,0 +1,151 @@
+"""Service-layer helpers for the ``auth`` domain.
+
+Framework-agnostic: accept a session, a redis client, or both; do one
+job; return a plain value or model instance. Handlers in
+:mod:`app.auth.router` stay thin and delegate here.
+
+Contents:
+
+- :func:`revoke_sessions_for_user` — thin wrapper over
+  :func:`app.auth.sessions.revoke_all_for_user`. Exposed here (rather
+  than asking callers to import from ``sessions`` directly) so
+  ``feat_auth_002`` and ``feat_auth_003`` can import a stable symbol
+  when they need to invalidate active sessions on a role change or a
+  manual revoke.
+- :func:`find_or_create_user_for_test` — find-or-create helper used by
+  the env-gated test-only mint endpoint. Applies ``ADMIN_EMAILS``
+  bootstrap on first creation and optionally grants extra roles.
+  Not a general-purpose helper; real login paths (002, 003) create
+  their own find-or-create plus identity-linking routines.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from redis.asyncio import Redis
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import sessions
+from app.auth.bootstrap import grant_admin_if_listed
+from app.auth.models import Role, User
+from app.settings import Settings
+
+
+async def revoke_sessions_for_user(
+    user_id: int,
+    *,
+    redis: Redis,
+) -> None:
+    """Invalidate every active session for ``user_id``.
+
+    Deliberately ``DEL``-based (not update-based): no races, no stale
+    caches. See §7.6 of ``docs/design/auth-login-and-roles.md``.
+    """
+
+    await sessions.revoke_all_for_user(user_id, redis=redis)
+
+
+async def _ensure_user_role(session: AsyncSession, user: User) -> None:
+    """Ensure ``user`` has the default ``user`` role."""
+
+    if any(r.name == "user" for r in user.roles):
+        return
+    result = await session.execute(select(Role).where(Role.name == "user"))
+    role = result.scalar_one_or_none()
+    if role is None:
+        # Migration seeds the role; missing seed is a bug in ops, not
+        # something we silently paper over by creating the row here.
+        return
+    user.roles.append(role)
+    await session.flush()
+
+
+async def _grant_extra_roles(
+    session: AsyncSession,
+    user: User,
+    names: Iterable[str],
+) -> None:
+    """Grant each named role to ``user`` (case-sensitive; unknown skipped)."""
+
+    wanted = {n for n in names if n}
+    wanted.discard("user")  # handled by ``_ensure_user_role``
+    if not wanted:
+        return
+
+    existing = {r.name for r in user.roles}
+    to_grant = wanted - existing
+    if not to_grant:
+        return
+
+    result = await session.execute(
+        select(Role).where(Role.name.in_(to_grant))
+    )
+    for role in result.scalars().all():
+        user.roles.append(role)
+    await session.flush()
+
+
+async def find_or_create_user_for_test(
+    session: AsyncSession,
+    *,
+    email: str,
+    display_name: str | None,
+    extra_roles: Iterable[str] = (),
+    settings: Settings,
+) -> User:
+    """Find or create a :class:`User` for the test-only mint endpoint.
+
+    Semantics:
+
+    - Lookup is case-insensitive (``email`` is stored as ``CITEXT``).
+    - If the user exists, reuse it. Applying extra roles and the
+      ``ADMIN_EMAILS`` bootstrap on an existing user is deliberately
+      idempotent: a second mint does not add a second ``admin`` row and
+      does not downgrade the user.
+    - If the user does not exist, create them, grant the default ``user``
+      role, apply the ``ADMIN_EMAILS`` bootstrap, and grant any extra
+      roles. A concurrent second creation for the same email is
+      tolerated via a ``UNIQUE`` violation + re-read.
+    - Does **not** create an ``auth_identities`` row. Identity rows
+      belong to real login paths (002/003).
+    """
+
+    stmt = select(User).where(User.email == email)
+    result = await session.execute(stmt)
+    user = result.scalar_one_or_none()
+
+    if user is None:
+        user = User(email=email, display_name=display_name)
+        session.add(user)
+        try:
+            await session.flush()
+        except IntegrityError:
+            # A concurrent mint created the row first. Rolling back the
+            # nested state and re-reading is simpler than SAVEPOINT-ing
+            # the insert. Matches §7.7 of the design doc's guidance.
+            await session.rollback()
+            result = await session.execute(stmt)
+            user = result.scalar_one()
+
+    # Always ensure defaults. These are all idempotent when the user
+    # already has the role, so a second mint is a no-op.
+    await _ensure_user_role(session, user)
+    await grant_admin_if_listed(user, session=session, settings=settings)
+    await _grant_extra_roles(session, user, extra_roles)
+
+    await session.commit()
+    # Re-fetch to make ``user.roles`` reflect the committed state. With
+    # ``expire_on_commit=False`` on the sessionmaker (see ``app/db.py``),
+    # the attribute collection is still valid — but a selectin-loaded
+    # relationship is lazy on first access, so we trigger it here.
+    _ = user.roles  # noqa: B018 - force selectin load
+    return user
+
+
+__all__ = [
+    "revoke_sessions_for_user",
+    "find_or_create_user_for_test",
+]

--- a/backend/app/auth/service.py
+++ b/backend/app/auth/service.py
@@ -17,6 +17,15 @@ Contents:
   bootstrap on first creation and optionally grants extra roles.
   Not a general-purpose helper; real login paths (002, 003) create
   their own find-or-create plus identity-linking routines.
+
+Note on async-session + relationships: in SQLAlchemy 2.x, accessing a
+relationship attribute (``user.roles``) on an instance whose collection
+has not yet been loaded triggers a lazy SELECT. When the parent session
+is async, that implicit SELECT goes through the greenlet-bridged
+``await_only`` and raises ``MissingGreenlet`` if called from bare
+attribute access. We therefore load role *names* via explicit SELECTs
+over the ``user_roles`` association table, never via the ORM
+relationship accessor inside this module.
 """
 
 from __future__ import annotations
@@ -24,13 +33,13 @@ from __future__ import annotations
 from typing import Iterable
 
 from redis.asyncio import Redis
-from sqlalchemy import select
+from sqlalchemy import insert, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import sessions
-from app.auth.bootstrap import grant_admin_if_listed
-from app.auth.models import Role, User
+from app.auth.bootstrap import admin_emails_from_settings
+from app.auth.models import Role, User, UserRole
 from app.settings import Settings
 
 
@@ -48,44 +57,65 @@ async def revoke_sessions_for_user(
     await sessions.revoke_all_for_user(user_id, redis=redis)
 
 
-async def _ensure_user_role(session: AsyncSession, user: User) -> None:
-    """Ensure ``user`` has the default ``user`` role."""
+async def _current_role_names(
+    session: AsyncSession, user_id: int
+) -> set[str]:
+    """Return the set of role names currently granted to ``user_id``.
 
-    if any(r.name == "user" for r in user.roles):
-        return
-    result = await session.execute(select(Role).where(Role.name == "user"))
-    role = result.scalar_one_or_none()
-    if role is None:
-        # Migration seeds the role; missing seed is a bug in ops, not
-        # something we silently paper over by creating the row here.
-        return
-    user.roles.append(role)
-    await session.flush()
-
-
-async def _grant_extra_roles(
-    session: AsyncSession,
-    user: User,
-    names: Iterable[str],
-) -> None:
-    """Grant each named role to ``user`` (case-sensitive; unknown skipped)."""
-
-    wanted = {n for n in names if n}
-    wanted.discard("user")  # handled by ``_ensure_user_role``
-    if not wanted:
-        return
-
-    existing = {r.name for r in user.roles}
-    to_grant = wanted - existing
-    if not to_grant:
-        return
+    Reads via an explicit SELECT join over ``user_roles`` / ``roles`` so
+    this is safe to call on a freshly-created user in an async session
+    without triggering an implicit lazy-load greenlet error.
+    """
 
     result = await session.execute(
-        select(Role).where(Role.name.in_(to_grant))
+        select(Role.name)
+        .select_from(UserRole)
+        .join(Role, Role.id == UserRole.role_id)
+        .where(UserRole.user_id == user_id)
     )
-    for role in result.scalars().all():
-        user.roles.append(role)
-    await session.flush()
+    return {name for (name,) in result.all()}
+
+
+async def _grant_role_if_missing(
+    session: AsyncSession,
+    user_id: int,
+    role_name: str,
+    *,
+    already_granted: set[str],
+) -> bool:
+    """Idempotently insert a ``user_roles`` row.
+
+    Returns ``True`` when an insert actually happened. ``already_granted``
+    is the caller-supplied set of existing role names for the user; we
+    mutate it in place on a successful grant so sequential calls stay
+    coherent without a re-read.
+    """
+
+    if role_name in already_granted:
+        return False
+
+    result = await session.execute(
+        select(Role.id).where(Role.name == role_name)
+    )
+    role_id = result.scalar_one_or_none()
+    if role_id is None:
+        # Migration seeds ``admin`` and ``user``; anything else is a
+        # caller bug (unknown role). Skip silently rather than erroring.
+        return False
+
+    try:
+        await session.execute(
+            insert(UserRole).values(user_id=user_id, role_id=role_id)
+        )
+    except IntegrityError:
+        # Row already exists under a concurrent writer. Keep the state
+        # the caller believes they have.
+        await session.rollback()
+        already_granted.add(role_name)
+        return False
+
+    already_granted.add(role_name)
+    return True
 
 
 async def find_or_create_user_for_test(
@@ -95,7 +125,7 @@ async def find_or_create_user_for_test(
     display_name: str | None,
     extra_roles: Iterable[str] = (),
     settings: Settings,
-) -> User:
+) -> tuple[User, list[str]]:
     """Find or create a :class:`User` for the test-only mint endpoint.
 
     Semantics:
@@ -111,6 +141,10 @@ async def find_or_create_user_for_test(
       tolerated via a ``UNIQUE`` violation + re-read.
     - Does **not** create an ``auth_identities`` row. Identity rows
       belong to real login paths (002/003).
+
+    Returns a ``(user, role_names)`` pair so callers can build a session
+    payload without touching the lazy-loaded :attr:`User.roles`
+    collection on the still-live async session.
     """
 
     stmt = select(User).where(User.email == email)
@@ -123,26 +157,38 @@ async def find_or_create_user_for_test(
         try:
             await session.flush()
         except IntegrityError:
-            # A concurrent mint created the row first. Rolling back the
-            # nested state and re-reading is simpler than SAVEPOINT-ing
-            # the insert. Matches §7.7 of the design doc's guidance.
             await session.rollback()
             result = await session.execute(stmt)
             user = result.scalar_one()
 
-    # Always ensure defaults. These are all idempotent when the user
-    # already has the role, so a second mint is a no-op.
-    await _ensure_user_role(session, user)
-    await grant_admin_if_listed(user, session=session, settings=settings)
-    await _grant_extra_roles(session, user, extra_roles)
+    assert user.id is not None  # flushed above
+
+    role_names = await _current_role_names(session, user.id)
+
+    # Always ensure the default ``user`` role.
+    await _grant_role_if_missing(
+        session, user.id, "user", already_granted=role_names
+    )
+
+    # ADMIN_EMAILS bootstrap (case-insensitive membership test).
+    admins = admin_emails_from_settings(settings)
+    if (email or "").strip().lower() in admins:
+        await _grant_role_if_missing(
+            session, user.id, "admin", already_granted=role_names
+        )
+
+    # Extra caller-specified roles (unknown names are silently skipped
+    # inside ``_grant_role_if_missing``).
+    for name in extra_roles or ():
+        if not name:
+            continue
+        await _grant_role_if_missing(
+            session, user.id, name, already_granted=role_names
+        )
 
     await session.commit()
-    # Re-fetch to make ``user.roles`` reflect the committed state. With
-    # ``expire_on_commit=False`` on the sessionmaker (see ``app/db.py``),
-    # the attribute collection is still valid — but a selectin-loaded
-    # relationship is lazy on first access, so we trigger it here.
-    _ = user.roles  # noqa: B018 - force selectin load
-    return user
+
+    return user, sorted(role_names)
 
 
 __all__ = [

--- a/backend/app/auth/sessions.py
+++ b/backend/app/auth/sessions.py
@@ -1,0 +1,186 @@
+"""Redis-backed session store.
+
+Design references: §6.2 (keyspaces) and §7.4 / §7.5 / §7.6 of
+``docs/design/auth-login-and-roles.md``, plus the "Data flow" section of
+``docs/specs/feat_auth_001/design_auth_001.md``.
+
+Key shapes:
+
+- ``session:<64-hex>`` — JSON payload describing the authenticated user.
+  TTL = ``settings.session_ttl_seconds``.
+- ``user_sessions:<user_id>`` — Redis ``SET`` of session IDs owned by
+  the user, used as a reverse index for ``revoke_all_for_user``.
+
+Only two helpers in this feature ever touch Redis: :func:`create` writes
+both keys, :func:`delete` and :func:`revoke_all_for_user` tear them down.
+The middleware uses :func:`get` to resolve a cookie into an
+:class:`AuthContext`.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from redis.asyncio import Redis
+
+from app.auth.schemas import AuthContext
+
+# Exposed as module-level constants so call sites never hand-string Redis
+# keys. Keeps future "rename the key" refactors one-edit jobs.
+SESSION_KEY_PREFIX = "session:"
+USER_SESSIONS_KEY_PREFIX = "user_sessions:"
+
+
+def _session_key(session_id: str) -> str:
+    return f"{SESSION_KEY_PREFIX}{session_id}"
+
+
+def _user_sessions_key(user_id: int | str) -> str:
+    return f"{USER_SESSIONS_KEY_PREFIX}{user_id}"
+
+
+def _now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _decode_member(value: bytes | str) -> str:
+    """Normalize a Redis ``SMEMBERS`` element to ``str``.
+
+    The repo default builds the async Redis client with
+    ``decode_responses=True`` so members arrive as ``str`` already, but
+    callers may hand us a raw bytes-mode client; support both.
+    """
+
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+async def create(
+    user: Any,
+    *,
+    redis: Redis,
+    ttl_seconds: int,
+) -> str:
+    """Mint a new session for ``user`` and return its opaque ID.
+
+    ``user`` is any object with ``id``, ``email``, and a ``roles``
+    iterable whose elements expose a ``name`` attribute. Typically a
+    :class:`app.auth.models.User`, but the test suite passes a lightweight
+    stand-in, so the contract is kept duck-typed.
+
+    Writes both the session payload and the reverse-index entry in a
+    single pipelined round-trip.
+    """
+
+    session_id = secrets.token_hex(32)  # 64 hex chars, 256 bits of entropy
+    payload = {
+        "user_id": int(user.id),
+        "email": str(user.email),
+        "roles": [r.name for r in user.roles],
+        "created_at": _now_iso(),
+    }
+
+    session_key = _session_key(session_id)
+    reverse_key = _user_sessions_key(user.id)
+
+    pipe = redis.pipeline()
+    pipe.set(session_key, json.dumps(payload), ex=ttl_seconds)
+    pipe.sadd(reverse_key, session_id)
+    pipe.expire(reverse_key, ttl_seconds)
+    await pipe.execute()
+
+    return session_id
+
+
+async def get(session_id: str, *, redis: Redis) -> AuthContext | None:
+    """Resolve a session ID to an :class:`AuthContext` or ``None``.
+
+    Collapses three failure modes — missing key, malformed JSON, missing
+    required field — to ``None``. The middleware treats ``None`` as
+    "anonymous" and clears the cookie; no exception escapes.
+    """
+
+    raw = await redis.get(_session_key(session_id))
+    if raw is None:
+        return None
+
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    try:
+        user_id = int(payload["user_id"])
+        email = str(payload["email"])
+        roles = tuple(str(r) for r in payload.get("roles", []))
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    return AuthContext(
+        user_id=user_id,
+        email=email,
+        roles=roles,
+        session_id=session_id,
+    )
+
+
+async def delete(
+    session_id: str,
+    user_id: int,
+    *,
+    redis: Redis,
+) -> None:
+    """Remove a single session and its reverse-index membership.
+
+    Safe to call for a session that has already expired in Redis — both
+    ``DEL`` and ``SREM`` are idempotent and happily return 0 when the
+    target is absent.
+    """
+
+    pipe = redis.pipeline()
+    pipe.delete(_session_key(session_id))
+    pipe.srem(_user_sessions_key(user_id), session_id)
+    await pipe.execute()
+
+
+async def revoke_all_for_user(
+    user_id: int,
+    *,
+    redis: Redis,
+) -> None:
+    """Wipe every active session for ``user_id``.
+
+    Fetches the reverse-index set, deletes every referenced session key
+    in one ``DELETE`` call, then drops the reverse index itself. No-op
+    when the reverse index is empty.
+    """
+
+    members: Iterable[bytes | str] = await redis.smembers(
+        _user_sessions_key(user_id)
+    )
+    session_ids = [_decode_member(m) for m in members]
+    if session_ids:
+        await redis.delete(*[_session_key(sid) for sid in session_ids])
+    await redis.delete(_user_sessions_key(user_id))
+
+
+__all__ = [
+    "SESSION_KEY_PREFIX",
+    "USER_SESSIONS_KEY_PREFIX",
+    "create",
+    "get",
+    "delete",
+    "revoke_all_for_user",
+]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,7 +20,11 @@ from app.api.v1 import api_v1_router
 from app.db import build_engine, build_sessionmaker
 from app.errors import install_exception_handlers
 from app.logging import configure_logging, get_logger
-from app.middleware import ExceptionEnvelopeMiddleware, RequestIDMiddleware
+from app.middleware import (
+    ExceptionEnvelopeMiddleware,
+    RequestIDMiddleware,
+    SessionMiddleware,
+)
 from app.redis_client import build_redis
 from app.settings import Settings, get_settings
 
@@ -78,9 +82,19 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
 
     # Middleware order (outermost-first after ServerErrorMiddleware):
-    #   RequestIDMiddleware -> ExceptionEnvelopeMiddleware -> ExceptionMiddleware -> app
+    #   RequestIDMiddleware
+    #     -> SessionMiddleware
+    #       -> ExceptionEnvelopeMiddleware
+    #         -> ExceptionMiddleware (Starlette-internal)
+    #           -> app
+    #
     # ``add_middleware`` prepends to the stack, so the LAST call is outermost.
+    # ``SessionMiddleware`` sits inside ``RequestIDMiddleware`` so the one
+    # log event it emits carries ``request_id``, and sits outside the
+    # exception envelope so any 401/403 raised by a dependency still flows
+    # through the envelope handler cleanly.
     app.add_middleware(ExceptionEnvelopeMiddleware)
+    app.add_middleware(SessionMiddleware)
     app.add_middleware(
         RequestIDMiddleware, header_name=resolved.request_id_header
     )
@@ -89,6 +103,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.include_router(health_router)
     app.include_router(api_v1_router)
+
+    # Env-gated test-only session mint. Imported inside the branch so
+    # production builds do not even parse the symbol. See
+    # ``docs/specs/feat_auth_001/design_auth_001.md`` →
+    # "Test-only session-mint endpoint".
+    if resolved.env == "test":
+        from app.auth.router import test_router
+
+        app.include_router(test_router, prefix="/api/v1")
 
     return app
 

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,8 +1,12 @@
-"""ASGI middleware: request ID correlation and unhandled-exception envelope."""
+"""ASGI middleware: request ID correlation, session resolution, and
+unhandled-exception envelope."""
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
+from http.cookies import SimpleCookie
 from uuid import uuid4
 
 import structlog
@@ -153,4 +157,191 @@ class ExceptionEnvelopeMiddleware:
             )
 
 
-__all__ = ["RequestIDMiddleware", "ExceptionEnvelopeMiddleware"]
+# ---------------------------------------------------------------------------
+# Session middleware (feat_auth_001)
+# ---------------------------------------------------------------------------
+#
+# Installed between ``RequestIDMiddleware`` (outermost, binds request_id) and
+# ``ExceptionEnvelopeMiddleware`` so:
+#
+# 1. Log events emitted from the middleware carry ``request_id``.
+# 2. Any ``HTTPException`` raised by a downstream dependency (401, 403)
+#    flows through the envelope handler unchanged.
+#
+# On every request:
+#
+# - Reads ``settings.session_cookie_name`` from the request cookies.
+# - If present, makes a single ``GET session:<id>`` to Redis.
+# - On hit: populates ``request.state.auth`` with an :class:`AuthContext`.
+# - On miss, malformed payload, or malformed cookie: ``request.state.auth``
+#   is ``None`` and the response carries a ``Set-Cookie`` that clears the
+#   cookie (``Max-Age=0``).
+#
+# The middleware NEVER touches the database. Role data lives in the session
+# payload; see §2 of ``docs/design/auth-login-and-roles.md``.
+
+_SESSION_ID_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _session_id_hash(session_id: str) -> str:
+    """Return a short, non-reversible tag for a session ID.
+
+    Used in the one log event this middleware emits so operators can
+    correlate ``expired_cookie_cleared`` lines without the log stream
+    ever containing a raw, re-usable session ID.
+    """
+
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:16]
+
+
+class SessionMiddleware:
+    """Resolve the session cookie to an :class:`AuthContext`.
+
+    Pure ASGI middleware (same style as :class:`RequestIDMiddleware`) to
+    avoid ``BaseHTTPMiddleware``'s streaming-response pitfalls.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(
+        self, scope: Scope, receive: Receive, send: Send
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Deferred imports so test code that overrides settings via
+        # ``dependency_overrides`` or env mutations still picks up fresh
+        # values on each app build.
+        from app.auth import sessions
+        from app.auth.schemas import AuthContext
+        from app.logging import get_logger
+        from app.settings import Settings
+
+        log = get_logger(__name__)
+
+        settings: Settings | None = None
+        redis = None
+        # The app is always available on the scope in Starlette/FastAPI.
+        app_obj = scope.get("app")
+        if app_obj is not None:
+            settings = getattr(app_obj.state, "settings", None)
+            redis = getattr(app_obj.state, "redis", None)
+
+        # Defensive fallback: if the app hasn't been fully bootstrapped
+        # yet (test builds that skip lifespan, unusual ordering), behave
+        # like the anonymous path so we never raise from middleware.
+        cookie_name = (
+            settings.session_cookie_name
+            if settings is not None
+            else "session"
+        )
+
+        # Pull the cookie value out of the headers without constructing
+        # a full Starlette ``Request`` (cheaper; avoids early body reads).
+        raw_cookie_header = _read_header(scope, b"cookie")
+        cookie_value: str | None = None
+        if raw_cookie_header:
+            try:
+                jar = SimpleCookie()
+                jar.load(raw_cookie_header)
+                morsel = jar.get(cookie_name)
+                if morsel is not None:
+                    cookie_value = morsel.value
+            except Exception:  # noqa: BLE001 - defensive
+                cookie_value = None
+
+        ctx: AuthContext | None = None
+        clear_cookie_reason: str | None = None
+
+        if cookie_value is not None and redis is not None:
+            if not _SESSION_ID_PATTERN.match(cookie_value):
+                # Cookie was present but obviously not one we minted
+                # (wrong length, non-hex). Clear and log.
+                clear_cookie_reason = "malformed_cookie"
+            else:
+                # One Redis GET. sessions.get already collapses
+                # "missing key" and "malformed payload" to None, but we
+                # want to distinguish them for the log line, so probe
+                # the raw value first.
+                raw = await redis.get(f"session:{cookie_value}")
+                if raw is None:
+                    clear_cookie_reason = "missing_key"
+                else:
+                    ctx = await sessions.get(cookie_value, redis=redis)
+                    if ctx is None:
+                        clear_cookie_reason = "malformed_payload"
+
+        # Stash the result so downstream dependencies can read it.
+        # Starlette copies ``scope["state"]`` onto ``request.state`` for
+        # each request, so this is visible as ``request.state.auth``.
+        state = scope.setdefault("state", {})
+        state["auth"] = ctx
+
+        if clear_cookie_reason is not None and cookie_value is not None:
+            log.info(
+                "auth.session.expired_cookie_cleared",
+                reason=clear_cookie_reason,
+                session_id_hash=_session_id_hash(cookie_value),
+            )
+
+        if clear_cookie_reason is None:
+            await self.app(scope, receive, send)
+            return
+
+        # Need to rewrite response headers to append a Set-Cookie that
+        # clears the bad cookie. ``secure`` flag is echoed from settings
+        # so staging/prod clears are also marked Secure.
+        secure = (
+            settings.session_cookie_secure if settings is not None else False
+        )
+        clear_cookie_header = _build_clear_cookie_header(cookie_name, secure)
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers") or [])
+                headers.append((b"set-cookie", clear_cookie_header))
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+def _read_header(scope: Scope, name: bytes) -> str | None:
+    """Return the first value for ``name`` (lower-case, bytes) or ``None``."""
+
+    for k, v in scope.get("headers", []) or []:
+        if k == name:
+            try:
+                return v.decode("latin-1")
+            except Exception:  # noqa: BLE001 - defensive
+                return None
+    return None
+
+
+def _build_clear_cookie_header(name: str, secure: bool) -> bytes:
+    """Build a ``Set-Cookie`` value that clears ``name``.
+
+    Attributes match the mint path so the browser treats the clear
+    as a scope-identical overwrite: ``Path=/``, ``HttpOnly``,
+    ``SameSite=Lax``, plus ``Secure`` when configured.
+    """
+
+    parts = [
+        f"{name}=",
+        "Max-Age=0",
+        "Path=/",
+        "HttpOnly",
+        "SameSite=Lax",
+    ]
+    if secure:
+        parts.append("Secure")
+    return "; ".join(parts).encode("latin-1")
+
+
+__all__ = [
+    "RequestIDMiddleware",
+    "ExceptionEnvelopeMiddleware",
+    "SessionMiddleware",
+]

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -37,6 +37,33 @@ class Settings(BaseSettings):
 
     request_id_header: str = "X-Request-ID"
 
+    # ---- Auth (feat_auth_001) -------------------------------------------
+    # Session cookie and role-bootstrap controls for the auth foundation.
+    # See ``docs/design/auth-login-and-roles.md`` §§2, 8, 11 for rationale.
+    session_cookie_name: str = "session"
+    session_ttl_seconds: int = 86400
+    session_cookie_secure: bool = False
+    # Raw comma-separated list; parse via :attr:`admin_emails_set`. Empty
+    # string (the default) yields an empty set, so a fresh clone grants
+    # admin to nobody.
+    admin_emails: str = ""
+
+    @property
+    def admin_emails_set(self) -> frozenset[str]:
+        """Parsed, lower-cased set of bootstrap-admin email addresses.
+
+        Empty fragments (from trailing or duplicate commas) are skipped.
+        Whitespace around each entry is stripped. Matching against a user
+        email is case-insensitive because the stored form is lower-cased
+        and callers lower-case the probe value.
+        """
+
+        return frozenset(
+            e.strip().lower()
+            for e in self.admin_emails.split(",")
+            if e.strip()
+        )
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/backend/tests/test_auth_bootstrap.py
+++ b/backend/tests/test_auth_bootstrap.py
@@ -3,6 +3,14 @@
 Covers every case in ``test_auth_001.md`` → ``test_auth_bootstrap.py``.
 Each test exercises ``grant_admin_if_listed`` against a fresh session
 opened on the real test database.
+
+Note on role readback: we verify role membership by re-reading the
+``user_roles`` association table with an explicit JOIN, rather than by
+touching :attr:`User.roles` on the async-session-live instance. The ORM
+relationship's implicit lazy load is not bridged to ``await`` in
+SQLAlchemy 2.x async sessions (``MissingGreenlet``), and this module is
+the one that enforces that the *production* code goes through explicit
+SELECTs — so the test suite follows the same rule.
 """
 
 from __future__ import annotations
@@ -15,7 +23,7 @@ from app.auth.bootstrap import (
     admin_emails_from_settings,
     grant_admin_if_listed,
 )
-from app.auth.models import User
+from app.auth.models import Role, User, UserRole
 from app.db import build_sessionmaker
 from app.settings import Settings, reset_settings_cache
 
@@ -31,9 +39,6 @@ async def db_session(require_db):
     try:
         sm = build_sessionmaker(engine)
         async with engine.begin() as conn:
-            # Truncate with CASCADE to reset ``users``, ``user_roles``,
-            # and ``auth_identities`` between tests without touching
-            # ``roles`` (which is seeded by the migration).
             await conn.execute(
                 text(
                     "TRUNCATE TABLE auth_identities, user_roles, users "
@@ -57,6 +62,18 @@ async def _make_user(
     return user
 
 
+async def _role_names(session, user_id: int) -> set[str]:
+    """Return the role names currently granted to ``user_id``."""
+
+    result = await session.execute(
+        select(Role.name)
+        .select_from(UserRole)
+        .join(Role, Role.id == UserRole.role_id)
+        .where(UserRole.user_id == user_id)
+    )
+    return {name for (name,) in result.all()}
+
+
 def _settings(admin_emails: str) -> Settings:
     """Build a ``Settings`` instance without touching env vars."""
 
@@ -72,9 +89,10 @@ async def test_empty_admin_emails_never_grants(db_session):
     granted = await grant_admin_if_listed(
         user, session=db_session, settings=settings
     )
+    await db_session.commit()
 
     assert granted is False
-    assert [r.name for r in user.roles] == []
+    assert await _role_names(db_session, user.id) == set()
 
 
 async def test_exact_match_grants(db_session):
@@ -86,9 +104,10 @@ async def test_exact_match_grants(db_session):
     granted = await grant_admin_if_listed(
         user, session=db_session, settings=settings
     )
+    await db_session.commit()
 
     assert granted is True
-    assert "admin" in [r.name for r in user.roles]
+    assert "admin" in await _role_names(db_session, user.id)
 
 
 async def test_case_insensitive_match(db_session):
@@ -100,9 +119,10 @@ async def test_case_insensitive_match(db_session):
     granted = await grant_admin_if_listed(
         user, session=db_session, settings=settings
     )
+    await db_session.commit()
 
     assert granted is True
-    assert "admin" in [r.name for r in user.roles]
+    assert "admin" in await _role_names(db_session, user.id)
 
 
 async def test_whitespace_tolerant(db_session):
@@ -114,9 +134,10 @@ async def test_whitespace_tolerant(db_session):
     granted = await grant_admin_if_listed(
         user, session=db_session, settings=settings
     )
+    await db_session.commit()
 
     assert granted is True
-    assert "admin" in [r.name for r in user.roles]
+    assert "admin" in await _role_names(db_session, user.id)
 
 
 async def test_non_member_not_granted(db_session):
@@ -128,9 +149,10 @@ async def test_non_member_not_granted(db_session):
     granted = await grant_admin_if_listed(
         user, session=db_session, settings=settings
     )
+    await db_session.commit()
 
     assert granted is False
-    assert "admin" not in [r.name for r in user.roles]
+    assert "admin" not in await _role_names(db_session, user.id)
 
 
 def test_settings_cache_reflects_env(monkeypatch):
@@ -167,13 +189,27 @@ async def test_idempotent_grant(db_session):
     second = await grant_admin_if_listed(
         user, session=db_session, settings=settings
     )
+    await db_session.commit()
 
     assert first is True
     # Second call returns False because the role is already present.
     assert second is False
 
-    admin_count = sum(1 for r in user.roles if r.name == "admin")
-    assert admin_count == 1
+    # Exactly one row in user_roles linking user -> admin role.
+    result = await db_session.execute(
+        select(UserRole).where(UserRole.user_id == user.id)
+    )
+    rows = result.scalars().all()
+    admin_ids = {
+        r[0]
+        for r in (
+            await db_session.execute(
+                select(Role.id).where(Role.name == "admin")
+            )
+        ).all()
+    }
+    admin_rows = [r for r in rows if r.role_id in admin_ids]
+    assert len(admin_rows) == 1
 
 
 def test_admin_emails_from_settings_helper():

--- a/backend/tests/test_auth_bootstrap.py
+++ b/backend/tests/test_auth_bootstrap.py
@@ -1,0 +1,184 @@
+"""Unit tests for :mod:`app.auth.bootstrap`.
+
+Covers every case in ``test_auth_001.md`` → ``test_auth_bootstrap.py``.
+Each test exercises ``grant_admin_if_listed`` against a fresh session
+opened on the real test database.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.auth.bootstrap import (
+    admin_emails_from_settings,
+    grant_admin_if_listed,
+)
+from app.auth.models import User
+from app.db import build_sessionmaker
+from app.settings import Settings, reset_settings_cache
+
+
+@pytest.fixture
+async def db_session(require_db):
+    """Yield an ``AsyncSession`` bound to the configured test database.
+
+    Each test starts from a clean ``users`` / ``user_roles`` state.
+    """
+
+    engine = create_async_engine(require_db)
+    try:
+        sm = build_sessionmaker(engine)
+        async with engine.begin() as conn:
+            # Truncate with CASCADE to reset ``users``, ``user_roles``,
+            # and ``auth_identities`` between tests without touching
+            # ``roles`` (which is seeded by the migration).
+            await conn.execute(
+                text(
+                    "TRUNCATE TABLE auth_identities, user_roles, users "
+                    "RESTART IDENTITY CASCADE"
+                )
+            )
+        async with sm() as session:
+            yield session
+    finally:
+        await engine.dispose()
+
+
+async def _make_user(
+    session, email: str, display_name: str | None = None
+) -> User:
+    """Insert a fresh :class:`User` with no roles attached."""
+
+    user = User(email=email, display_name=display_name)
+    session.add(user)
+    await session.flush()
+    return user
+
+
+def _settings(admin_emails: str) -> Settings:
+    """Build a ``Settings`` instance without touching env vars."""
+
+    return Settings(admin_emails=admin_emails)
+
+
+async def test_empty_admin_emails_never_grants(db_session):
+    """Case 1: empty list is a no-op."""
+
+    user = await _make_user(db_session, "alice@x.com")
+    settings = _settings("")
+
+    granted = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+
+    assert granted is False
+    assert [r.name for r in user.roles] == []
+
+
+async def test_exact_match_grants(db_session):
+    """Case 2: email in the list grants the ``admin`` role."""
+
+    user = await _make_user(db_session, "alice@x.com")
+    settings = _settings("alice@x.com")
+
+    granted = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+
+    assert granted is True
+    assert "admin" in [r.name for r in user.roles]
+
+
+async def test_case_insensitive_match(db_session):
+    """Case 3: case differences in the env list still grant."""
+
+    user = await _make_user(db_session, "alice@x.com")
+    settings = _settings("ALICE@x.com")
+
+    granted = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+
+    assert granted is True
+    assert "admin" in [r.name for r in user.roles]
+
+
+async def test_whitespace_tolerant(db_session):
+    """Case 4: leading/trailing whitespace is stripped per entry."""
+
+    user = await _make_user(db_session, "bob@x.com")
+    settings = _settings(" alice@x.com , bob@x.com ")
+
+    granted = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+
+    assert granted is True
+    assert "admin" in [r.name for r in user.roles]
+
+
+async def test_non_member_not_granted(db_session):
+    """Case 5: an email not in the list is not granted admin."""
+
+    user = await _make_user(db_session, "carol@x.com")
+    settings = _settings("alice@x.com,bob@x.com")
+
+    granted = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+
+    assert granted is False
+    assert "admin" not in [r.name for r in user.roles]
+
+
+def test_settings_cache_reflects_env(monkeypatch):
+    """Case 6: resetting the cache after ``monkeypatch.setenv`` picks up the
+    new value."""
+
+    from app.settings import get_settings
+
+    monkeypatch.setenv("ADMIN_EMAILS", "first@x.com")
+    reset_settings_cache()
+    try:
+        s1 = get_settings()
+        assert "first@x.com" in s1.admin_emails_set
+
+        monkeypatch.setenv("ADMIN_EMAILS", "second@x.com")
+        reset_settings_cache()
+
+        s2 = get_settings()
+        assert "second@x.com" in s2.admin_emails_set
+        assert "first@x.com" not in s2.admin_emails_set
+    finally:
+        reset_settings_cache()
+
+
+async def test_idempotent_grant(db_session):
+    """Case 7: calling twice does not produce two ``admin`` rows."""
+
+    user = await _make_user(db_session, "alice@x.com")
+    settings = _settings("alice@x.com")
+
+    first = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+    second = await grant_admin_if_listed(
+        user, session=db_session, settings=settings
+    )
+
+    assert first is True
+    # Second call returns False because the role is already present.
+    assert second is False
+
+    admin_count = sum(1 for r in user.roles if r.name == "admin")
+    assert admin_count == 1
+
+
+def test_admin_emails_from_settings_helper():
+    """The helper is a thin pass-through to the settings property."""
+
+    s = _settings("  a@x.com, B@x.com ,, c@x.com  ")
+    got = admin_emails_from_settings(s)
+    assert got == frozenset({"a@x.com", "b@x.com", "c@x.com"})

--- a/backend/tests/test_auth_dependencies.py
+++ b/backend/tests/test_auth_dependencies.py
@@ -1,0 +1,117 @@
+"""Unit tests for :mod:`app.auth.dependencies`.
+
+These do not spin up the FastAPI app. They exercise the three helpers
+(``current_user``, ``require_authenticated``, ``require_roles``) directly
+against a fabricated ``request.state.auth`` to verify:
+
+- Authentication precedes authorization (401 before 403).
+- ``require_roles`` has OR semantics across the names it is given.
+- Missing state is treated the same as explicit ``None``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth.dependencies import (
+    current_user,
+    require_authenticated,
+    require_roles,
+)
+from app.auth.schemas import AuthContext
+
+
+def _fake_request(auth: Any) -> Any:
+    """Build a minimal object exposing ``state.auth`` for the dependency."""
+
+    return SimpleNamespace(state=SimpleNamespace(auth=auth))
+
+
+def _ctx(roles: tuple[str, ...] = ("user",)) -> AuthContext:
+    return AuthContext(
+        user_id=1,
+        email="a@x.com",
+        roles=roles,
+        session_id="a" * 64,
+    )
+
+
+def test_current_user_returns_context_when_authenticated():
+    ctx = _ctx()
+    req = _fake_request(ctx)
+    assert current_user(req) is ctx
+
+
+def test_current_user_raises_401_when_none():
+    req = _fake_request(None)
+    with pytest.raises(HTTPException) as ei:
+        current_user(req)
+    assert ei.value.status_code == 401
+    assert ei.value.detail == "not_authenticated"
+
+
+def test_require_authenticated_is_an_alias_for_current_user():
+    # Same function object; same semantics.
+    assert require_authenticated is current_user
+
+    req = _fake_request(None)
+    with pytest.raises(HTTPException) as ei:
+        require_authenticated(req)
+    assert ei.value.status_code == 401
+    assert ei.value.detail == "not_authenticated"
+
+
+def test_require_roles_single_match():
+    dep = require_roles("user")
+    ctx = _ctx(("user",))
+    req = _fake_request(ctx)
+    assert dep(req) is ctx
+
+
+def test_require_roles_single_miss_returns_403():
+    dep = require_roles("admin")
+    ctx = _ctx(("user",))
+    req = _fake_request(ctx)
+    with pytest.raises(HTTPException) as ei:
+        dep(req)
+    assert ei.value.status_code == 403
+    assert ei.value.detail == "forbidden"
+
+
+def test_require_roles_or_semantics_first_matches():
+    dep = require_roles("admin", "user")
+    ctx = _ctx(("admin",))
+    req = _fake_request(ctx)
+    assert dep(req) is ctx
+
+
+def test_require_roles_or_semantics_second_matches():
+    dep = require_roles("admin", "user")
+    ctx = _ctx(("user",))
+    req = _fake_request(ctx)
+    assert dep(req) is ctx
+
+
+def test_require_roles_neither_matches_returns_403():
+    dep = require_roles("admin", "user")
+    ctx = _ctx(("guest",))
+    req = _fake_request(ctx)
+    with pytest.raises(HTTPException) as ei:
+        dep(req)
+    assert ei.value.status_code == 403
+    assert ei.value.detail == "forbidden"
+
+
+def test_require_roles_no_session_returns_401_not_403():
+    """Unauthenticated wins over unauthorized."""
+
+    dep = require_roles("admin")
+    req = _fake_request(None)
+    with pytest.raises(HTTPException) as ei:
+        dep(req)
+    assert ei.value.status_code == 401
+    assert ei.value.detail == "not_authenticated"

--- a/backend/tests/test_auth_me_logout.py
+++ b/backend/tests/test_auth_me_logout.py
@@ -1,0 +1,314 @@
+"""End-to-end tests for the ``/auth/me`` + ``/auth/logout`` pair.
+
+Exercises the full lifecycle through the env-gated test-only mint endpoint:
+
+mint → /auth/me → /auth/logout → /auth/me (401).
+
+Also covers ``ADMIN_EMAILS`` bootstrap, extra-roles parameter, idempotent
+mint, cookie attributes, and ``revoke_sessions_for_user`` end-to-end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.auth import service
+from app.auth.models import AuthIdentity, User
+from app.db import build_sessionmaker
+from app.main import create_app
+from app.settings import Settings, reset_settings_cache
+
+
+@pytest.fixture
+async def clean_db(require_db) -> str:
+    """Return the DB URL after truncating the auth tables."""
+
+    engine = create_async_engine(require_db)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "TRUNCATE TABLE auth_identities, user_roles, users "
+                    "RESTART IDENTITY CASCADE"
+                )
+            )
+    finally:
+        await engine.dispose()
+    return require_db
+
+
+async def _build_client(settings: Settings):
+    app = create_app(settings)
+    return app, app.router.lifespan_context(app)
+
+
+@pytest.fixture
+async def client_for_settings(require_db, require_redis, clean_db):
+    """Factory that builds an ``httpx`` client for a given Settings."""
+
+    opened: list = []
+
+    async def _open(settings: Settings):
+        reset_settings_cache()
+        app = create_app(settings)
+        cm = app.router.lifespan_context(app)
+        await cm.__aenter__()
+        # Scrub redis between builds.
+        await app.state.redis.flushdb()
+        transport = ASGITransport(app=app)
+        client = AsyncClient(transport=transport, base_url="http://test")
+        await client.__aenter__()
+        opened.append((app, cm, client))
+        return app, client
+
+    yield _open
+
+    for app, cm, client in opened:
+        try:
+            await client.__aexit__(None, None, None)
+        finally:
+            await cm.__aexit__(None, None, None)
+
+
+def _cookie_from(resp) -> str:
+    set_cookie = resp.headers.get("set-cookie") or ""
+    pairs = set_cookie.split(";")
+    first = pairs[0].strip()
+    assert first.startswith("session="), set_cookie
+    return first.removeprefix("session=")
+
+
+async def test_happy_path_mint_me_logout_me(client_for_settings):
+    _app, client = await client_for_settings(Settings(env="test"))
+
+    # 1. Mint
+    mint = await client.post(
+        "/api/v1/_test/session",
+        json={"email": "a@x.com", "display_name": "Alice"},
+    )
+    assert mint.status_code == 200, mint.text
+    sid = _cookie_from(mint)
+    body = mint.json()
+    assert body["email"] == "a@x.com"
+    assert body["display_name"] == "Alice"
+    assert body["roles"] == ["user"]
+
+    # 2. /auth/me (1)
+    me1 = await client.get(
+        "/api/v1/auth/me", cookies={"session": sid}
+    )
+    assert me1.status_code == 200
+    b1 = me1.json()
+    assert b1["email"] == "a@x.com"
+    assert b1["display_name"] == "Alice"
+    assert b1["roles"] == ["user"]
+
+    # 3. /auth/logout
+    logout = await client.post(
+        "/api/v1/auth/logout", cookies={"session": sid}
+    )
+    assert logout.status_code == 204
+    # Cookie cleared.
+    set_cookie = logout.headers.get("set-cookie") or ""
+    assert "session=" in set_cookie
+    assert "Max-Age=0" in set_cookie or "max-age=0" in set_cookie.lower()
+
+    # 4. /auth/me (2) — session is gone.
+    me2 = await client.get(
+        "/api/v1/auth/me", cookies={"session": sid}
+    )
+    assert me2.status_code == 401
+
+
+async def test_admin_emails_bootstrap(client_for_settings):
+    _app, client = await client_for_settings(
+        Settings(env="test", admin_emails="alice@x.com")
+    )
+
+    mint = await client.post(
+        "/api/v1/_test/session",
+        json={"email": "alice@x.com"},
+    )
+    assert mint.status_code == 200, mint.text
+    sid = _cookie_from(mint)
+
+    me = await client.get("/api/v1/auth/me", cookies={"session": sid})
+    assert me.status_code == 200
+    roles = set(me.json()["roles"])
+    assert roles == {"user", "admin"}
+
+
+async def test_non_bootstrap_user_only_gets_user(client_for_settings):
+    _app, client = await client_for_settings(
+        Settings(env="test", admin_emails="alice@x.com")
+    )
+
+    mint = await client.post(
+        "/api/v1/_test/session",
+        json={"email": "bob@x.com"},
+    )
+    assert mint.status_code == 200
+    sid = _cookie_from(mint)
+
+    me = await client.get("/api/v1/auth/me", cookies={"session": sid})
+    assert me.status_code == 200
+    assert me.json()["roles"] == ["user"]
+
+
+async def test_extra_roles_parameter(client_for_settings):
+    _app, client = await client_for_settings(Settings(env="test"))
+
+    mint = await client.post(
+        "/api/v1/_test/session",
+        json={"email": "a@x.com", "roles": ["admin"]},
+    )
+    assert mint.status_code == 200, mint.text
+    sid = _cookie_from(mint)
+
+    me = await client.get("/api/v1/auth/me", cookies={"session": sid})
+    assert me.status_code == 200
+    roles = set(me.json()["roles"])
+    # User always granted as the default; admin granted via extra_roles.
+    assert roles == {"user", "admin"}
+
+
+async def test_idempotent_mint(client_for_settings, require_db):
+    _app, client = await client_for_settings(Settings(env="test"))
+
+    r1 = await client.post(
+        "/api/v1/_test/session",
+        json={"email": "a@x.com"},
+    )
+    r2 = await client.post(
+        "/api/v1/_test/session",
+        json={"email": "a@x.com"},
+    )
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+
+    # Exactly one users row and zero auth_identities rows for that email.
+    engine = create_async_engine(require_db)
+    try:
+        sm = build_sessionmaker(engine)
+        async with sm() as session:
+            users = (
+                await session.execute(
+                    select(User).where(User.email == "a@x.com")
+                )
+            ).scalars().all()
+            assert len(users) == 1
+
+            identities = (
+                await session.execute(
+                    select(AuthIdentity).where(
+                        AuthIdentity.user_id == users[0].id
+                    )
+                )
+            ).scalars().all()
+            assert identities == []
+    finally:
+        await engine.dispose()
+
+
+async def test_revoke_sessions_for_user_end_to_end(client_for_settings):
+    app, client = await client_for_settings(Settings(env="test"))
+
+    # Mint two sessions for the same user (two separate POSTs).
+    m1 = await client.post(
+        "/api/v1/_test/session", json={"email": "a@x.com"}
+    )
+    sid_a = _cookie_from(m1)
+
+    m2 = await client.post(
+        "/api/v1/_test/session", json={"email": "a@x.com"}
+    )
+    sid_b = _cookie_from(m2)
+
+    assert sid_a != sid_b
+
+    # Pull the user ID out of /auth/me.
+    probe = await client.get(
+        "/api/v1/auth/me", cookies={"session": sid_a}
+    )
+    user_id = probe.json()["user_id"]
+
+    # Revoke every session for this user.
+    await service.revoke_sessions_for_user(user_id, redis=app.state.redis)
+
+    # Both cookies should now be dead.
+    r1 = await client.get("/api/v1/auth/me", cookies={"session": sid_a})
+    r2 = await client.get("/api/v1/auth/me", cookies={"session": sid_b})
+    assert r1.status_code == 401
+    assert r2.status_code == 401
+
+    # Reverse index is gone.
+    assert await app.state.redis.exists(f"user_sessions:{user_id}") == 0
+
+
+async def test_no_cookie_me_returns_401(client_for_settings):
+    _app, client = await client_for_settings(Settings(env="test"))
+    resp = await client.get("/api/v1/auth/me")
+    assert resp.status_code == 401
+    assert resp.json()["error"]["message"] == "not_authenticated"
+
+
+async def test_logout_without_session_is_401(client_for_settings):
+    app, client = await client_for_settings(Settings(env="test"))
+    redis = app.state.redis
+
+    # Capture Redis commands by intercepting execute_command. The logout
+    # handler should never reach the ``delete`` call on an unauthenticated
+    # request — the ``current_user`` dependency short-circuits first.
+    captured: list[str] = []
+    orig = redis.execute_command
+
+    async def spy(*args, **kwargs):
+        captured.append(str(args[0]).upper() if args else "")
+        return await orig(*args, **kwargs)
+
+    redis.execute_command = spy  # type: ignore[assignment]
+    try:
+        resp = await client.post("/api/v1/auth/logout")
+    finally:
+        redis.execute_command = orig  # type: ignore[assignment]
+
+    assert resp.status_code == 401
+    # No DEL issued against any session key.
+    assert not any(cmd == "DEL" for cmd in captured), captured
+
+
+async def test_cookie_attributes_insecure(client_for_settings):
+    _app, client = await client_for_settings(
+        Settings(env="test", session_cookie_secure=False)
+    )
+
+    mint = await client.post(
+        "/api/v1/_test/session", json={"email": "a@x.com"}
+    )
+    assert mint.status_code == 200
+    sc = mint.headers.get("set-cookie", "")
+
+    assert "HttpOnly" in sc
+    assert "SameSite=Lax" in sc or "samesite=lax" in sc.lower()
+    assert "Path=/" in sc
+    # Max-Age matches the default settings.session_ttl_seconds (86400).
+    assert "Max-Age=86400" in sc or "max-age=86400" in sc.lower()
+    # Secure absent.
+    assert "Secure" not in sc
+
+
+async def test_cookie_attributes_secure(client_for_settings):
+    _app, client = await client_for_settings(
+        Settings(env="test", session_cookie_secure=True)
+    )
+
+    mint = await client.post(
+        "/api/v1/_test/session", json={"email": "a@x.com"}
+    )
+    assert mint.status_code == 200
+    sc = mint.headers.get("set-cookie", "")
+
+    assert "Secure" in sc

--- a/backend/tests/test_auth_middleware.py
+++ b/backend/tests/test_auth_middleware.py
@@ -1,0 +1,224 @@
+"""Integration tests for :class:`app.middleware.SessionMiddleware`.
+
+Exercises the middleware behaviour end-to-end through ``httpx.AsyncClient``:
+
+- No cookie → request goes through with ``request.state.auth = None``.
+- Valid cookie → ``request.state.auth`` is populated from the Redis payload.
+- Expired / malformed session → 401 from the dependency, ``Set-Cookie``
+  clears the cookie, a log event is emitted.
+- ``RequestIDMiddleware`` remains outermost (log event carries ``request_id``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+from app.settings import Settings, reset_settings_cache
+
+
+@pytest.fixture
+def test_settings(require_db, require_redis) -> Settings:
+    """Settings pinned to ``env=test`` so the mint endpoint is mounted."""
+
+    reset_settings_cache()
+    return Settings(env="test")
+
+
+@pytest.fixture
+async def app_and_client(test_settings):
+    app = create_app(test_settings)
+    async with app.router.lifespan_context(app):
+        # Also flush Redis so no state leaks across tests in this module.
+        redis = app.state.redis
+        await redis.flushdb()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            yield app, client
+        await redis.flushdb()
+
+
+async def test_no_cookie_public_endpoint_has_no_set_cookie(app_and_client):
+    _app, client = app_and_client
+
+    resp = await client.get("/healthz")
+
+    assert resp.status_code == 200
+    # No Set-Cookie at all — public endpoint, no session work happened.
+    assert "set-cookie" not in {k.lower() for k in resp.headers.keys()}
+
+
+async def _mint(client: AsyncClient, email: str) -> str:
+    """Mint via the test-only endpoint and return the ``session`` cookie."""
+
+    resp = await client.post(
+        "/api/v1/_test/session",
+        json={"email": email, "display_name": "Tester"},
+    )
+    assert resp.status_code == 200, resp.text
+    set_cookie = resp.headers.get("set-cookie")
+    assert set_cookie, "test mint did not set a cookie"
+    # Extract the ``session=<id>`` value from the header.
+    value = set_cookie.split(";", 1)[0]
+    assert "=" in value
+    name, raw = value.split("=", 1)
+    assert name.strip() == "session"
+    return raw
+
+
+async def test_valid_cookie_populates_context(app_and_client):
+    _app, client = app_and_client
+
+    session_id = await _mint(client, "a@x.com")
+
+    # Now call /auth/me carrying the cookie and verify the payload the
+    # middleware's context produced.
+    resp = await client.get(
+        "/api/v1/auth/me",
+        cookies={"session": session_id},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["email"] == "a@x.com"
+    assert "user" in body["roles"]
+
+
+async def test_expired_session_clears_cookie(app_and_client):
+    app, client = app_and_client
+    redis = app.state.redis
+
+    session_id = await _mint(client, "b@x.com")
+
+    # Simulate expiry by deleting the session key directly in Redis.
+    await redis.delete(f"session:{session_id}")
+
+    resp = await client.get(
+        "/api/v1/auth/me",
+        cookies={"session": session_id},
+    )
+    assert resp.status_code == 401
+    body = resp.json()
+    # HTTPException(detail="not_authenticated") envelope-wrapped.
+    assert body["error"]["message"] == "not_authenticated"
+
+    # Set-Cookie clears the cookie.
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "session=" in set_cookie
+    assert "Max-Age=0" in set_cookie
+
+
+async def test_malformed_payload_clears_cookie(app_and_client, caplog):
+    app, client = app_and_client
+    redis = app.state.redis
+
+    session_id = await _mint(client, "c@x.com")
+
+    # Overwrite the session key with non-JSON to trigger the
+    # ``malformed_payload`` branch.
+    await redis.set(f"session:{session_id}", "not json")
+
+    with caplog.at_level(logging.INFO):
+        resp = await client.get(
+            "/api/v1/auth/me",
+            cookies={"session": session_id},
+        )
+
+    assert resp.status_code == 401
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "Max-Age=0" in set_cookie
+
+    # Log line should say ``reason=malformed_payload``. The structured
+    # logger renders JSON records on stdout; ``caplog`` captures the raw
+    # ``LogRecord.getMessage`` which is the positional event name in our
+    # wiring.
+    events = [
+        r
+        for r in caplog.records
+        if "auth.session.expired_cookie_cleared" in r.getMessage()
+        or "malformed_payload" in r.getMessage()
+    ]
+    assert events, f"no expected log record in {caplog.text}"
+
+
+async def test_malformed_cookie_clears_cookie(app_and_client, caplog):
+    _app, client = app_and_client
+
+    # 60 hex chars is not 64; middleware should treat it as malformed.
+    with caplog.at_level(logging.INFO):
+        resp = await client.get(
+            "/api/v1/auth/me",
+            cookies={"session": "a" * 60},
+        )
+
+    assert resp.status_code == 401
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "Max-Age=0" in set_cookie
+
+    events = [
+        r
+        for r in caplog.records
+        if "auth.session.expired_cookie_cleared" in r.getMessage()
+        or "malformed_cookie" in r.getMessage()
+    ]
+    assert events, f"no expected log record in {caplog.text}"
+
+
+async def test_middleware_runs_after_request_id(app_and_client):
+    _app, client = app_and_client
+
+    # Just confirm that a request that hits our middleware path still
+    # carries the X-Request-ID header, proving RequestIDMiddleware is
+    # still outermost.
+    resp = await client.get(
+        "/api/v1/auth/me",
+        cookies={"session": "f" * 64},  # malformed-length? no, length OK
+    )
+    # With a syntactically valid-looking but missing session:
+    # the middleware logs ``missing_key`` and clears the cookie; the
+    # response carries an X-Request-ID from the outer middleware.
+    assert resp.status_code == 401
+    rid = resp.headers.get("x-request-id")
+    assert rid and len(rid) >= 8
+
+
+async def test_no_db_hit_on_missing_cookie(app_and_client):
+    """Calling /healthz while no cookie is set does not trigger a DB query.
+
+    This is a weak proxy for the middleware's "no DB hit per request"
+    invariant — in practice middleware runs on every request, and we
+    want it to stay out of the data layer. A stronger check would wire
+    a SQLAlchemy event listener; for now we rely on the fact that a
+    successful /healthz only ever touches app.state.
+    """
+
+    app, client = app_and_client
+
+    # Use the engine's pool-reset event to count connection checkouts.
+    # If the middleware touched the DB, we would see a checkout count
+    # after the probe.
+    engine = app.state.engine
+    counts = {"checkouts": 0}
+
+    from sqlalchemy import event
+
+    def _on_checkout(*_args, **_kwargs):
+        counts["checkouts"] += 1
+
+    event.listen(engine.sync_engine, "checkout", _on_checkout)
+    try:
+        resp = await client.get("/healthz")
+    finally:
+        event.remove(engine.sync_engine, "checkout", _on_checkout)
+
+    assert resp.status_code == 200
+    assert counts["checkouts"] == 0
+
+
+# Silence unused-import warnings in CI tools that scan strictly.
+_ = json

--- a/backend/tests/test_auth_sessions.py
+++ b/backend/tests/test_auth_sessions.py
@@ -1,0 +1,176 @@
+"""Unit tests for :mod:`app.auth.sessions`.
+
+These are "unit" tests in the sense that they exercise the Redis store
+helpers directly — no FastAPI app, no middleware — but they *do* talk to
+a real Redis. If Redis is unreachable at the configured URL the whole
+module is skipped. Matches the existing scaffold's ``require_redis``
+pattern.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from redis.asyncio import from_url
+
+from app.auth import sessions
+from app.auth.schemas import AuthContext
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def redis(require_redis):
+    """A per-test Redis client tied to the configured URL.
+
+    Flushes the current DB before and after so a test never sees keys
+    left over from a prior run.
+    """
+
+    client = from_url(require_redis, encoding="utf-8", decode_responses=True)
+    try:
+        await client.flushdb()
+        yield client
+        await client.flushdb()
+    finally:
+        await client.aclose()
+
+
+def _user_like(user_id: int, email: str, role_names: list[str]) -> Any:
+    """Return an object with the attributes ``sessions.create`` reads."""
+
+    roles = [SimpleNamespace(name=n) for n in role_names]
+    return SimpleNamespace(id=user_id, email=email, roles=roles)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_create_round_trip(redis):
+    """Case 1: create writes both keys with the expected payload and TTL."""
+
+    user = _user_like(42, "a@x.com", ["user"])
+    ttl = 86400
+
+    session_id = await sessions.create(user, redis=redis, ttl_seconds=ttl)
+
+    # 64 hex chars, all [0-9a-f].
+    assert isinstance(session_id, str)
+    assert len(session_id) == 64
+    assert all(c in "0123456789abcdef" for c in session_id)
+
+    raw = await redis.get(f"session:{session_id}")
+    assert raw is not None
+    payload = json.loads(raw)
+    assert payload["user_id"] == 42
+    assert payload["email"] == "a@x.com"
+    assert payload["roles"] == ["user"]
+    assert "created_at" in payload
+
+    members = await redis.smembers("user_sessions:42")
+    assert session_id in members
+
+    session_ttl = await redis.ttl(f"session:{session_id}")
+    reverse_ttl = await redis.ttl("user_sessions:42")
+    assert 0 < session_ttl <= ttl
+    assert 0 < reverse_ttl <= ttl
+    # Both keys are expected to hit within a couple of seconds of ttl
+    # unless the CI box is pathologically slow.
+    assert session_ttl >= ttl - 5
+    assert reverse_ttl >= ttl - 5
+
+
+async def test_get_returns_auth_context(redis):
+    """Case 2: get returns an AuthContext that mirrors the payload."""
+
+    user = _user_like(42, "a@x.com", ["user"])
+    session_id = await sessions.create(user, redis=redis, ttl_seconds=600)
+
+    ctx = await sessions.get(session_id, redis=redis)
+
+    assert isinstance(ctx, AuthContext)
+    assert ctx.user_id == 42
+    assert ctx.email == "a@x.com"
+    assert ctx.roles == ("user",)
+    assert ctx.session_id == session_id
+
+
+async def test_get_missing_key_returns_none(redis):
+    """Case 3: a random session ID resolves to None."""
+
+    ctx = await sessions.get("a" * 64, redis=redis)
+    assert ctx is None
+
+
+async def test_get_malformed_payload_returns_none(redis):
+    """Case 4: non-JSON in the session key does not raise."""
+
+    session_id = "f" * 64
+    await redis.set(f"session:{session_id}", "not json")
+    ctx = await sessions.get(session_id, redis=redis)
+    assert ctx is None
+
+
+async def test_delete_wipes_both_keys(redis):
+    """Case 5: delete removes the session and reverse-index entry."""
+
+    user = _user_like(42, "a@x.com", ["user"])
+    session_id = await sessions.create(user, redis=redis, ttl_seconds=600)
+
+    await sessions.delete(session_id, 42, redis=redis)
+
+    raw = await redis.get(f"session:{session_id}")
+    assert raw is None
+
+    members = await redis.smembers("user_sessions:42")
+    assert session_id not in members
+
+
+async def test_revoke_all_for_user_drops_every_session(redis):
+    """Case 6: revoke_all_for_user wipes every session for a user."""
+
+    user = _user_like(42, "a@x.com", ["user"])
+    sid_a = await sessions.create(user, redis=redis, ttl_seconds=600)
+    sid_b = await sessions.create(user, redis=redis, ttl_seconds=600)
+
+    assert sid_a != sid_b
+
+    await sessions.revoke_all_for_user(42, redis=redis)
+
+    assert await redis.get(f"session:{sid_a}") is None
+    assert await redis.get(f"session:{sid_b}") is None
+    # Reverse index gone too.
+    assert await redis.exists("user_sessions:42") == 0
+
+
+async def test_revoke_all_for_user_noop_when_empty(redis):
+    """Case 7: calling revoke on a user with no sessions is a no-op."""
+
+    # Never-logged-in user ID; no arrangement.
+    await sessions.revoke_all_for_user(999_999, redis=redis)
+    # Nothing to assert except "did not raise"; sanity-check the key.
+    assert await redis.exists("user_sessions:999999") == 0
+
+
+async def test_ttl_is_exactly_session_ttl_seconds(redis):
+    """Case 8: TTL matches the configured value at creation time."""
+
+    user = _user_like(42, "a@x.com", ["user"])
+    await sessions.create(user, redis=redis, ttl_seconds=10)
+
+    members = await redis.smembers("user_sessions:42")
+    sid = next(iter(members))
+
+    session_ttl = await redis.ttl(f"session:{sid}")
+    reverse_ttl = await redis.ttl("user_sessions:42")
+
+    assert 8 <= session_ttl <= 10
+    assert 8 <= reverse_ttl <= 10

--- a/backend/tests/test_auth_test_mint_gating.py
+++ b/backend/tests/test_auth_test_mint_gating.py
@@ -1,0 +1,71 @@
+"""Verify the test-only mint endpoint is mounted only when ``env == "test"``.
+
+The real ``/auth/me`` is mounted in every environment; the env gate only
+applies to the mint. All four cases in ``test_auth_001.md`` →
+``test_auth_test_mint_gating.py`` are covered.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+from app.settings import Settings, reset_settings_cache
+
+
+async def _probe(settings: Settings, path: str, method: str = "GET", **kw):
+    reset_settings_cache()
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as c:
+            if method == "GET":
+                return await c.get(path, **kw)
+            return await c.post(path, **kw)
+
+
+@pytest.mark.parametrize("env", ["dev", "prod"])
+async def test_test_mint_not_mounted_outside_test(env):
+    resp = await _probe(
+        Settings(env=env),
+        "/api/v1/_test/session",
+        method="POST",
+        json={"email": "a@x.com"},
+    )
+    assert resp.status_code == 404
+
+
+async def test_test_mint_mounted_in_test(require_db, require_redis):
+    # Clean slate first: flush redis + truncate users to avoid collisions
+    # from other tests in this module.
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlalchemy import text
+
+    engine = create_async_engine(require_db)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "TRUNCATE TABLE auth_identities, user_roles, users "
+                    "RESTART IDENTITY CASCADE"
+                )
+            )
+    finally:
+        await engine.dispose()
+
+    resp = await _probe(
+        Settings(env="test"),
+        "/api/v1/_test/session",
+        method="POST",
+        json={"email": "a@x.com", "display_name": "Alice"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.parametrize("env", ["dev", "test", "prod"])
+async def test_auth_me_mounted_in_every_env(env):
+    resp = await _probe(Settings(env=env), "/api/v1/auth/me")
+    assert resp.status_code == 401

--- a/backend/tests/test_migration_0002_auth.py
+++ b/backend/tests/test_migration_0002_auth.py
@@ -1,0 +1,271 @@
+"""Verify the ``0002_create_auth`` migration against a real Postgres.
+
+Covers every row in ``test_auth_001.md`` → ``test_migration_0002_auth.py``:
+
+- Clean upgrade produces the four tables and two seed roles.
+- Clean downgrade drops the tables (the extension may remain
+  installed because Postgres ``DROP EXTENSION`` is ``IF EXISTS``-gated
+  above — we verify that the tables are gone).
+- ``CITEXT`` gives case-insensitive uniqueness on ``users.email``.
+- ``ON DELETE CASCADE`` on user deletion.
+- ``ON DELETE RESTRICT`` on role deletion.
+- Constraint names match the naming convention.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.db import build_sessionmaker
+
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+
+
+def _alembic(*args: str) -> None:
+    """Run ``alembic`` as a subprocess from the backend directory."""
+
+    subprocess.run(
+        ["uv", "run", "alembic", *args],
+        cwd=str(_BACKEND_DIR),
+        check=True,
+    )
+
+
+@pytest.fixture
+async def pg_engine(require_db):
+    engine = create_async_engine(require_db)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def upgraded_head(pg_engine):
+    """Ensure schema is at ``head`` before the test runs."""
+
+    # Alembic is async-capable in ``env.py``; we call it as a CLI so the
+    # subprocess drives the migrations through the configured DSN.
+    await asyncio.to_thread(_alembic, "upgrade", "head")
+    yield pg_engine
+    # Leave the DB at head so subsequent tests (that expect the schema
+    # to exist) still pass.
+
+
+async def test_upgrade_creates_tables_and_seeds_roles(upgraded_head):
+    async with upgraded_head.connect() as conn:
+        tables = {
+            row[0]
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT table_name FROM information_schema.tables "
+                        "WHERE table_schema='public'"
+                    )
+                )
+            ).all()
+        }
+        for expected in {
+            "users",
+            "roles",
+            "user_roles",
+            "auth_identities",
+        }:
+            assert expected in tables, f"{expected} not created"
+
+        role_names = {
+            row[0]
+            for row in (
+                await conn.execute(text("SELECT name FROM roles"))
+            ).all()
+        }
+        assert role_names == {"admin", "user"}
+
+        has_citext = (
+            (
+                await conn.execute(
+                    text(
+                        "SELECT count(*) FROM pg_extension "
+                        "WHERE extname='citext'"
+                    )
+                )
+            ).scalar_one()
+            == 1
+        )
+        assert has_citext
+
+
+async def test_downgrade_then_upgrade(pg_engine, require_db):
+    # First: downgrade -1 (to 0001) to drop the auth tables.
+    await asyncio.to_thread(_alembic, "downgrade", "0001")
+
+    async with pg_engine.connect() as conn:
+        tables = {
+            row[0]
+            for row in (
+                await conn.execute(
+                    text(
+                        "SELECT table_name FROM information_schema.tables "
+                        "WHERE table_schema='public'"
+                    )
+                )
+            ).all()
+        }
+        for gone in {
+            "users",
+            "roles",
+            "user_roles",
+            "auth_identities",
+        }:
+            assert gone not in tables, f"{gone} not dropped"
+
+    # Put the schema back so sibling tests that rely on ``head`` still
+    # find the tables.
+    await asyncio.to_thread(_alembic, "upgrade", "head")
+
+
+async def test_email_case_insensitive_uniqueness(upgraded_head):
+    # Clean slate for the users table.
+    async with upgraded_head.begin() as conn:
+        await conn.execute(
+            text(
+                "TRUNCATE TABLE auth_identities, user_roles, users "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    sm = build_sessionmaker(upgraded_head)
+    async with sm() as session:
+        await session.execute(
+            text("INSERT INTO users (email) VALUES ('Alice@X.com')")
+        )
+        await session.commit()
+
+        with pytest.raises(IntegrityError):
+            await session.execute(
+                text("INSERT INTO users (email) VALUES ('alice@x.com')")
+            )
+            await session.commit()
+        await session.rollback()
+
+
+async def test_cascade_on_user_delete(upgraded_head):
+    async with upgraded_head.begin() as conn:
+        await conn.execute(
+            text(
+                "TRUNCATE TABLE auth_identities, user_roles, users "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    sm = build_sessionmaker(upgraded_head)
+    async with sm() as session:
+        await session.execute(
+            text("INSERT INTO users (id, email) VALUES (1001, 'a@x.com')")
+        )
+        await session.execute(
+            text(
+                "INSERT INTO user_roles (user_id, role_id) "
+                "SELECT 1001, id FROM roles WHERE name='user'"
+            )
+        )
+        await session.execute(
+            text(
+                "INSERT INTO auth_identities "
+                "(user_id, provider, provider_user_id, email_at_identity) "
+                "VALUES (1001, 'google', 'xyz', 'a@x.com')"
+            )
+        )
+        await session.commit()
+
+        # Delete the user; cascades should drop both dependent rows.
+        await session.execute(text("DELETE FROM users WHERE id=1001"))
+        await session.commit()
+
+        remaining_user_roles = (
+            await session.execute(
+                text("SELECT count(*) FROM user_roles WHERE user_id=1001")
+            )
+        ).scalar_one()
+        assert remaining_user_roles == 0
+
+        remaining_identities = (
+            await session.execute(
+                text(
+                    "SELECT count(*) FROM auth_identities "
+                    "WHERE user_id=1001"
+                )
+            )
+        ).scalar_one()
+        assert remaining_identities == 0
+
+
+async def test_restrict_on_role_delete(upgraded_head):
+    # Ensure a row exists referencing the admin role.
+    async with upgraded_head.begin() as conn:
+        await conn.execute(
+            text(
+                "TRUNCATE TABLE auth_identities, user_roles, users "
+                "RESTART IDENTITY CASCADE"
+            )
+        )
+
+    sm = build_sessionmaker(upgraded_head)
+    async with sm() as session:
+        await session.execute(
+            text("INSERT INTO users (id, email) VALUES (1002, 'b@x.com')")
+        )
+        await session.execute(
+            text(
+                "INSERT INTO user_roles (user_id, role_id) "
+                "SELECT 1002, id FROM roles WHERE name='admin'"
+            )
+        )
+        await session.commit()
+
+        with pytest.raises(IntegrityError):
+            await session.execute(
+                text("DELETE FROM roles WHERE name='admin'")
+            )
+            await session.commit()
+        await session.rollback()
+
+
+async def test_constraint_names_match_convention(upgraded_head):
+    """Expect pk/uq/fk names wired via ``NAMING_CONVENTION`` in app/db.py."""
+
+    # Pull all constraints from the auth tables and assert the names
+    # we care about are present.
+    expected_names = {
+        "pk_users",
+        "uq_users_email",
+        "pk_roles",
+        "uq_roles_name",
+        "pk_user_roles",
+        "fk_user_roles_user_id_users",
+        "fk_user_roles_role_id_roles",
+        "pk_auth_identities",
+        "fk_auth_identities_user_id_users",
+        "uq_auth_identities_provider",
+    }
+
+    async with upgraded_head.connect() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT conname FROM pg_constraint WHERE conrelid::regclass::text "
+                    "IN ('users','roles','user_roles','auth_identities')"
+                )
+            )
+        ).all()
+
+    actual = {row[0] for row in rows}
+    missing = expected_names - actual
+    assert not missing, f"expected constraint names missing: {missing}"

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -42,6 +42,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_infra_001`        | Planned    | Dockerfiles, `docker-compose.yml`, `.env` templates, local orchestration.   |
 | `feat_testing_001`      | Planned    | `test.sh` driver, test conventions, minimal backend + frontend test examples.|
 | `feat_backend_002`      | In Build   | Backend rules (`backend/RULES.md`), logging callsite + redaction, items domain move. |
-| `feat_auth_001`         | In Spec    | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
+| `feat_auth_001`         | In Build   | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_auth_001/changelog_auth_001.md
+++ b/docs/specs/feat_auth_001/changelog_auth_001.md
@@ -1,0 +1,75 @@
+# Changelog: feat_auth_001 — Auth foundation
+
+## Added
+
+- **Users, roles, identities schema.** Alembic migration
+  `0002_create_auth.py` creates `users`, `roles`, `user_roles`,
+  `auth_identities` and installs the `citext` Postgres extension.
+  Seeds the two bootstrap roles `admin` and `user`.
+- **SQLAlchemy 2.x models.** `User`, `Role`, `UserRole`,
+  `AuthIdentity` under `backend/app/auth/models.py`. `User.roles` is a
+  `secondary`-based relationship returning `list[Role]`.
+- **Redis session store** under `backend/app/auth/sessions.py`:
+  `create`, `get`, `delete`, `revoke_all_for_user`. Opaque 256-bit
+  session IDs; pipelined writes; reverse-index set
+  `user_sessions:<user_id>` for role-change revocation.
+- **`SessionMiddleware`** in `backend/app/middleware.py`. One Redis
+  `GET` per request; populates `request.state.auth`; clears the
+  cookie on miss / malformed payload / malformed cookie. No DB hit.
+- **Authorization dependencies** at
+  `backend/app/auth/dependencies.py`: `current_user`,
+  `require_authenticated`, `require_roles(*names)` (OR semantics,
+  401 before 403).
+- **ADMIN_EMAILS bootstrap** at `backend/app/auth/bootstrap.py`.
+  Grants the `admin` role on first user creation when the email
+  appears in the comma-separated env list. Idempotent.
+- **`revoke_sessions_for_user(user_id)`** service helper in
+  `backend/app/auth/service.py` for 002/003 to call on role changes.
+- **`GET /api/v1/auth/me`** — authenticated; returns `{user_id,
+  email, display_name, roles}`.
+- **`POST /api/v1/auth/logout`** — authenticated; deletes the
+  session in Redis, clears the cookie, returns `204 No Content`.
+- **`POST /api/v1/_test/session`** — env-gated test-only mint
+  endpoint, mounted only when `settings.env == "test"`. Removed by
+  `feat_auth_002`.
+- **Four new settings fields** in `backend/app/settings.py`:
+  `session_cookie_name` (`"session"`), `session_ttl_seconds`
+  (`86400`), `session_cookie_secure` (`False`), `admin_emails`
+  (`""`). Computed `admin_emails_set` property returns a lower-cased
+  `frozenset[str]`.
+- **Four matching env vars** in `infra/.env.example` under a new
+  `Auth (feat_auth_001)` heading.
+- **Redis AOF durability tightened.** `infra/docker-compose.yml`
+  Redis `command` now passes `--appendfsync everysec` alongside the
+  existing `--appendonly yes`. Volume name `redisdata` preserved.
+
+## Tests
+
+- Seven new backend test modules under `backend/tests/` covering the
+  session store, middleware, dependencies, ADMIN_EMAILS bootstrap,
+  `/me` + `/logout` end-to-end, test-mint env gating, and the
+  Alembic migration.
+- One new external REST test (`tests/tests/test_auth.py`) verifying
+  `/auth/me` and `/auth/logout` return 401 without a cookie on the
+  dev compose stack.
+
+## Changed
+
+- `backend/app/main.py` installs `SessionMiddleware` between
+  `RequestIDMiddleware` (outermost) and
+  `ExceptionEnvelopeMiddleware`. Mounts the auth router under
+  `/api/v1/auth` and the env-gated test router under `/api/v1/_test`
+  when `env == "test"`.
+- `backend/app/api/v1/__init__.py` now includes the auth router
+  alongside the items router.
+- `backend/alembic/env.py` imports `app.auth.models` as a
+  side-effect import so autogenerate diffs see the new tables.
+- `docs/tracking/features.md` and `docs/specs/README.md` advance
+  `feat_auth_001` to `In Build` (and later `Merged` on PR merge).
+
+## Out of scope (tracked for future features)
+
+- Real OTP flow → `feat_auth_002`.
+- Google OAuth flow → `feat_auth_003`.
+- Frontend login UI → `feat_frontend_002`.
+- Deployment docs (`docs/deployment/*`) → ride with 002/003.

--- a/docs/specs/feat_auth_001/impl_auth_001.md
+++ b/docs/specs/feat_auth_001/impl_auth_001.md
@@ -1,0 +1,183 @@
+# Implementation Notes: feat_auth_001 — Auth foundation
+
+## Summary
+
+Implemented the auth foundation per the three spec files under
+`docs/specs/feat_auth_001/`. Everything in the "In Scope" list of the
+feature spec landed; everything in "Out of Scope" was skipped. Two
+small deviations from the design spec are flagged at the bottom.
+
+## What shipped
+
+### Schema and ORM
+
+- Alembic migration `backend/alembic/versions/0002_create_auth.py`
+  creates `citext`, `users`, `roles`, `user_roles`, `auth_identities`
+  and seeds the two role rows (`admin`, `user`). Constraint names
+  follow the naming convention that `feat_backend_002` wired onto
+  `Base.metadata`.
+- SQLAlchemy models live at `backend/app/auth/models.py`. `User.roles`
+  is a `secondary="user_roles"` relationship loaded with
+  `lazy="selectin"` so eager reads are cheap when they happen, but we
+  deliberately do not rely on that path on freshly-created async-session
+  instances (see implementation note below).
+
+### Session plumbing
+
+- Redis-backed session store at `backend/app/auth/sessions.py`:
+  `create`, `get`, `delete`, `revoke_all_for_user`. Opaque 256-bit IDs
+  via `secrets.token_hex(32)`; JSON payloads; pipelined writes;
+  reverse-index set `user_sessions:<user_id>` with the same TTL.
+- `SessionMiddleware` lives in `backend/app/middleware.py` alongside the
+  existing `RequestIDMiddleware` and `ExceptionEnvelopeMiddleware`. It
+  parses the cookie, does one Redis `GET`, and populates
+  `request.state.auth`. On miss / malformed payload / malformed cookie
+  it logs `auth.session.expired_cookie_cleared` with a `session_id_hash`
+  (never the raw ID) and appends a `Set-Cookie: <name>=; Max-Age=0`
+  header. No DB hit.
+
+### Middleware order
+
+Installed as `RequestIDMiddleware → SessionMiddleware →
+ExceptionEnvelopeMiddleware → app` (outermost first). This matches
+§5.4 of the design doc: the request ID is bound before session work,
+and any 401/403 raised by a dependency still flows through the
+exception envelope.
+
+### Authorization primitives
+
+- `backend/app/auth/dependencies.py` exposes `current_user`,
+  `require_authenticated` (alias), and `require_roles(*names)`. OR
+  semantics across role names; unauthenticated always precedes
+  unauthorized (401 > 403).
+- `backend/app/auth/bootstrap.py` parses `ADMIN_EMAILS` and exposes
+  `grant_admin_if_listed(user, session=..., settings=...)`. All
+  association-table manipulation goes through explicit SELECT/INSERT.
+- `backend/app/auth/service.py` exposes `revoke_sessions_for_user`
+  (thin wrapper for stability across 002/003) and
+  `find_or_create_user_for_test`, which is the ADMIN_EMAILS-aware
+  helper the test-only mint endpoint uses.
+
+### Endpoints
+
+- `GET /api/v1/auth/me` and `POST /api/v1/auth/logout` are mounted
+  under `/api/v1/auth`, always.
+- `POST /api/v1/_test/session` is mounted only when
+  `settings.env == "test"`. Verified both by unit tests that build the
+  app with each env value and by the production dev compose stack
+  (which runs with `ENV=dev` and correctly returns 404 on that route).
+
+### Config
+
+- Four new `Settings` fields: `session_cookie_name`,
+  `session_ttl_seconds`, `session_cookie_secure`, `admin_emails`, plus
+  an `admin_emails_set` property.
+- Same four vars in `infra/.env.example` under a new `Auth
+  (feat_auth_001)` heading.
+- `infra/docker-compose.yml` Redis command extended from
+  `--appendonly yes` to `--appendonly yes --appendfsync everysec`.
+  Volume name `redisdata` preserved per the spec-level deviation
+  documented in `design_auth_001.md`.
+
+## Implementation notes
+
+### Async-session + SQLAlchemy relationships
+
+The original service-layer draft used `user.roles.append(role)` to
+manipulate role membership, relying on `lazy="selectin"` to keep
+reads cheap. In an async session that pattern raises
+`sqlalchemy.exc.MissingGreenlet` whenever the relationship hasn't
+been eagerly loaded yet (e.g., on a freshly inserted user):
+attribute-access-triggered lazy loads are not bridged to `await`
+automatically.
+
+Fixed by routing every role write through explicit SELECT/INSERT on
+the `user_roles` association table. The ORM relationship remains
+loaded eagerly for read paths that *do* go through a full SELECT
+(e.g., `/auth/me` does `db.get(User, ctx.user_id)` and could iterate
+`user.roles` without issue) — but `service.py` and `bootstrap.py`
+never touch that attribute on a freshly-created instance.
+
+`find_or_create_user_for_test` therefore returns `(user,
+sorted(role_names))` rather than just `user` so callers can build the
+session payload from plain strings without re-reading the relationship.
+This is a small shape change from the design spec, flagged below.
+
+### Settings flow into handlers
+
+Route handlers that need settings read them via a tiny `_settings`
+dependency that pulls `request.app.state.settings` (installed by
+`create_app` → `_make_lifespan`). Using the module-level
+`get_settings` LRU cache instead would have broken tests that build
+an app with a synthetic `Settings(env="test", admin_emails="...")`
+instance, because the LRU cache only honors env vars.
+
+### Email validation
+
+The feature spec forbids new top-level dependencies. Pydantic's
+`EmailStr` requires the `email-validator` package, which is not in
+`pyproject.toml`. Replaced with a hand-rolled shape check (`@` must
+be present, length ≥ 3) on the test-only mint request body. Real
+provider-side validation lands with OTP (feat_auth_002) and Google
+(feat_auth_003).
+
+### No DB hit per request
+
+`SessionMiddleware` makes one Redis `GET`; zero DB calls. The dev-loop
+integration test `test_no_db_hit_on_missing_cookie` verifies this
+against `/healthz` by wiring a SQLAlchemy `checkout` listener onto the
+engine and confirming the counter stays at zero.
+
+`GET /auth/me` does issue one DB query (`db.get(User, id)`) to fetch
+`display_name`, which isn't stored in the session payload. That is by
+design — keeping `display_name` out of the payload lets profile edits
+propagate without needing session revocation. The "no DB hit per
+request" invariant is specifically about the middleware and the
+role-check fast path; both of those stay zero-DB.
+
+## Deviations from the spec
+
+1. **Service-layer return type.**
+   `find_or_create_user_for_test` returns `(User, list[str])` rather
+   than just `User`. The extra `role_names` list is the set of
+   authoritative role names at commit time. Necessary to avoid a
+   `MissingGreenlet` from the lazy-loaded `User.roles` relationship on
+   a freshly-created instance (see note above). Callers (just
+   `router.py` in this feature) simply unpack the pair.
+
+2. **Email shape check instead of `EmailStr`.**
+   Requirement 15 forbids new top-level dependencies, and pydantic's
+   `EmailStr` pulls in `email-validator`. Schemas use `str` with a
+   minimal `@`-present validator on `TestSessionRequest.email`. Real
+   flows in 002/003 verify the email provider-side.
+
+No other deviations. `citext` extension, cookie attributes, log event
+shape, middleware order, env gating, tracker row, and REST suite
+extension all match the spec verbatim.
+
+## Test coverage
+
+Seven new backend test modules:
+
+- `test_auth_sessions.py` — 8 cases (Redis round-trip, TTL,
+  malformed-payload tolerance, revoke-all, empty reverse index).
+- `test_auth_middleware.py` — 7 cases (no-cookie, valid cookie,
+  expired/malformed/malformed-length, RequestID-still-outermost,
+  no-DB-on-healthz).
+- `test_auth_dependencies.py` — 9 cases (401 vs 403 precedence, OR
+  semantics).
+- `test_auth_bootstrap.py` — 8 cases (empty / exact / case / whitespace
+  / non-member / cache-reset / idempotent / helper).
+- `test_auth_me_logout.py` — 10 cases (happy path, ADMIN_EMAILS
+  bootstrap, non-bootstrap, extra roles, idempotent mint, revoke
+  end-to-end, cookies absent/secure/insecure, logout-without-session
+  without Redis DEL).
+- `test_auth_test_mint_gating.py` — 4 cases across dev/test/prod.
+- `test_migration_0002_auth.py` — 6 cases (upgrade/downgrade clean,
+  citext uniqueness, cascade/restrict, constraint names).
+
+External REST suite gains `tests/tests/test_auth.py` (2 cases: 401 on
+`/auth/me` and `/auth/logout` without a cookie).
+
+Full suite: 74 passed, 1 pre-existing skip (git-ignored-file check on
+a bare repo), 0 failures. External suite: 9 passed.

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -8,4 +8,4 @@
 | feat_infra_001 | docker-compose stack + dockerfiles | Merged | #11 | #10 | #12 | - |
 | feat_testing_001 | external REST functional test suite | Merged | #14 | #13 | #15 | - |
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
-| feat_auth_001 | auth foundation: users, roles, identities, sessions | Specced | #20 | #19 | - | - |
+| feat_auth_001 | auth foundation: users, roles, identities, sessions | In Build | #20 | #19 | - | - |

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -37,6 +37,13 @@ MIGRATE=1
 
 REQUEST_ID_HEADER=X-Request-ID
 
+# ---- Auth (feat_auth_001) -----------------------------------------------
+# Session cookie and role-bootstrap controls for the auth foundation.
+SESSION_COOKIE_NAME=session
+SESSION_TTL_SECONDS=86400
+SESSION_COOKIE_SECURE=false        # flip to true in staging/prod
+ADMIN_EMAILS=                      # comma-separated; empty = no bootstrap admin
+
 # ---- Frontend runtime ---------------------------------------------------
 # Vite runs INSIDE the frontend container. The dev server proxies `/api/*`
 # to this URL, which is a server-side resolution inside the compose network.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    command: ["redis-server", "--appendonly", "yes"]
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
     volumes:
       - redisdata:/data
     networks:

--- a/tests/tests/test_auth.py
+++ b/tests/tests/test_auth.py
@@ -1,0 +1,39 @@
+"""Black-box checks for ``/api/v1/auth/me`` and ``/api/v1/auth/logout``.
+
+External REST suite — runs against the compose-brought-up backend. The
+default dev compose runs with ``ENV=dev`` which does **not** mount the
+test-only mint endpoint, so these tests only cover the unauthenticated
+code path (401 / cookie-not-set paths).
+"""
+
+from __future__ import annotations
+
+import httpx
+
+
+ME_PATH = "/api/v1/auth/me"
+LOGOUT_PATH = "/api/v1/auth/logout"
+
+
+def test_auth_me_requires_a_cookie(client: httpx.Client) -> None:
+    """Without a session cookie ``/auth/me`` returns 401."""
+
+    response = client.get(ME_PATH)
+
+    assert response.status_code == 401, response.text
+    body = response.json()
+    assert "error" in body
+    # Error envelope carries ``message`` and ``request_id`` fields; we
+    # only assert the message because envelope shape is
+    # feat_backend_002's contract.
+    assert body["error"]["message"] == "not_authenticated"
+
+
+def test_auth_logout_requires_a_cookie(client: httpx.Client) -> None:
+    """Without a session cookie ``/auth/logout`` returns 401."""
+
+    response = client.post(LOGOUT_PATH)
+
+    assert response.status_code == 401, response.text
+    body = response.json()
+    assert body["error"]["message"] == "not_authenticated"


### PR DESCRIPTION
## Summary

First of four auth features. Ships the data model (`users` / `roles` /
`user_roles` / `auth_identities`), a Redis-backed opaque-cookie session
store, a `SessionMiddleware`, the `current_user` /
`require_authenticated` / `require_roles` dependencies, the
`ADMIN_EMAILS` bootstrap hook, `revoke_sessions_for_user`, and the
`GET /auth/me` + `POST /auth/logout` pair. No real login paths — OTP
and Google OAuth land in 002 and 003.

Also ships an env-gated `POST /api/v1/_test/session` mint endpoint so
the middleware and `/me` + `/logout` pair can be exercised end-to-end
before OTP verify becomes the real session minter. `feat_auth_002`
removes that endpoint.

Closes #19

## Changes

- `backend/alembic/versions/0002_create_auth.py` — citext + 4 tables +
  role seeds.
- `backend/app/auth/` — new domain package (`models`, `schemas`,
  `sessions`, `dependencies`, `bootstrap`, `service`, `router`).
- `backend/app/middleware.py` — new `SessionMiddleware` class.
- `backend/app/main.py` — middleware install order
  (`RequestID → Session → ExceptionEnvelope → app`); auth router
  mounted at `/api/v1/auth`; env-gated `_test` router mounted at
  `/api/v1/_test` when `env == "test"`.
- `backend/app/settings.py` — `session_cookie_name`,
  `session_ttl_seconds`, `session_cookie_secure`, `admin_emails` +
  `admin_emails_set` property.
- `infra/.env.example` — four new lines under an
  `# ---- Auth (feat_auth_001) ----` heading.
- `infra/docker-compose.yml` — Redis gets `--appendfsync everysec`
  alongside the existing `--appendonly yes`. `redisdata` volume name
  preserved.
- `backend/tests/` — 7 new test modules; `tests/tests/test_auth.py` —
  external REST 401 checks.
- `docs/tracking/features.md` / `docs/specs/README.md` — status
  advanced to `In Build`.
- `docs/specs/feat_auth_001/impl_auth_001.md` +
  `changelog_auth_001.md` — implementation notes and changelog.

## Spec References

- Feature spec: `docs/specs/feat_auth_001/feat_auth_001.md`
- Design spec: `docs/specs/feat_auth_001/design_auth_001.md`
- Test spec: `docs/specs/feat_auth_001/test_auth_001.md`
- Architectural background: `docs/design/auth-login-and-roles.md`

## Test Plan

- [x] `./test.sh` — 9 passed, 0 failed.
- [x] `uv run pytest` inside the backend container against real
      Postgres + Redis — 74 passed, 1 pre-existing skip, 0 failed.
- [x] `alembic upgrade head` + `alembic downgrade 0001` tested
      against a clean Postgres.
- [x] Verified `POST /api/v1/_test/session` returns 404 in `env=dev`
      and `env=prod`, 200 in `env=test`.
- [x] Verified `GET /auth/me` returns 401 across dev/test/prod.

## Deviations from the spec

1. **`find_or_create_user_for_test` return type.** Returns
   `(User, list[str])` instead of just `User`. Avoids a
   `MissingGreenlet` from the lazy-loaded `User.roles` relationship on
   a freshly-inserted async-session instance. Documented in
   `impl_auth_001.md`.
2. **Email validation.** The spec forbids new top-level dependencies
   (req. 15), so `EmailStr` (which requires `email-validator`) is
   replaced with a hand-rolled `@`-present check on
   `TestSessionRequest.email`. Real provider-side validation lands in
   002/003.

No other deviations.