### PR TITLE
spec(feat_auth_002): email OTP login — EmailSender, OTP endpoints, deployment docs

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -43,5 +43,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_testing_001`      | Planned    | `test.sh` driver, test conventions, minimal backend + frontend test examples.|
 | `feat_backend_002`      | In Build   | Backend rules (`backend/RULES.md`), logging callsite + redaction, items domain move. |
 | `feat_auth_001`         | In Build   | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
+| `feat_auth_002`         | In Spec    | Email OTP login: `EmailSender` abstraction, `/auth/otp/request` + `/auth/otp/verify`, Resend provider, deployment docs. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_auth_002/design_auth_002.md
+++ b/docs/specs/feat_auth_002/design_auth_002.md
@@ -1,0 +1,575 @@
+# Design: Email OTP login
+
+## Source of truth
+
+The architectural decisions — why server-side sessions, why bcrypt-hashed
+OTP codes, why same-response-for-known-and-unknown emails, why rate-limit
+per email hash, the full security posture — live in
+**`docs/design/auth-login-and-roles.md`** (committed by `feat_auth_001`).
+This design spec does **not** repeat that reasoning. It describes the
+concrete file-level work that lands in `feat_auth_002` and references
+the design doc by section:
+
+- **§5.1** — module layout under `app/auth/email/` and `app/auth/otp.py`.
+- **§6.2** — Redis keyspaces `otp:*`, `otp_rate:*:minute`, `otp_rate:*:hour`.
+- **§7.1** — OTP request → verify → session data flow (verbatim contract).
+- **§8** — security posture row-set that 002 implements.
+- **§10** — log-event vocabulary for the OTP flow.
+- **§11** — environment variables (`EMAIL_*` and `OTP_*` blocks).
+- **§13** — deployment documentation (`docs/deployment/*`).
+
+When this spec says "per §7.1" it means "see the design doc, section 7.1
+— don't duplicate."
+
+## Approach
+
+Five disjoint pieces of work, one build:
+
+1. **Email plumbing.** Ship the `EmailSender` protocol plus two
+   implementations (`ConsoleEmailSender`, `ResendEmailSender`) and a
+   provider factory. Instance lives on `app.state.email_sender`, set
+   during lifespan startup.
+2. **OTP primitives.** `app/auth/otp.py` (pure helpers: hash, verify,
+   generate, key helpers) and `app/auth/otp_store.py` (Redis I/O:
+   store, load, increment-preserve-ttl, consume, rate-limit).
+3. **Endpoints.** `POST /auth/otp/request` and `POST /auth/otp/verify`
+   added to the existing `app.auth.router.router`. Schemas and a new
+   `find_or_create_user_for_otp` service helper.
+4. **Test-only OTP fixture.** The `TEST_OTP_EMAIL` / `TEST_OTP_CODE`
+   affordance lands inside `/otp/request`, gated on `env == "test"`
+   and both values non-empty. No production code path references the
+   pair.
+5. **Cleanup + docs.** Delete `test_router`, `mint_test_session`,
+   `TestSessionRequest`, `find_or_create_user_for_test`, and the
+   corresponding test file. Rewrite two 001 tests to mint via OTP.
+   Ship `docs/deployment/README.md` + `email-otp-setup.md`. Update
+   tracking rows.
+
+Nothing in this feature adds a database migration. The `users`,
+`auth_identities`, `user_roles` touches all use 001's schema. Role-
+change revocation is available via `service.revoke_sessions_for_user`
+(already shipped); 002 does not call it — OTP login creates sessions,
+it does not mutate roles.
+
+## Files to Create
+
+| Path | Purpose |
+|---|---|
+| `backend/app/auth/email/__init__.py` | Package marker. Exposes `EmailSender`, `build_email_sender`, `get_email_sender`, `EmailSendError`, `EmailProviderConfigError`. |
+| `backend/app/auth/email/base.py` | `EmailSender` runtime-checkable Protocol plus the two exception classes. |
+| `backend/app/auth/email/console.py` | `ConsoleEmailSender` — logs via `app.logging.get_logger`. |
+| `backend/app/auth/email/resend.py` | `ResendEmailSender` — thin `httpx.AsyncClient` wrapper over `POST https://api.resend.com/emails`. |
+| `backend/app/auth/email/factory.py` | `build_email_sender(settings)` dispatch + startup validation. |
+| `backend/app/auth/otp.py` | Pure OTP helpers: `generate_code`, `hash_code`, `verify_code`, `email_hash`, `otp_key`, `rate_limit_keys`. |
+| `backend/app/auth/otp_store.py` | Redis I/O for OTP: `OtpRecord`, `RateLimitResult`, `store_otp`, `load_otp`, `increment_attempts_preserve_ttl`, `consume_otp`, `check_and_increment_rate`. |
+| `backend/tests/test_auth_otp_helpers.py` | Unit tests for `app/auth/otp.py`. |
+| `backend/tests/test_auth_otp_store.py` | Unit tests for `app/auth/otp_store.py` against a real Redis. |
+| `backend/tests/test_auth_email_senders.py` | Unit tests for `ConsoleEmailSender` and `ResendEmailSender` (Resend tested against a `respx`-style mocked transport; see note below). |
+| `backend/tests/test_auth_email_factory.py` | Unit tests for `build_email_sender` dispatch and validation. |
+| `backend/tests/test_auth_otp_request.py` | Endpoint tests for `POST /auth/otp/request` — happy, rate limit, provider failure, same-response parity. |
+| `backend/tests/test_auth_otp_verify.py` | Endpoint tests for `POST /auth/otp/verify` — happy, wrong code, expired, attempts exhausted, one-shot, auto-link, `ADMIN_EMAILS` bootstrap. |
+| `backend/tests/test_auth_test_otp_fixture.py` | Tests the `TEST_OTP_EMAIL` / `TEST_OTP_CODE` env-gated affordance — active only under `env=test` + both set; inactive otherwise; startup-refusal when set in non-test env. |
+| `docs/deployment/README.md` | One-screen index of external-service setup guides. |
+| `docs/deployment/email-otp-setup.md` | Operator guide for Resend + the console dev-mode login story. |
+| `docs/specs/feat_auth_002/feat_auth_002.md` | Feature spec. |
+| `docs/specs/feat_auth_002/design_auth_002.md` | This file. |
+| `docs/specs/feat_auth_002/test_auth_002.md` | Test spec. |
+
+**Note on `respx`.** `respx` is an `httpx` mock transport used by many
+FastAPI projects for third-party HTTP mocking. It is **not** being
+added. The `test_auth_email_senders.py` tests for Resend use `httpx`'s
+built-in `MockTransport` (documented at
+<https://www.python-httpx.org/advanced/transports/#mock-transport>),
+which ships with `httpx` — no new dependency. The assertions check
+request method, URL, body JSON, and the `Authorization` header value;
+mismatches return synthetic `httpx.Response` objects.
+
+## Files to Modify
+
+| Path | Change |
+|---|---|
+| `backend/app/auth/schemas.py` | **Add** `OtpRequestIn`, `OtpVerifyIn`. **Delete** `TestSessionRequest` and the now-unused `field_validator` import (keep `_validate_email_shape` — `OtpRequestIn` / `OtpVerifyIn` reuse it verbatim). |
+| `backend/app/auth/router.py` | **Add** two new route handlers: `@router.post("/otp/request", status_code=204)` and `@router.post("/otp/verify", status_code=200, response_model=MeResponse)`. **Delete** the `test_router` block (currently lines 114–175), the `_UserLike` helper (now moved next to the verify handler since verify is its only consumer) and the `from types import SimpleNamespace` import if no other user remains. |
+| `backend/app/auth/service.py` | **Add** `find_or_create_user_for_otp(session, *, email, settings) -> tuple[User, list[str], bool]` (returns user, role names, `new_user` flag). **Delete** `find_or_create_user_for_test`. `_current_role_names` and `_grant_role_if_missing` stay — `find_or_create_user_for_otp` reuses them. |
+| `backend/app/auth/__init__.py` | No change required — still re-exports `router`. |
+| `backend/app/main.py` | **Add** lifespan wiring: `app.state.email_sender = build_email_sender(resolved)`. Teardown closes the sender's `httpx.AsyncClient` if present (delegated to the sender — `ResendEmailSender.aclose()` is a no-op when the client was not created lazily, or closes the client if it was). **Delete** the `if resolved.env == "test": from app.auth.router import test_router; app.include_router(...)` block (currently lines 107–114). |
+| `backend/app/settings.py` | **Add** the `email_provider`, `email_from`, `email_provider_timeout_seconds`, `resend_api_key`, `otp_code_ttl_seconds`, `otp_max_attempts`, `otp_rate_per_minute`, `otp_rate_per_hour`, `test_otp_email`, `test_otp_code` fields. **Add** an imported-in-factory runtime guard (not a validator — keeps `Settings` instantiation pure) that refuses to build the email sender when `env != "test"` and `test_otp_email` / `test_otp_code` are non-empty. |
+| `backend/pyproject.toml` | **Add** `bcrypt>=4.1` to `[project] dependencies`. **Promote** `httpx` from `[dependency-groups] dev` to `[project] dependencies` only if the build-time `uv pip show httpx` check in a Vulcan-side verification step shows it is not already transitively available at runtime. If it is, leave `pyproject.toml` alone on the httpx row. |
+| `infra/.env.example` | **Append** the `# ---- Email / OTP (feat_auth_002) ----` block and the `# ---- Test-only OTP fixture (feat_auth_002) ----` block per requirement 12 of the feature spec. |
+| `backend/tests/test_auth_middleware.py` | **Rewrite** the two test cases that used `POST /_test/session` to instead mint sessions via `POST /auth/otp/request` + `POST /auth/otp/verify`, driven by the `TEST_OTP_*` affordance set up by a new fixture. Other cases (anonymous, malformed cookie, malformed payload, missing key) are untouched. |
+| `backend/tests/test_auth_me_logout.py` | **Rewrite** every mint call to go through the OTP flow with the test fixture. Cases 1–9 semantics preserved; only the "how do we get a cookie" step changes. |
+| `backend/tests/test_auth_bootstrap.py`, `test_auth_sessions.py`, `test_auth_dependencies.py` | **No change.** None of these exercise the mint endpoint. |
+| `tests/tests/conftest.py` | **Add** a compose-side overlay that sets `TEST_OTP_EMAIL` / `TEST_OTP_CODE` for the two new external scenarios (and only for those scenarios — uses a scoped fixture, not `autouse`). |
+| `tests/tests/test_auth.py` | **Add** two new scenarios: OTP request → verify → `/me` happy path, and OTP request → wrong-code verify → 400. |
+| `docs/specs/README.md` | Roster table gains a row for `feat_auth_002`. |
+| `docs/tracking/features.md` | One new row; `Status=Specced` with Spec PR and Issues backfilled per Atlas Step 4 / Step 5. |
+
+## Files to Delete
+
+| Path | Reason |
+|---|---|
+| `backend/tests/test_auth_test_mint_gating.py` | Tested the `_test/session` endpoint. Endpoint is deleted; test becomes meaningless. |
+
+Plus the symbols listed in "Files to Modify" — `test_router`,
+`mint_test_session`, `TestSessionRequest`, `find_or_create_user_for_test`,
+and the env-gated `include_router(test_router, ...)` block in `main.py`.
+
+## Module layout (per §5.1 of the design doc)
+
+After this feature, the `app/auth/` tree is:
+
+```
+backend/app/auth/
+  __init__.py              # unchanged — re-exports router
+  bootstrap.py             # unchanged
+  dependencies.py          # unchanged
+  models.py                # unchanged
+  schemas.py               # MeResponse, AuthContext, OtpRequestIn, OtpVerifyIn
+  service.py               # revoke_sessions_for_user, find_or_create_user_for_otp
+  sessions.py              # unchanged
+  router.py                # /me, /logout, /otp/request, /otp/verify
+  otp.py                   # NEW — pure helpers
+  otp_store.py             # NEW — Redis I/O
+  email/
+    __init__.py            # NEW — re-exports
+    base.py                # NEW — Protocol + errors
+    console.py             # NEW
+    resend.py              # NEW
+    factory.py             # NEW
+```
+
+`otp.py` and `otp_store.py` are split so the pure helpers (no I/O,
+deterministic, easy to unit-test under pytest parametrize) are free of
+Redis-client imports. The split matches the separation 001 already
+has between `schemas.py` (pure) and `sessions.py` (I/O).
+
+## Endpoint inventory (after this feature)
+
+| Method + path | Feature | Purpose | Auth required |
+|---|---|---|---|
+| `POST /api/v1/auth/otp/request` | **002** | Send OTP to email | no |
+| `POST /api/v1/auth/otp/verify` | **002** | Verify OTP → session | no |
+| `GET /api/v1/auth/me` | 001 | Current user + roles | yes |
+| `POST /api/v1/auth/logout` | 001 | Revoke session | yes |
+| `POST /api/v1/_test/session` | ~~001~~ | **Deleted by this feature** | — |
+
+Google OAuth endpoints are intentionally absent — they land in 003.
+
+## Data flow
+
+### `/auth/otp/request`
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Router as auth/router.py
+    participant OtpStore as otp_store.py
+    participant Redis
+    participant Email as EmailSender
+
+    Client->>Router: POST /auth/otp/request {email}
+    Router->>Router: _validate_email_shape(email)<br/>normalized = email.strip().lower()
+    Router->>OtpStore: check_and_increment_rate(email, per_minute, per_hour)
+    OtpStore->>Redis: pipeline(<br/>  INCR otp_rate:<h>:minute<br/>  EXPIRE 60 NX<br/>  INCR otp_rate:<h>:hour<br/>  EXPIRE 3600 NX<br/>)
+    Redis-->>OtpStore: counts
+    OtpStore-->>Router: RateLimitResult(allowed, retry_after, window)
+    alt !allowed
+        Router->>Router: log auth.otp.rate_limited
+        Router-->>Client: 429 {detail, retry_after} + Retry-After header
+    else allowed
+        Router->>Router: code = generate_code()<br/>code_hash = hash_code(code)
+        alt test-OTP fixture active AND normalized == settings.test_otp_email
+            Router->>Router: code_hash = hash_code(settings.test_otp_code)
+        end
+        Router->>OtpStore: store_otp(email, code_hash, ttl=OTP_CODE_TTL_SECONDS)
+        OtpStore->>Redis: SET otp:<h> {code_hash, attempts:0, created_at} EX 600
+        Router->>Email: send_otp(to=email, code=code)
+        alt send succeeds
+            Router->>Router: log auth.otp.requested
+        else send fails (caught)
+            Router->>Router: log auth.otp.send_failed
+        end
+        Router-->>Client: 204 No Content
+    end
+```
+
+Notes:
+
+- Rate-limit increments happen **before** the OTP is stored, so a
+  denied request never writes an `otp:<h>` key. A user on their second
+  request within 60 s sees `429` and the previous minute's code
+  remains valid.
+- The test-OTP fixture substitution happens **between** `generate_code`
+  and `store_otp`. The real code is still generated (so
+  `ConsoleEmailSender` still logs a plausible decoy); only the stored
+  hash differs when the fixture matches.
+- Email-send errors are caught and logged, but the response is still
+  `204`. Leaving the stored OTP intact means a user whose email
+  bounced can retry verify after a provider recovery; the rate limiter
+  protects us from the reverse (a user retrying `/request` to work
+  around a bounce).
+
+### `/auth/otp/verify`
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Router
+    participant OtpStore
+    participant Redis
+    participant Service as service.find_or_create_user_for_otp
+    participant PG as Postgres
+    participant Sessions as sessions.create
+
+    Client->>Router: POST /auth/otp/verify {email, code}
+    Router->>Router: validate email + code shape
+    Router->>OtpStore: load_otp(email)
+    OtpStore->>Redis: GET otp:<h>
+    Redis-->>OtpStore: raw
+    OtpStore-->>Router: OtpRecord | None
+    alt record is None
+        Router->>Router: log auth.otp.failed reason=missing
+        Router-->>Client: 400 {detail: invalid_or_expired_code}
+    else record.attempts >= OTP_MAX_ATTEMPTS
+        Router->>OtpStore: consume_otp(email)
+        Router->>Router: log auth.otp.failed reason=attempts_exhausted
+        Router-->>Client: 400 {detail: invalid_or_expired_code}
+    else verify_code mismatch
+        Router->>OtpStore: increment_attempts_preserve_ttl(email)
+        Router->>Router: log auth.otp.failed reason=wrong_code
+        Router-->>Client: 400 {detail: invalid_or_expired_code}
+    else verify_code match
+        Router->>OtpStore: consume_otp(email)
+        Router->>Service: find_or_create_user_for_otp(email, settings)
+        Service->>PG: SELECT auth_identities WHERE provider='email'<br/>AND provider_user_id=email
+        alt identity exists
+            PG-->>Service: identity -> user
+        else no identity, user exists
+            Service->>PG: SELECT users WHERE email (citext)
+            PG-->>Service: user
+            Service->>PG: INSERT auth_identities (user_id, 'email', email, email)
+        else no user
+            Service->>PG: INSERT users (email)
+            Service->>PG: INSERT user_roles (user.id, 'user' role)
+            Service->>Service: grant_admin_if_listed (001 helper)
+            Service->>PG: INSERT auth_identities (user_id, 'email', email, email)
+        end
+        Service-->>Router: (user, role_names, new_user)
+        Router->>Sessions: create(_UserLike(user, role_names), redis, ttl)
+        Sessions->>Redis: pipeline(<br/>  SET session:<sid> {...} EX 86400<br/>  SADD user_sessions:<uid> <sid><br/>  EXPIRE user_sessions:<uid> 86400<br/>)
+        Router->>Router: set_cookie(session=<sid>, HttpOnly, SameSite=Lax, ...)
+        Router->>Router: log auth.otp.verified + auth.session.created
+        Router-->>Client: 200 MeResponse + Set-Cookie
+    end
+```
+
+Notes:
+
+- Four distinct bad-code conditions produce the **same response
+  body** (`{"detail": "invalid_or_expired_code"}`) and HTTP 400. An
+  attacker cannot distinguish "never requested" from "expired" from
+  "wrong code" from "attempts exhausted". Logging uses distinct
+  `reason` values so operators can still diagnose.
+- `increment_attempts_preserve_ttl` is implemented via a one-shot
+  Lua `EVAL`:
+
+  ```lua
+  local raw = redis.call('GET', KEYS[1])
+  if raw == false then return 0 end
+  local ok, obj = pcall(cjson.decode, raw)
+  if not ok then return 0 end
+  obj.attempts = (obj.attempts or 0) + 1
+  local ttl = redis.call('PTTL', KEYS[1])
+  if ttl <= 0 then return 0 end
+  redis.call('SET', KEYS[1], cjson.encode(obj), 'PX', ttl)
+  return obj.attempts
+  ```
+
+  Using `PX` with the exact remaining PTTL is how we match the §7.1
+  spec's "preserve TTL" requirement without a Redis 7-only `KEEPTTL`
+  (defensible for non-Redis-7 deployments). The Lua runs in
+  `redis.call` atomically — no RMW race.
+- `find_or_create_user_for_otp` writes to Postgres in one transaction
+  (the caller's `AsyncSession`). `session.commit()` is called inside
+  the helper after the identity row is inserted; the verify handler
+  never sees a half-committed state.
+
+### Test-OTP fixture gating (the only non-production code path in 002)
+
+```python
+# backend/app/auth/router.py (inside request_otp, after store_otp):
+if (
+    settings.env == "test"
+    and settings.test_otp_email
+    and settings.test_otp_code
+    and normalized_email == settings.test_otp_email.strip().lower()
+):
+    # Overwrite the stored hash with one that will match the fixture code.
+    # The generated `code` variable is left as-is so ConsoleEmailSender
+    # still logs a plausible-looking decoy.
+    await otp_store.store_otp(
+        email,
+        otp.hash_code(settings.test_otp_code),
+        redis=redis,
+        ttl_seconds=settings.otp_code_ttl_seconds,
+    )
+```
+
+**This is the only branch in production code that reads `test_otp_*`.**
+No verify-side branch. No middleware branch. No settings cache helper
+that happens to check them. A `grep -r test_otp backend/app/` after
+this feature must show this one block plus the factory guard plus the
+schema field definitions — nothing else.
+
+### Startup guard for accidental non-test population
+
+```python
+# backend/app/auth/email/factory.py
+def build_email_sender(settings: Settings) -> EmailSender:
+    # Refuse to start if the test-OTP fixture is set outside of ENV=test.
+    if settings.env != "test" and (settings.test_otp_email or settings.test_otp_code):
+        raise EmailProviderConfigError(
+            "TEST_OTP_EMAIL / TEST_OTP_CODE are set but ENV != 'test'. "
+            "These variables must be empty outside the test environment."
+        )
+    # ... dispatch on email_provider ...
+```
+
+The factory is the right place for this guard — it runs once at
+lifespan startup, before any request is served. Not in `Settings`
+validation because pydantic-settings runs at instantiation; tests and
+scripts that instantiate `Settings()` for non-startup reasons
+(e.g. the `reset_env` fixture in `backend/tests/conftest.py`) should
+not explode.
+
+## Redis keyspaces written by this feature
+
+Per §6.2 of the design doc. Reading row applies only to 002; other
+rows remain as specified in 001 / reserved for 003.
+
+| Key pattern | Value | TTL | Set by | Consumed by |
+|---|---|---|---|---|
+| `otp:<h>` | `{"code_hash": "...", "attempts": 0, "created_at": "..."}` | `OTP_CODE_TTL_SECONDS` (600) | `/otp/request` step 4 | `/otp/verify` (read + delete), or expiry |
+| `otp_rate:<h>:minute` | counter (INCR) | 60 | `/otp/request` step 2 | self-expires |
+| `otp_rate:<h>:hour` | counter (INCR) | 3600 | `/otp/request` step 2 | self-expires |
+
+`<h>` is `sha256(email.strip().lower())` hex. Never a plaintext email.
+
+`EXPIRE` on the rate-counter keys is set with `NX` (only if no TTL
+exists) on first increment — not every increment — so the 60-second
+window lines up with the first request of the window, not the most
+recent. Implemented via a 4-command `Pipeline` (`INCR`,
+`EXPIRE key 60 NX`, `INCR`, `EXPIRE key 3600 NX`) rather than a Lua
+script — two extra round-trips, no correctness loss.
+
+## `AuthIdentity` write semantics
+
+On a new OTP login, the `auth_identities` row is:
+
+| Column | Value |
+|---|---|
+| `user_id` | the just-found-or-created `users.id` |
+| `provider` | `"email"` (literal string) |
+| `provider_user_id` | `email.strip().lower()` — the normalized email itself; case-preservation concerns are handled by `CITEXT` on the column, but we store the canonical lowercased form so the unique index over `(provider, provider_user_id)` is deterministic |
+| `email_at_identity` | same normalized email |
+| `created_at` | `now()` (server default) |
+
+The design doc's §6.1 additional columns `last_login_at` on `users`,
+`last_used_at` on `auth_identities`, and `is_active` on `users` do not
+exist in 001's migration (see `backend/app/auth/models.py:44-63`). 002
+does **not** add them. The handler's design-spec steps that would
+touch them (§7.1 step 6 "`last_login_at = now()`") are documented
+no-ops in 002; a future `feat_backend_NNN` or `feat_auth_NNN` can
+land an additive migration when session analytics become a priority.
+
+## `OtpRequestIn` / `OtpVerifyIn` / `MeResponse` — schema shapes
+
+```python
+# backend/app/auth/schemas.py (additions)
+
+class OtpRequestIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    email: str
+
+    @field_validator("email")
+    @classmethod
+    def _email_shape(cls, v: str) -> str:
+        return _validate_email_shape(v)
+
+
+class OtpVerifyIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    email: str
+    code: str
+
+    @field_validator("email")
+    @classmethod
+    def _email_shape(cls, v: str) -> str:
+        return _validate_email_shape(v)
+
+    @field_validator("code")
+    @classmethod
+    def _code_shape(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) != 6 or not v.isdigit():
+            # Same as wrong code. Do not leak "validation" vs "wrong".
+            raise ValueError("not_a_valid_code")
+        return v
+```
+
+`MeResponse` is unchanged from 001.
+
+The `_code_shape` validator rejection produces a Pydantic 422 by
+default. 002 explicitly converts that to a 400 with the uniform
+`invalid_or_expired_code` body via an exception handler registered at
+router level — we cannot let a 422 leak because it would distinguish
+"shape wrong" from "wrong code", which the design doc §7.1 prohibits.
+Implementation: catch `RequestValidationError` for the `/otp/verify`
+route only (via `dependencies=[Depends(_mask_verify_validation)]` on
+the route, or a route-local `responses={400: ...}` + explicit
+`HTTPException` re-raise in a `Body(...)`-loose model, whichever is
+cleaner to Vulcan). The test spec asserts the "short code" ->
+"400 invalid_or_expired_code" mapping explicitly.
+
+## Deployment documentation (§13 of the design doc)
+
+Two files.
+
+### `docs/deployment/README.md`
+
+```markdown
+# Deployment
+
+External services that need manual setup before production. Each guide
+is self-contained and lists the env vars it populates.
+
+- [Email / OTP](email-otp-setup.md) — required for `feat_auth_002` in
+  non-dev environments (Sign in with email OTP).
+
+*(Google OAuth — added by `feat_auth_003`.)*
+
+Separate from the top-level `deployment/` path reserved by
+[`conventions.md` §8](../../conventions.md) for production artifacts
+such as Helm charts and Terraform modules.
+```
+
+### `docs/deployment/email-otp-setup.md`
+
+Full table of contents (exact headings Vulcan will commit):
+
+1. **Overview** — one paragraph.
+2. **Provider comparison** — four-row table (Resend / SendGrid / SES /
+   Postmark), columns: **Price tier**, **Setup effort**, **Free-tier
+   ceiling**, **Primary region**.
+3. **Why the template defaults to Resend.**
+4. **Dev login flow (console provider).** Includes the exact
+   `docker compose logs backend | grep auth.email.console_otp_sent | tail -n 1`
+   command plus the structlog-JSON shape and an example log line.
+5. **Step 1: Create a Resend account.**
+6. **Step 2: Verify your sending domain.** DKIM + SPF DNS records
+   (both shown), 24 h DNS-propagation caveat.
+7. **Step 3: Generate an API key.** Sending-only scope.
+8. **Step 4: Populate `infra/.env`.** Exact var names and values.
+9. **Step 5: Verify end-to-end.** `make up`, `curl POST /otp/request`,
+   confirm email lands, inspect DKIM pass.
+10. **Troubleshooting.** Table — five rows: spam-folder, DKIM fail,
+    sender-not-verified, Resend rate limit, switching provider.
+11. **Rotating credentials.**
+12. **Test-OTP fixture reminder.** `TEST_OTP_EMAIL` / `TEST_OTP_CODE`
+    must stay empty in non-test environments; the backend refuses to
+    start otherwise (factory startup guard).
+
+All prose is written fresh; no copy-paste from third-party docs.
+
+## Deviations from the design doc
+
+1. **`last_login_at`, `last_used_at`, `is_active` columns.** The design
+   doc §6.1 lists them; `feat_auth_001`'s migration did not add them
+   (see `backend/app/auth/models.py`). 002 does not add them either —
+   no new migration. The three design-doc steps that would touch them
+   (§7.1 step 6, §7.2 step 7, §7.1 deactivated-user failure row) are
+   documented no-ops in 002. A follow-on feature can add them
+   additively. Vulcan should note this in
+   `docs/specs/feat_auth_002/impl_auth_002.md` on the build PR.
+2. **No Resend SDK package.** §11 of the design doc is silent on
+   whether to use the SDK or the HTTP API; we use `httpx` for one
+   endpoint + one JSON body. Reduces dependency surface.
+3. **`bcrypt` as the one new top-level dependency.** §6.2 of the
+   design doc specifies bcrypt; 002 is the first feature that
+   actually needs it. The `backend/pyproject.toml` addition is a
+   requirement-4-covered one-line dependency bump.
+4. **OTP rate-limit uses `EXPIRE ... NX` + pipeline, not Lua.** §7.1
+   of the design doc shows the semantics; it does not prescribe the
+   implementation. Pipeline keeps the module simple.
+5. **`increment_attempts_preserve_ttl` uses `PTTL` + `SET ... PX`
+   inside Lua**, not `SET ... KEEPTTL`. `KEEPTTL` is Redis 7+; the
+   `infra/docker-compose.yml` pins `redis:7-alpine` so `KEEPTTL`
+   would also work. `PTTL` + `PX` costs one extra `redis.call` and
+   keeps the module portable. Either implementation is acceptable;
+   Vulcan chooses, test spec asserts only the observable behavior.
+
+## Edge cases and risks
+
+| Risk | Mitigation |
+|---|---|
+| Resend API outage | Email-send failure is caught; `/otp/request` still returns `204`. User can retry verify using the already-stored code once Resend recovers. |
+| Resend rate limit (429) on the API | Caught as `EmailSendError`; logged with `http_status=429`; response to the client is `204` (we rate-limit upstream, so this only happens on misconfigured high-traffic). |
+| Attacker enumerates accounts via timing | `/request` does zero DB reads; timing is constant modulo the Redis `INCR` + `SET` + HTTP call to Resend. The Resend call is the variable; the console provider is constant-time. Acceptable because the design doc ranks this threat as medium. |
+| Attacker floods `/request` with varied emails | Rate limit is per-email-hash, so a distinct email each time does defeat the rate limit. Mitigated only at the reverse-proxy layer (out of scope for 002). Documented in the deployment guide's "production sizing" section as a known future gap. |
+| Attacker brute-forces verify | `OTP_MAX_ATTEMPTS=5` + one-shot lockout + 1M search space at bcrypt cost → infeasible. |
+| Stored hash collision between test-OTP fixture and real user in the same Redis | The fixture overwrites the key with the hash of the configured test code. If a real user happens to be the same `TEST_OTP_EMAIL` in `ENV=test`, the real code they typed won't verify — acceptable, the test env is the test env. |
+| `TEST_OTP_EMAIL` / `TEST_OTP_CODE` set in production | Factory startup guard refuses to build the email sender — backend crashes at import of `create_app`. |
+| `EMAIL_PROVIDER=resend` + missing `RESEND_API_KEY` | Factory raises `EmailProviderConfigError` at startup. Surfaces loudly on `make up`. |
+| `EMAIL_PROVIDER=console` in production | Technically allowed; OTP codes land in logs. The deployment guide flags this: "`EMAIL_PROVIDER=console` is a developer convenience only; switch to a real provider before exposing the backend to the public internet." Not enforced in code — operator responsibility. |
+| Redis wiped mid-verify | The `otp:<h>` key is gone; `/verify` returns `invalid_or_expired_code`. User re-requests an OTP. Same as expiry. |
+| Clock skew between backend and Redis for TTL | Irrelevant — TTLs are Redis-side. Backend only passes `ex=N`. |
+| `increment_attempts_preserve_ttl` race with concurrent `GET` | Lua EVAL is atomic; the read-then-write happens inside one Redis command. No race. |
+| A Pydantic 422 for `email`/`code` shape escapes as 422 | The route-level handler converts to 400 `invalid_or_expired_code`. Test spec asserts the mapping for both fields. |
+| `find_or_create_user_for_otp` race: two concurrent verifies for a new email | Both verifies go through `IntegrityError` on the second `INSERT users(email)` thanks to the `UNIQUE` constraint. The helper re-reads and reuses the existing row. Same pattern `find_or_create_user_for_test` used in 001. |
+| Log leakage of the OTP code | Only `ConsoleEmailSender` logs it (intentional). `ResendEmailSender` never logs it. Reviewer check: `grep -r '\"code\"' backend/app/auth/email/` should match only `console.py`. |
+| Deleting `test_router` breaks a test that imports `TestSessionRequest` | The spec-side deletion list is exhaustive; the test rewrite is part of this feature's scope (requirement 10). |
+| `httpx` not installed at runtime | Factory raises at startup when `EMAIL_PROVIDER=resend` (import of `httpx` inside `resend.py` fails). Console provider doesn't need `httpx`. Fallback: promote `httpx` to main deps per requirement 16. |
+
+## Security considerations
+
+The full posture table lives at §8 of the design doc. 002 implements
+the following rows end-to-end:
+
+- **OTP brute force** — bcrypt-hashed codes, 5-attempt one-shot
+  lockout, 10-min TTL, 1/min + 10/hour per-email rate limits.
+- **OTP enumeration** — same `204` for known and unknown emails on
+  `/request`; same `400 invalid_or_expired_code` for all four bad
+  conditions on `/verify`.
+- **Stored OTP compromise** — codes stored as bcrypt hash, not
+  plaintext. Redis `otp:<h>` value is a JSON blob with `code_hash`
+  only.
+- **Redis session leak via `KEYS *`** — email keys are hashed
+  (`otp:<sha256(email)[..]>` never raw email); session keys remain
+  opaque.
+- **Log leakage** — `email_hash` + `session_id_hash` in every event;
+  full email only in structured-log redaction-scope fields; OTP code
+  only in the intentional `auth.email.console_otp_sent` dev event.
+- **Cookie flags** — reused verbatim from 001's `sessions.create` + the
+  verify handler's `response.set_cookie` call. `HttpOnly`, `SameSite=Lax`,
+  `Path=/`, `Secure` echoed from settings.
+- **Same-origin CSRF on `/otp/verify`** — `SameSite=Lax` + JSON body +
+  the verify handler's lack of a critical side-effect beyond session
+  creation. A cross-site POST that successfully minted a session
+  would still land on the attacker's domain (where the `Set-Cookie`
+  header is scoped to the backend origin). Acceptable per §8 of the
+  design doc.
+
+## Open questions
+
+None blocking. Decisions closed above and in clarifying-answer 1–5:
+
+- Ordering of follow-ons (`002 → frontend_002 → 003`) is Atlas's
+  default. Reconfirmed before 002 merges.
+- Dev login flow uses the real `ConsoleEmailSender`; developer greps
+  the backend log (clarifying answer 2).
+- Test-only dummy OTP is env-var driven, gated on `env == "test"` AND
+  both vars non-empty; no hardcoded defaults (clarifying answer 3).
+- Deployment path is `docs/deployment/` (clarifying answer 4). No
+  `conventions.md:120` amendment.
+- `docs/deployment/README.md` + `docs/deployment/email-otp-setup.md`
+  ship in this feature (clarifying answer 5).

--- a/docs/specs/feat_auth_002/feat_auth_002.md
+++ b/docs/specs/feat_auth_002/feat_auth_002.md
@@ -1,0 +1,717 @@
+# Feature: Email OTP login — `EmailSender`, OTP endpoints, deployment docs
+
+## Problem Statement
+
+`feat_auth_001` laid the session rails (users/roles/identities schema, Redis
+session store, `SessionMiddleware`, `GET /auth/me`, `POST /auth/logout`,
+`require_roles`, `ADMIN_EMAILS` bootstrap) but shipped **no real login
+path**. The only way to mint a session today is the env-gated
+`POST /api/v1/_test/session` endpoint in `backend/app/auth/router.py`,
+which exists solely so 001 could exercise the session plumbing
+end-to-end. That endpoint is explicitly marked for removal by this
+feature — per `feat_auth_001.md:9` ("ships no login paths of its own")
+and `feat_auth_001.md:37` ("Removed by `feat_auth_002`").
+
+`feat_auth_002` is the **first real login path**: email one-time-password
+(OTP). A user enters their email, the backend emails a six-digit code,
+the user enters the code, a session is minted. No passwords, no third
+party (for the dev/test default). This is the feature that takes the
+template from "has auth plumbing" to "can actually log in" without yet
+needing an external OAuth configuration.
+
+The full architectural rationale — why OTP over passwords, why bcrypt
+hashing of codes, why same-response-for-known-and-unknown-emails, how
+the Redis keyspaces interlock, the full security posture — lives in
+**`docs/design/auth-login-and-roles.md`** (committed by 001). This spec
+pulls only the slice that lands in 002. Specifically:
+
+- §§2, 3, 4 (session, role, identity models) — already built in 001;
+  002 consumes the shared helpers.
+- §5.1 (module layout) — 002 fills in `app/auth/otp.py` and the
+  `app/auth/email/` package.
+- §6.2 (Redis keyspaces) — 002 writes `otp:<email_hash>`,
+  `otp_rate:<email_hash>:minute`, `otp_rate:<email_hash>:hour`.
+- §7.1 (OTP request → verify → session data flow) — verbatim contract.
+- §11 (env vars) — 002 adds the `EMAIL_*` and `OTP_*` block.
+- §13 (deployment docs) — 002 ships `docs/deployment/README.md` + the
+  email-OTP setup guide.
+
+## Requirements
+
+### Functional
+
+1. **`EmailSender` abstraction.** One-method protocol under
+   `backend/app/auth/email/base.py`:
+
+   ```python
+   class EmailSender(Protocol):
+       async def send_otp(self, *, to: str, code: str) -> None: ...
+   ```
+
+   Minimal by design — OTP is the only consumer in this feature. If a
+   future feature needs arbitrary transactional email, the package
+   hoists to `app/email/` (§5.1 of the design doc says so explicitly)
+   and `send_otp` either stays as a convenience wrapper or is replaced
+   with `send(...)` at that time. Not a concern for 002.
+
+2. **`ConsoleEmailSender`** (`backend/app/auth/email/console.py`). Logs
+   the OTP code through the existing `app.logging.get_logger(__name__)`
+   chain — **not** `print()` and **not** raw stdout. Emits one log
+   event per send:
+
+   ```
+   auth.email.console_otp_sent  email_hash=<h>  code=<code>
+   ```
+
+   The `code` field is the intentional, documented dev-only exception
+   to the "never log OTP codes" rule from §10 of the design doc. The
+   log event name includes `console` so an accidental production use
+   of this sender surfaces loudly in log search.
+
+3. **`ResendEmailSender`** (`backend/app/auth/email/resend.py`). Uses
+   `httpx.AsyncClient` (already in the dev dependency group via
+   `backend/pyproject.toml:22`, and available at runtime because
+   `uvicorn[standard]>=0.30` pulls it in transitively through
+   `httptools`/`watchfiles` — verify at build time with
+   `uv pip show httpx`; if it is not present at runtime, promote `httpx`
+   from the `dev` group to the main `dependencies` list — **no other
+   new top-level Python dependency is introduced**). No Resend SDK
+   package. Calls `POST https://api.resend.com/emails` with a JSON body
+   of `{from, to, subject, text}`, `Authorization: Bearer <api_key>`,
+   and a short timeout (5 s default, exposed as
+   `EMAIL_PROVIDER_TIMEOUT_SECONDS`). On non-2xx: raise a typed
+   `EmailSendError` carrying the HTTP status and (if JSON) the `message`
+   field from Resend's error envelope. Never logs the API key, the
+   recipient raw, or the OTP code.
+
+4. **Provider factory** (`backend/app/auth/email/factory.py`). Exposes
+   `build_email_sender(settings: Settings) -> EmailSender`. Dispatches
+   on `settings.email_provider`:
+
+   | Value | Sender | Validation |
+   |---|---|---|
+   | `"console"` | `ConsoleEmailSender()` | Always allowed. |
+   | `"resend"` | `ResendEmailSender(api_key=..., from_=..., timeout=..., http=...)` | `RESEND_API_KEY` must be non-empty; `EMAIL_FROM` must be non-empty; otherwise raise `EmailProviderConfigError` at startup. |
+   | other | — | `EmailProviderConfigError` at startup. |
+
+   The sender is built once at app-lifespan startup and stashed on
+   `app.state.email_sender`. A `get_email_sender(request) -> EmailSender`
+   FastAPI dependency under `backend/app/auth/email/__init__.py` reads
+   it off app state, mirroring `app.redis_client.get_redis`.
+
+5. **OTP helpers** (`backend/app/auth/otp.py`):
+   - `_email_hash(email: str) -> str` — `sha256(email.strip().lower())`
+     hex, used verbatim in every Redis key the OTP flow writes.
+   - `generate_code() -> str` — `f"{secrets.randbelow(10**6):06d}"`.
+     Six digits. Uses `secrets.randbelow`, not `random.randrange`.
+   - `hash_code(code: str) -> str` — bcrypt hash of the raw code. Work
+     factor pinned at **10 rounds** (see §6.2 of the design doc for the
+     "tune for ~10 ms verify" rationale — at a 1M search space, a
+     higher work factor buys nothing).
+   - `verify_code(code: str, hash_: str) -> bool` — constant-time
+     bcrypt verify.
+   - `rate_limit_keys(email: str) -> tuple[str, str]` — returns
+     `(otp_rate:<h>:minute, otp_rate:<h>:hour)`.
+   - `otp_key(email: str) -> str` — returns `otp:<h>`.
+
+   **Note on `bcrypt`.** `bcrypt` is **not** currently a top-level
+   dependency. It is added to `backend/pyproject.toml` under the main
+   `dependencies` list as `bcrypt>=4.1`. The design doc §6.2 explicitly
+   specifies bcrypt hashing. This is the one permitted new top-level
+   dependency in 002 (justification: hash primitive, not avoidable via
+   stdlib; `hashlib.scrypt` would work but the design doc has already
+   committed to bcrypt).
+
+6. **OTP storage helpers** (`backend/app/auth/otp_store.py` — new
+   file; split from `otp.py` to keep the pure helpers above free of
+   Redis I/O). All async, all take `redis: Redis`:
+   - `store_otp(email: str, code_hash: str, *, redis, ttl_seconds: int) -> None`
+     — `SET otp:<h> '{"code_hash":"...","attempts":0,"created_at":...}' EX <ttl>`.
+   - `load_otp(email: str, *, redis) -> OtpRecord | None` — single `GET`,
+     JSON-parsed, missing/malformed → `None`.
+   - `increment_attempts_preserve_ttl(email: str, *, redis) -> int` —
+     reads the current blob, rewrites with `attempts += 1`, preserves
+     remaining TTL via `EXPIRE ... KEEPTTL` (Redis 7) or a Lua script
+     that does `SET ... KEEPTTL` (safe and atomic; see §7.1 step 3 of
+     the design doc — the spec there says "preserve TTL after mismatch").
+     Returns the new attempt count.
+   - `consume_otp(email: str, *, redis) -> None` — `DEL otp:<h>`.
+   - `check_and_increment_rate(email: str, *, redis, per_minute_limit: int, per_hour_limit: int) -> RateLimitResult`
+     — pipelined `INCR` on both counters plus `EXPIRE` on first increment,
+     returning a `RateLimitResult(allowed: bool, retry_after: int)`
+     where `retry_after` is 0 on allow and the remaining TTL of the
+     offending window on deny (minute window preferred when both are
+     full).
+
+   `RateLimitResult` and `OtpRecord` are tiny frozen dataclasses in
+   `app/auth/otp_store.py`; no Pydantic.
+
+7. **`POST /api/v1/auth/otp/request`** — new route on the existing
+   `app.auth.router.router` (same `APIRouter` that serves `/me` and
+   `/logout`; prefix `/auth` is applied by `app.api.v1`). Request body:
+   `OtpRequestIn(email: str)`. Flow (verbatim from §7.1 of the design
+   doc):
+   1. Validate email shape (reuse `_validate_email_shape` from
+      `app.auth.schemas`; do not add a new Pydantic validator).
+   2. `check_and_increment_rate(email, per_minute_limit=OTP_RATE_PER_MINUTE, per_hour_limit=OTP_RATE_PER_HOUR)`.
+      On deny → return `429` with JSON body
+      `{"detail": "too_many_requests", "retry_after": <seconds>}`.
+      Also sets `Retry-After: <seconds>` header.
+   3. `code = generate_code()`. `code_hash = hash_code(code)`.
+   4. `store_otp(email, code_hash, redis=..., ttl_seconds=OTP_CODE_TTL_SECONDS)`.
+   5. `await email_sender.send_otp(to=email, code=code)`.
+   6. Emit log event `auth.otp.requested email_hash=<h> provider=<name>`.
+   7. Respond `204 No Content`. **Same response for known and unknown
+      emails** — no DB lookup on request; email-to-user resolution
+      happens on verify (§7.1 "account enumeration" note).
+
+   Email-send failures from step 5 are caught and logged as
+   `auth.otp.send_failed email_hash=<h> provider=<name> reason=<code>`.
+   The stored OTP remains intact so a retry without re-request is
+   possible within TTL. The response is still `204` so the response
+   shape stays constant regardless of provider health — the rate
+   limiter ensures a user cannot weaponize this to spam Resend.
+
+8. **`POST /api/v1/auth/otp/verify`** — new route on the same router.
+   Request body: `OtpVerifyIn(email: str, code: str)`. Flow (verbatim
+   from §7.1 verify steps):
+   1. Validate email + code shape (code must be six digits; any non-
+      match short-circuits to the same failure path as "wrong code" to
+      avoid surfacing a distinct validation error).
+   2. `record = load_otp(email)`. Missing → `400 invalid_or_expired_code`.
+   3. `record.attempts >= OTP_MAX_ATTEMPTS` → `consume_otp(email)` then
+      `400 invalid_or_expired_code`.
+   4. `verify_code(code, record.code_hash)`:
+      - Mismatch → `increment_attempts_preserve_ttl(email)`,
+        `400 invalid_or_expired_code`.
+      - Match → `consume_otp(email)` (one-shot), proceed.
+   5. Find-or-create user + identity (§4 of the design doc). Helper
+      lives in `app.auth.service.find_or_create_user_for_otp`:
+      - Look up `(provider="email", provider_user_id=<normalized_email>)`
+        in `auth_identities`; if found, `user = identity.user`.
+      - Else look up `users` by email (case-insensitive via `CITEXT`);
+        if found, **auto-link** — create a new `auth_identities` row
+        with `provider="email"` and `provider_user_id=<normalized_email>`.
+      - Else create `User(email, display_name=None)` + grant default
+        `"user"` role + call
+        `app.auth.bootstrap.grant_admin_if_listed(user, ...)` + create
+        an `auth_identities` row with
+        `provider="email", provider_user_id=<normalized_email>,
+         email_at_identity=<normalized_email>`.
+      - The user record's `last_login_at` column is **not** updated
+        here because it does not exist on `users` today (see
+        `backend/app/auth/models.py:44-63` — 001 shipped `created_at`
+        and `updated_at` but not `last_login_at`, a minor deviation
+        from §6.1 of the design doc that 001 did not surface). This
+        feature touches **no migration**; adding `last_login_at` is
+        filed as a future tracking item. `auth_identities.last_used_at`
+        is also absent on 001's migration and not added here. The
+        design-doc §7.1 step 6 ("`last_login_at = now()`") is therefore
+        a documented no-op in 002, called out explicitly in the design
+        spec's "Deviations from the design doc" section.
+   6. Deactivated user (`is_active == false`): **also not applicable in 002.**
+      001 did not add `is_active` to the model (see `models.py`); no
+      code path can set it to false today. The design doc §7.1's
+      `403 account_disabled` failure mode is therefore unreachable in
+      this feature. The route still documents it in the OpenAPI
+      responses, guarded by a `getattr(user, "is_active", True)` check
+      so that when a later feature adds the column, the behavior comes
+      online automatically.
+   7. Create session (reuse `app.auth.sessions.create` — unchanged from
+      001). Pass a `_UserLike(id, email, role_names)` shim for the
+      same reason the test-mint route used it (avoid async lazy-load
+      on `user.roles`).
+   8. Set the session cookie using **exactly the same attributes** the
+      test-mint set — `settings.session_cookie_name`,
+      `settings.session_ttl_seconds`, `HttpOnly`, `SameSite=Lax`,
+      `Path=/`, `Secure` echoed from `settings.session_cookie_secure`.
+   9. Respond `200 OK` with body `MeResponse` (reuse 001's schema) —
+      same shape `GET /auth/me` returns, so the frontend can treat the
+      verify response interchangeably with a subsequent `/me` call.
+
+   The four failure conditions in step 2/3/4 all return the **same
+   body** `{"detail": "invalid_or_expired_code"}`, the same HTTP 400.
+   Attacker cannot distinguish "never requested" from "expired" from
+   "wrong code" from "attempts exhausted" — per §7.1 of the design doc.
+
+9. **Test-only OTP-code affordance** (env + env-var gated). Needed so
+   the external REST suite (`tests/tests/test_auth.py`) can drive
+   request → verify without scraping logs. Rules set by the human:
+
+   - **No hardcoded defaults in `app/settings.py`.** The two new
+     settings fields are `test_otp_email: str = ""` and
+     `test_otp_code: str = ""` — **empty defaults**, never populated
+     from a compiled-in literal.
+   - **Active only when `settings.env == "test"` AND both fields are
+     non-empty.** If either condition fails, the affordance is a no-op
+     — identical to production behavior.
+   - **Mechanism:** inside `POST /auth/otp/request`, after step 4
+     (stored real OTP) and **before** step 5 (send email), if the
+     affordance is active and the normalized request email matches
+     `settings.test_otp_email` (case-insensitive), **overwrite** the
+     stored `code_hash` with `hash_code(settings.test_otp_code)`. The
+     real code is still generated and still sent (so the console path
+     continues to log a decoy), but verify will succeed only for the
+     test code. Overwrite happens via the same `store_otp` call
+     (replacing the record; TTL resets to the configured value).
+   - **No behavior change on verify.** Verify reads whatever hash is
+     in Redis — no branching. The gating lives entirely in request.
+   - **No behavior change on rate-limit.** The test affordance does
+     not bypass rate limits; tests must space calls or reset
+     `otp_rate:*` keys via a test fixture.
+
+   The env-var names are `TEST_OTP_EMAIL` and `TEST_OTP_CODE`, matching
+   the `SESSION_COOKIE_*` / `ADMIN_EMAILS` style (upper-snake with the
+   feature-area prefix). New env-var rows in `infra/.env.example` sit
+   under a dedicated `# ---- Test-only OTP fixture (feat_auth_002) ----`
+   heading with both values **empty** and a multi-line comment block
+   explaining they must stay empty outside of the test environment.
+
+10. **Remove the test-only session-mint endpoint.** `test_router` and
+    `mint_test_session` in `backend/app/auth/router.py` (currently lines
+    114–175), their conditional mount in `backend/app/main.py`
+    (currently lines 107–114), and the `TestSessionRequest` schema in
+    `backend/app/auth/schemas.py` (currently lines 69–88, including the
+    import-level `field_validator` it pulled in) are **deleted**. The
+    corresponding test file `backend/tests/test_auth_test_mint_gating.py`
+    is deleted. The other 001 tests that rely on the mint endpoint
+    (`test_auth_middleware.py`, `test_auth_me_logout.py`) are rewritten
+    to mint sessions via `POST /api/v1/auth/otp/request` +
+    `POST /api/v1/auth/otp/verify` with the test-OTP affordance set up
+    by the test fixture. `test_auth_bootstrap.py`, `test_auth_dependencies.py`,
+    and `test_auth_sessions.py` do not use the mint endpoint and are
+    unchanged.
+
+    `app.auth.service.find_or_create_user_for_test` (currently defined
+    in `backend/app/auth/service.py`, referenced by
+    `design_auth_001.md:44` and exported at `service.py:195`) is
+    deleted alongside — the new `find_or_create_user_for_otp` replaces
+    it, and no test should synthesize users behind the router anymore.
+
+11. **New settings fields** (`backend/app/settings.py`), added under a
+    new `# ---- Email / OTP (feat_auth_002) ----` header block:
+
+    ```python
+    email_provider: Literal["console", "resend"] = "console"
+    email_from: str = "minimalist-app <noreply@example.com>"
+    email_provider_timeout_seconds: float = 5.0
+    resend_api_key: str = ""
+
+    otp_code_ttl_seconds: int = 600
+    otp_max_attempts: int = 5
+    otp_rate_per_minute: int = 1
+    otp_rate_per_hour: int = 10
+
+    # Test-only OTP fixture (see feat_auth_002 spec requirement 9).
+    # Intentionally has NO compiled-in default value; populated from env
+    # ONLY in the test environment. Must stay empty in dev/prod.
+    test_otp_email: str = ""
+    test_otp_code: str = ""
+    ```
+
+    All values use the exact numeric defaults the design doc §11
+    specifies. `test_otp_email` / `test_otp_code` additionally carry a
+    runtime guard: `app.auth.email.factory.build_email_sender` raises
+    `EmailProviderConfigError` at startup when
+    `settings.env != "test"` and either `test_otp_email` or
+    `test_otp_code` is non-empty — defense-in-depth against a
+    production .env that accidentally sets them.
+
+12. **New `.env.example` block** (`infra/.env.example`). Appended after
+    the existing auth block:
+
+    ```ini
+    # ---- Email / OTP (feat_auth_002) ---------------------------------------
+    # Controls how OTP codes are delivered. The `console` provider logs the
+    # code through the backend's structlog chain (visible via
+    # `docker compose logs backend | grep auth.email.console_otp_sent`).
+    # Switch to `resend` and populate RESEND_API_KEY in staging/prod — see
+    # docs/deployment/email-otp-setup.md.
+    EMAIL_PROVIDER=console
+    EMAIL_FROM=minimalist-app <noreply@example.com>
+    EMAIL_PROVIDER_TIMEOUT_SECONDS=5
+    RESEND_API_KEY=
+
+    OTP_CODE_TTL_SECONDS=600
+    OTP_MAX_ATTEMPTS=5
+    OTP_RATE_PER_MINUTE=1
+    OTP_RATE_PER_HOUR=10
+
+    # ---- Test-only OTP fixture (feat_auth_002) -----------------------------
+    # INTENTIONALLY EMPTY. Populate ONLY in the ENV=test environment.
+    # When both are set AND ENV=test, POST /auth/otp/request will make the
+    # verify code for TEST_OTP_EMAIL equal to TEST_OTP_CODE (rate-limit still
+    # applies). See docs/specs/feat_auth_002/feat_auth_002.md requirement 9.
+    # The backend refuses to start with these set when ENV != "test".
+    TEST_OTP_EMAIL=
+    TEST_OTP_CODE=
+    ```
+
+13. **Deployment documentation** (`docs/deployment/` — **new directory**,
+    per `conventions.md:120` this path is distinct from top-level
+    `deployment/` which is reserved for Helm/Terraform).
+
+    Two files ship in 002:
+
+    - **`docs/deployment/README.md`** — the landing-page index. One-
+      screen content per §13 of the design doc:
+
+      > External services that need manual setup before production.
+      > Each guide is self-contained and lists the env vars it populates.
+      >
+      > - [Email / OTP](email-otp-setup.md) — required for `feat_auth_002`
+      >   in non-dev environments (Sign in with email OTP).
+      > - *(Google OAuth — added by `feat_auth_003`.)*
+
+    - **`docs/deployment/email-otp-setup.md`** — the operator guide.
+      Structure per §13 of the design doc:
+      1. Provider comparison table (Resend / SendGrid / SES / Postmark —
+         four rows × four columns: **Price tier**, **Setup effort**,
+         **Free-tier ceiling**, **Primary region**).
+      2. Why the template defaults to Resend (simplest API, free tier).
+      3. **Dev login flow.** Explicit section: with the default
+         `EMAIL_PROVIDER=console`, the code is logged, not emailed.
+         Show the exact command to extract it:
+
+         ```bash
+         docker compose logs backend | grep auth.email.console_otp_sent | tail -n 1
+         ```
+
+         Plus the structlog-JSON field to grep
+         (`\"code\":\"123456\"`). This is the dev-mode login story the
+         human called out in clarifying answer 2.
+      4. Step 1: Create Resend account.
+      5. Step 2: Verify sending domain (DKIM + SPF DNS records). Call
+         out the 24 h DNS-propagation reality.
+      6. Step 3: Generate API key, note the scopes (sending only).
+      7. Step 4: Populate `.env` — `EMAIL_PROVIDER=resend`,
+         `RESEND_API_KEY=...`, `EMAIL_FROM="..."`.
+      8. Step 5: Verify — `make up`, POST `/api/v1/auth/otp/request`,
+         confirm email lands, check DKIM pass in headers.
+      9. Troubleshooting table: email in spam; DKIM fail;
+         sender-not-verified; Resend rate limit; switching to SendGrid.
+      10. Rotating credentials.
+      11. **Test-OTP fixture reminder.** Brief call-out reminding the
+          operator that `TEST_OTP_EMAIL` / `TEST_OTP_CODE` must stay
+          empty in non-test environments and that the backend refuses
+          to start otherwise (§11's startup guard).
+
+14. **Tracking rows.** `docs/tracking/features.md` gains a new row for
+    `feat_auth_002` with `Status=Specced`, Spec-PR and Issues
+    backfilled per Atlas's Step 4 / Step 5. `docs/specs/README.md`
+    roster table gains the same row.
+
+15. **Observability — log event vocabulary** (per §10 of the design
+    doc, §9.1 of this spec). Emit exactly the following events, no
+    more, no fewer:
+
+    | Event | Fields | Emitted by |
+    |---|---|---|
+    | `auth.otp.requested` | `email_hash`, `provider`, `rate_bucket_minute`, `rate_bucket_hour` | `/otp/request` happy path |
+    | `auth.otp.rate_limited` | `email_hash`, `retry_after`, `window` (`"minute"` or `"hour"`) | `/otp/request` deny |
+    | `auth.otp.send_failed` | `email_hash`, `provider`, `reason`, `http_status` (Resend only) | `/otp/request` step 5 error |
+    | `auth.email.console_otp_sent` | `email_hash`, `code` | `ConsoleEmailSender.send_otp` |
+    | `auth.otp.verified` | `user_id`, `email_hash`, `new_user` (bool) | `/otp/verify` happy path |
+    | `auth.otp.failed` | `email_hash`, `reason` ∈ `{missing,expired,wrong_code,attempts_exhausted}`, `attempts` | `/otp/verify` fail |
+    | `auth.session.created` | `user_id`, `session_id_hash` | verify happy path (reuses the helper from 001) |
+
+    `email_hash` and `session_id_hash` are the 16-char truncated
+    SHA-256 shapes already defined in `backend/app/middleware.py:186-194`
+    (the `_session_id_hash` pattern). OTP code is **never** logged
+    except in the `console_otp_sent` event (intentional dev-only
+    exception, called out in §10 of the design doc).
+
+### Non-functional
+
+16. **Python dependencies.** Exactly one new top-level addition:
+    `bcrypt>=4.1` in `backend/pyproject.toml` `[project] dependencies`.
+    `httpx` may be promoted from the `[dependency-groups] dev` list to
+    the main `dependencies` list if the build-time `uv pip show httpx`
+    check (requirement 3) shows it is not transitively available at
+    runtime; prefer promotion over adding the Resend SDK. **No Resend
+    SDK package is added.** No other additions.
+
+17. **No frontend changes.** The login UI is `feat_frontend_002`.
+    `frontend/` is untouched in this feature.
+
+18. **No schema changes.** No new Alembic migration. Every `users` /
+    `roles` / `user_roles` / `auth_identities` touch reuses the 001
+    schema exactly. The `last_login_at` / `last_used_at` /
+    `is_active` columns that the design doc §6.1 mentions but 001
+    did not implement stay absent; closing that gap is a future
+    backend-tracking ticket, filed outside this feature.
+
+19. **No DB hit on `/auth/me` or in `SessionMiddleware`.** The
+    invariant 001 established is preserved. OTP verify performs DB
+    writes (user + identity + role), which is expected — this is the
+    login path. `/otp/request` performs **zero DB writes** (by design:
+    keeps account enumeration impossible).
+
+20. **Backward-compatible with 001's external surface.**
+    `GET /api/v1/auth/me`, `POST /api/v1/auth/logout`, `/api/v1/hello`,
+    `/healthz`, `/readyz` are untouched in routing, behavior, and
+    response shape. The test-only mint at `POST /api/v1/_test/session`
+    is removed — any caller still hitting it gets `404 Not Found`
+    regardless of `env`.
+
+21. **Keeps `test.sh` passing.** The external suite under `tests/tests/`
+    continues to hit the live compose backend. Two new scenarios are
+    added (happy-path OTP request + verify using the test-OTP
+    affordance configured in a dedicated `tests/tests/conftest.py`
+    overlay); the existing `test_auth.py` assertions for unauthenticated
+    `/auth/me` + `/auth/logout` stay green.
+
+22. **No linting, formatting, or pre-commit tooling** (per
+    `conventions.md` §11).
+
+## User Stories
+
+- As **Vulcan** (builder of this feature), I want the session-creation
+  helper, `AuthContext` schema, `SessionMiddleware`, `current_user`
+  dependency, `ADMIN_EMAILS` bootstrap, and `auth_identities` table to
+  already exist, so OTP verify is purely a code-gen-and-check +
+  find-or-create + reuse-existing-helpers feature with no new
+  infrastructure.
+- As a **human developer on a fresh clone**, I want `make up && make test`
+  to keep passing with the default `.env.example`. The backend must not
+  require a Resend account — `EMAIL_PROVIDER=console` + "grep the
+  backend log for the code" is the documented dev login flow.
+- As a **human operator preparing for production**, I want one guide —
+  `docs/deployment/email-otp-setup.md` — that gets me from zero to a
+  working Resend integration, including the DKIM/SPF story, and one
+  landing page — `docs/deployment/README.md` — that tells me which
+  other external services a given feature requires.
+- As a **test author for the external REST suite**, I want a way to
+  drive `/otp/request` → `/otp/verify` deterministically without
+  scraping docker logs. The `TEST_OTP_EMAIL` / `TEST_OTP_CODE` env-gated
+  affordance gives me exactly one well-scoped injection point.
+- As a **security reviewer**, I want OTP codes to be bcrypt-hashed at
+  rest in Redis, rate-limited per email, one-shot on success,
+  bounded-attempts on failure, and indistinguishable across the four
+  bad-code conditions in the response body. All of §§7.1 + 8 of the
+  design doc is verifiable end-to-end from the test spec.
+
+## User Flow
+
+The OTP login flow is the user-facing contract; a sequence diagram is
+warranted (per the `## User Flow` template — this is a multi-step user-
+facing flow with response-shape branching).
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as Client
+    participant API as FastAPI (/auth/otp/*)
+    participant Redis
+    participant PG as Postgres
+    participant Mail as EmailSender
+
+    User->>UI: enter email
+    UI->>API: POST /auth/otp/request {email}
+    API->>Redis: INCR otp_rate:<h>:minute / :hour
+    alt rate exceeded
+        Redis-->>API: count > limit
+        API-->>UI: 429 {detail: too_many_requests, retry_after}
+        UI-->>User: "Try again in N seconds"
+    else allowed
+        Redis-->>API: count ok
+        API->>API: code = random 6 digits<br/>hash = bcrypt(code)
+        API->>Redis: SET otp:<h> {hash, attempts:0} EX 600
+        API->>Mail: send_otp(to, code)
+        Mail-->>API: ok
+        API-->>UI: 204 No Content
+        UI-->>User: "Check your email"
+    end
+
+    User->>UI: enter 6-digit code
+    UI->>API: POST /auth/otp/verify {email, code}
+    API->>Redis: GET otp:<h>
+    alt missing / expired / attempts>=max
+        Redis-->>API: null / exhausted
+        API-->>UI: 400 {detail: invalid_or_expired_code}
+    else mismatch
+        Redis-->>API: {hash, attempts}
+        API->>API: bcrypt verify fails
+        API->>Redis: SET otp:<h> {hash, attempts+1} KEEPTTL
+        API-->>UI: 400 {detail: invalid_or_expired_code}
+    else match
+        Redis-->>API: {hash, attempts}
+        API->>API: bcrypt verify ok
+        API->>Redis: DEL otp:<h>
+        API->>PG: find-or-create user + auth_identity
+        PG-->>API: user (+ new_user flag)
+        API->>Redis: SET session:<id> {user_id,email,roles} EX 86400<br/>SADD user_sessions:<uid>
+        API-->>UI: 200 MeResponse + Set-Cookie session=<id>
+        UI-->>User: logged in
+    end
+```
+
+## Scope
+
+### In Scope
+
+- `backend/app/auth/otp.py` — code generation, hashing, key helpers.
+- `backend/app/auth/otp_store.py` — Redis I/O for OTP and rate limit.
+- `backend/app/auth/email/__init__.py`, `base.py`, `console.py`,
+  `resend.py`, `factory.py`.
+- `backend/app/auth/schemas.py` — new `OtpRequestIn`, `OtpVerifyIn`
+  classes; **deletion** of `TestSessionRequest`.
+- `backend/app/auth/router.py` — two new route handlers
+  (`request_otp`, `verify_otp`); **deletion** of `test_router` and
+  `mint_test_session`.
+- `backend/app/auth/service.py` — new `find_or_create_user_for_otp`;
+  **deletion** of `find_or_create_user_for_test`.
+- `backend/app/main.py` — `app.state.email_sender` built at lifespan
+  startup; **deletion** of the env-gated `test_router` mount block.
+- `backend/app/settings.py` — new fields per requirement 11; startup
+  guard on `TEST_OTP_*`.
+- `backend/pyproject.toml` — `bcrypt>=4.1` added; `httpx` promoted to
+  main deps if the runtime check in requirement 3 shows it is not
+  transitively present.
+- `infra/.env.example` — new blocks per requirement 12.
+- `backend/tests/` — new tests per `test_auth_002.md`; **rewrite** of
+  `test_auth_middleware.py` and `test_auth_me_logout.py` to drive
+  sessions via OTP; **deletion** of `test_auth_test_mint_gating.py`.
+- `tests/tests/conftest.py` — overlay that configures `TEST_OTP_*` and
+  provides fixtures for new external scenarios.
+- `tests/tests/test_auth.py` — two new scenarios using the test-OTP
+  fixture.
+- `docs/deployment/README.md`, `docs/deployment/email-otp-setup.md`.
+- `docs/specs/feat_auth_002/{feat,design,test}_auth_002.md`.
+- `docs/specs/README.md`, `docs/tracking/features.md` — tracking rows.
+
+### Out of Scope
+
+- `GET /auth/google/start`, `GET /auth/google/callback`, `app/auth/google.py`,
+  JWKS verification, PKCE helpers — `feat_auth_003`.
+- `docs/deployment/google-oauth-setup.md` — `feat_auth_003`.
+- Any frontend work (login page, `AuthContext`, protected-route
+  wrapper, "signed in as" header) — `feat_frontend_002`.
+- Schema changes: `last_login_at`, `last_used_at`, `is_active`. Filed
+  outside this feature; not a blocker for OTP.
+- Account linking UI, email templating system, password reset, MFA/
+  TOTP, admin dashboard, account self-deletion (non-goals per §15 of
+  the design doc).
+- Custom email HTML templates. The OTP body is a string literal (§15
+  of the design doc).
+- Resend webhooks (bounce / complaint handling). Future ops concern.
+- Provider auto-fallback (`resend → sendgrid`). Single provider at a
+  time; switching is an ops-side env-var flip.
+
+## Acceptance Criteria
+
+- [ ] `backend/app/auth/email/base.py` exposes an `EmailSender` Protocol
+      with `async send_otp(*, to: str, code: str) -> None`. `console.py`
+      and `resend.py` both conform to it (verifiable via
+      `typing.runtime_checkable` + a `@pytest.mark.parametrize` fixture
+      over both implementations).
+- [ ] `ConsoleEmailSender.send_otp` emits exactly one log event
+      `auth.email.console_otp_sent` with fields `email_hash` and `code`,
+      using `app.logging.get_logger(__name__)`. No `print()` calls.
+- [ ] `ResendEmailSender.send_otp` POSTs to
+      `https://api.resend.com/emails` with a JSON body containing `from`,
+      `to`, `subject`, `text`; with `Authorization: Bearer <api_key>`;
+      with a configurable timeout. On a mocked non-2xx response it
+      raises `EmailSendError` carrying the HTTP status.
+- [ ] `build_email_sender(Settings(email_provider="resend", resend_api_key="", ...))`
+      raises `EmailProviderConfigError`. With `resend_api_key` set it
+      returns a `ResendEmailSender` instance.
+- [ ] `build_email_sender(Settings(env="dev", test_otp_email="x", test_otp_code="y", ...))`
+      raises `EmailProviderConfigError` at startup. With `env="test"`
+      and both set, it returns the configured provider and the
+      test-OTP overwrite path is active.
+- [ ] `otp.generate_code()` returns a 6-character all-digits string
+      over 10 000 samples. `otp.hash_code(code)` + `otp.verify_code(code, hash_)`
+      round-trips to `True`. `verify_code("999999", hash_of("000000"))`
+      is `False` with no timing spike detectable in the test harness.
+- [ ] `store_otp` + `load_otp` round-trip a record. Malformed JSON in
+      the Redis value → `load_otp` returns `None`.
+- [ ] `increment_attempts_preserve_ttl` increments `attempts` in the
+      stored record and leaves the key's remaining TTL within ±1 s of
+      its value before the call.
+- [ ] `check_and_increment_rate` returns `allowed=True` on the first
+      call, `allowed=False` with `retry_after ∈ [1, 60]` on the second
+      call within a minute when `per_minute_limit=1`. After the minute
+      TTL expires, the next call is `allowed=True` again.
+- [ ] `POST /api/v1/auth/otp/request` with a valid `{email}` returns
+      `204` and causes one `auth.otp.requested` log event. A second
+      call within 60 s returns `429` with body
+      `{"detail": "too_many_requests", "retry_after": <int>}` and a
+      `Retry-After` header.
+- [ ] `POST /api/v1/auth/otp/request` for **any** email (known or
+      unknown) returns the same `204` body and emits the same
+      `auth.otp.requested` event shape.
+- [ ] `POST /api/v1/auth/otp/request` with `EMAIL_PROVIDER=resend` and
+      the Resend endpoint mocked to return `500` still returns `204`,
+      emits `auth.otp.send_failed`, and leaves the stored OTP in Redis.
+- [ ] `POST /api/v1/auth/otp/verify` with the code minted by the
+      preceding request returns `200`, sets `Set-Cookie` with
+      `HttpOnly; Path=/; SameSite=Lax; Max-Age=86400` (plus `Secure`
+      when `SESSION_COOKIE_SECURE=true`), and returns a `MeResponse`
+      with `user_id`, `email`, `roles: ["user"]`. A follow-up
+      `GET /api/v1/auth/me` with the cookie returns the same payload.
+- [ ] `/auth/otp/verify` with a wrong code returns `400` body
+      `{"detail": "invalid_or_expired_code"}`. `attempts` in Redis
+      increments. A sixth wrong attempt returns the same 400; the
+      Redis key is deleted.
+- [ ] `/auth/otp/verify` with a never-requested email returns `400`
+      body `{"detail": "invalid_or_expired_code"}` — **same body** as
+      wrong code.
+- [ ] `/auth/otp/verify` twice with the same valid code: the second
+      call returns `400` `invalid_or_expired_code` (one-shot).
+- [ ] `ADMIN_EMAILS=alice@x.com` + OTP login for `alice@x.com` grants
+      both `user` and `admin`. `GET /auth/me` after verify shows both
+      roles.
+- [ ] A pre-existing user created by a hypothetical earlier
+      registration path (in the test suite, synthesized via a direct
+      SQL insert): first OTP login for that email **auto-links** a new
+      `auth_identities` row with `provider="email"` and reuses the
+      existing user; no duplicate `users` row.
+- [ ] `TEST_OTP_EMAIL=alice@x.com`, `TEST_OTP_CODE=123456`, `ENV=test`
+      → `/auth/otp/request` for `alice@x.com` stores
+      `hash_code("123456")`. `/auth/otp/verify` with `code="123456"`
+      succeeds. For any other email, the affordance is inactive and
+      the real generated code is what's stored.
+- [ ] Same settings with `ENV=dev` → backend refuses to start with
+      `EmailProviderConfigError`.
+- [ ] With `TEST_OTP_EMAIL=""` and `TEST_OTP_CODE=""` (defaults), the
+      affordance is inactive in `ENV=test` as well — behavior matches
+      production.
+- [ ] `POST /api/v1/_test/session` returns `404` under `ENV=test`
+      (endpoint deleted). `app.auth.service.find_or_create_user_for_test`
+      is not importable (symbol deleted). `TestSessionRequest` is not
+      importable (symbol deleted).
+- [ ] `backend/app/auth/router.py` no longer references `test_router`.
+      `backend/app/main.py` no longer contains the `if resolved.env == "test":
+      ... include_router(test_router, ...)` block.
+- [ ] `docs/deployment/README.md` exists with the index content from
+      requirement 13. `docs/deployment/email-otp-setup.md` exists
+      with the sections listed in requirement 13, including the dev-
+      flow `docker compose logs` snippet and the troubleshooting
+      table.
+- [ ] `infra/.env.example` contains the two new blocks under the
+      correct headings with the defaults from requirement 12. The
+      `TEST_OTP_*` block is immediately followed by the intentionally-
+      empty comment block.
+- [ ] `docs/tracking/features.md` contains a row for `feat_auth_002`
+      whose status advances `Specced` → `Ready` on merge. `docs/specs/README.md`
+      roster gains a matching row.
+- [ ] `uv run pytest` from `backend/` with `ENV=test` passes. Every
+      new test named in `test_auth_002.md` runs; the rewritten
+      `test_auth_middleware.py` / `test_auth_me_logout.py` continue to
+      pass using the OTP-minted sessions.
+- [ ] `test.sh` continues to pass, including the two new external
+      scenarios (requirement 21).
+
+## Follow-on features
+
+This spec treats the following as open, **not** committed, ordering for
+the remainder of the four-feature auth sequence. Confirmed before 002
+merges:
+
+- `feat_auth_003` — Google OAuth.
+- `feat_frontend_002` — Login UI.
+
+Default ordering (`002 → frontend_002 → 003`) is Atlas's working
+assumption per the human's note on clarifying question 1; it will be
+reconfirmed when 002 is close to merging.

--- a/docs/specs/feat_auth_002/test_auth_002.md
+++ b/docs/specs/feat_auth_002/test_auth_002.md
@@ -1,0 +1,361 @@
+# Test: Email OTP login
+
+## Scope
+
+This feature ships two new endpoints (`POST /api/v1/auth/otp/request`
+and `POST /api/v1/auth/otp/verify`), the `EmailSender` abstraction with
+two implementations, OTP helpers, a Redis-backed OTP store, and an
+env-gated test fixture that makes the verify code deterministic. It
+**removes** the `POST /api/v1/_test/session` endpoint introduced in
+`feat_auth_001`.
+
+Tests therefore:
+
+1. Unit-test every helper (`otp.py`, `otp_store.py`, `email/console.py`,
+   `email/resend.py`, `email/factory.py`) in isolation.
+2. Integration-test the two endpoints end-to-end against a real
+   Postgres + Redis, driven by the `TEST_OTP_*` fixture so verify is
+   deterministic without log scraping.
+3. Assert the deletion of the `_test/session` endpoint and the
+   associated symbols (`test_router`, `TestSessionRequest`,
+   `find_or_create_user_for_test`).
+4. Rewrite the two 001 tests that relied on the old mint endpoint
+   (`test_auth_middleware.py`, `test_auth_me_logout.py`) to mint via
+   OTP.
+5. Verify the `TEST_OTP_*` startup guard refuses to boot outside
+   `env=test`.
+6. Extend the external REST suite (`tests/tests/test_auth.py`) with
+   two new scenarios: happy-path OTP login through compose, and
+   wrong-code → 400.
+
+Coverage of Google OAuth (§9.2 Google rows of the design doc) and
+frontend login (§9.4) is **out of scope** — those land with `feat_auth_003`
+and `feat_frontend_002`.
+
+## New test files
+
+### `backend/tests/test_auth_otp_helpers.py`
+
+Unit tests for `backend/app/auth/otp.py`. Pure functions, no I/O.
+
+| # | Case | Input | Expected output |
+|---|---|---|---|
+| 1 | `generate_code` length and alphabet | call 10 000 times | every result matches `^[0-9]{6}$` |
+| 2 | `generate_code` uses `secrets.randbelow` | inspect module source via `inspect.getsource` | source references `secrets.randbelow`, not `random.` |
+| 3 | `hash_code` / `verify_code` round-trip | `code="123456"` | `verify_code("123456", hash_code("123456")) is True` |
+| 4 | `verify_code` mismatch | `code="000000"`, hash of `"123456"` | returns `False` |
+| 5 | `verify_code` constant-time (smoke) | hash one code; verify 100× with correct then wrong code | both batches complete; timing difference under 20 ms across batches (sanity, not proof) |
+| 6 | `email_hash` lowercases + trims | inputs `"Alice@X.com"`, `" alice@x.com "`, `"alice@x.com"` | all three produce the same hex string |
+| 7 | `email_hash` output shape | any input | `re.match(r"^[0-9a-f]{64}$", result)` |
+| 8 | `otp_key` | `"alice@x.com"` | `"otp:" + email_hash("alice@x.com")` |
+| 9 | `rate_limit_keys` | `"alice@x.com"` | returns `(f"otp_rate:{h}:minute", f"otp_rate:{h}:hour")` |
+| 10 | bcrypt work factor | inspect hash | `hash_code(code)[:7] == "$2b$10$"` (10 rounds) |
+
+### `backend/tests/test_auth_otp_store.py`
+
+Unit tests for `backend/app/auth/otp_store.py`. Uses the existing
+`require_redis` fixture; skips when Redis is unreachable.
+
+| # | Case | Arrangement | Assertion |
+|---|---|---|---|
+| 1 | `store_otp` + `load_otp` round-trip | Store with `code_hash="$2b$10$..."`, `ttl=600` | `load_otp` returns `OtpRecord(code_hash=..., attempts=0, created_at=...)`. `TTL otp:<h>` ∈ `[595, 600]`. |
+| 2 | `load_otp` missing key | No store; random email | returns `None` |
+| 3 | `load_otp` malformed payload | `SET otp:<h> "not json"` | returns `None`. No exception. |
+| 4 | `load_otp` dict missing `code_hash` | `SET otp:<h> '{"attempts":0}'` | returns `None` |
+| 5 | `increment_attempts_preserve_ttl` increments counter | Store with `attempts=0`, `ttl=600`; `sleep(0)`; call twice | `load_otp.attempts == 2`. TTL after second call within ±1 s of the first call's TTL. |
+| 6 | `increment_attempts_preserve_ttl` on missing key | Never stored | returns 0; no key created. |
+| 7 | `consume_otp` deletes the key | Store; consume | `GET otp:<h> -> None` |
+| 8 | `check_and_increment_rate` first call allowed | `per_minute_limit=1`, `per_hour_limit=10` | `RateLimitResult(allowed=True, retry_after=0, window=None)`. `otp_rate:<h>:minute` exists with TTL ∈ `[55, 60]`. |
+| 9 | Second call within the minute denies | As case 8, then immediate second call | `RateLimitResult(allowed=False, retry_after ∈ [1,60], window="minute")`. No new `otp:*` key would be written (caller's responsibility). |
+| 10 | After minute TTL expires | Case 9, then `PEXPIRE otp_rate:<h>:minute 1` + wait | Third call `allowed=True`. |
+| 11 | Hour limit enforced | `per_minute_limit=99`, `per_hour_limit=3`; call 4× rapidly | 4th returns `RateLimitResult(allowed=False, retry_after ∈ [1,3600], window="hour")`. |
+| 12 | First-increment-only `EXPIRE NX` | Inspect with `PTTL` after 5 rapid calls | TTL counts down monotonically; does not reset to 60/3600 on later calls. |
+
+### `backend/tests/test_auth_email_senders.py`
+
+Unit tests for `ConsoleEmailSender` and `ResendEmailSender`.
+
+**`ConsoleEmailSender`**:
+
+| # | Case | Arrangement | Assertion |
+|---|---|---|---|
+| 1 | `send_otp` emits the console event | capture structlog with `structlog.testing.capture_logs()` | exactly one record with `event == "auth.email.console_otp_sent"`, `email_hash`, `code` fields populated; no `to` field leaks raw email |
+| 2 | No `print()` calls | `capsys.readouterr()` | `captured.out == ""` and `captured.err == ""` |
+| 3 | `email_hash` matches `otp.email_hash(to)` | vary `to` case | assertion holds across cases |
+
+**`ResendEmailSender`** (using `httpx.MockTransport`):
+
+| # | Case | Arrangement | Assertion |
+|---|---|---|---|
+| 4 | Happy path | mock returns `200 {"id": "em_abc"}` | one request: `POST https://api.resend.com/emails` with JSON body containing `from == settings.email_from`, `to == <email>`, `subject`, `text` (containing the code). `Authorization: Bearer <api_key>` header. |
+| 5 | Non-2xx raises `EmailSendError` | mock returns `500 {"message": "oops"}` | `pytest.raises(EmailSendError)`; error carries `status_code == 500` and `detail == "oops"`. |
+| 6 | Non-JSON 5xx | mock returns `502 "bad gateway"` (text) | `EmailSendError(status_code=502, detail=None)`. |
+| 7 | Timeout surfaces as `EmailSendError` | mock raises `httpx.ReadTimeout` | `EmailSendError(status_code=None, detail="timeout")`. |
+| 8 | Never logs API key | capture structlog across cases 4–7 | no log record contains the test API key substring. |
+| 9 | Never logs OTP code | same capture | no log record under the ResendEmailSender module emits `code`. |
+| 10 | `Protocol` conformance | `isinstance(sender, EmailSender)` | `True` for both `ConsoleEmailSender()` and `ResendEmailSender(...)` (requires `@runtime_checkable`). |
+
+### `backend/tests/test_auth_email_factory.py`
+
+Unit tests for `build_email_sender`.
+
+| # | Case | Settings | Expected |
+|---|---|---|---|
+| 1 | Console path | `email_provider="console"` | returns `ConsoleEmailSender` instance |
+| 2 | Resend happy path | `email_provider="resend"`, `resend_api_key="k"`, `email_from="x"` | returns `ResendEmailSender` instance with fields populated |
+| 3 | Resend missing api key | `email_provider="resend"`, `resend_api_key=""` | raises `EmailProviderConfigError` with message mentioning `RESEND_API_KEY` |
+| 4 | Resend missing from | `email_provider="resend"`, `email_from=""` | raises `EmailProviderConfigError` mentioning `EMAIL_FROM` |
+| 5 | Unknown provider | `email_provider="sendgrid"` (Pydantic `Literal` should reject at Settings level, but factory guards anyway) | Settings instantiation raises; or, if bypassed by `model_construct`, factory raises `EmailProviderConfigError` |
+| 6 | Startup guard: test-OTP set in dev | `env="dev"`, `test_otp_email="a"`, `test_otp_code="b"` | raises `EmailProviderConfigError` referencing `TEST_OTP_EMAIL`/`TEST_OTP_CODE` |
+| 7 | Startup guard: test-OTP set in prod | `env="prod"`, `test_otp_email="a"`, `test_otp_code="b"` | raises `EmailProviderConfigError` |
+| 8 | Startup guard: test-OTP partial in test | `env="test"`, `test_otp_email="a"`, `test_otp_code=""` | does **not** raise (gating requires both; partial is a no-op, treated as off) |
+| 9 | Startup guard: test-OTP both empty in non-test | `env="dev"`, both empty | does not raise |
+| 10 | Startup guard: test-OTP both set in test | `env="test"`, both non-empty | does not raise |
+
+### `backend/tests/test_auth_otp_request.py`
+
+Endpoint tests for `POST /api/v1/auth/otp/request`. Real Postgres +
+Redis via `require_db` / `require_redis`. The email sender is
+**monkeypatched** on `app.state.email_sender` to a spy that records
+calls — the factory still builds the real console sender at startup,
+but the test replaces it so send failures can be simulated.
+
+| # | Case | Arrangement | Assertion |
+|---|---|---|---|
+| 1 | Happy path — console | fresh Redis; `email_provider="console"`; POST `{email: "alice@x.com"}` | 204. Spy recorded one call `send_otp(to="alice@x.com", code="NNNNNN")`. Redis has `otp:<h>` with `attempts=0`, TTL ∈ `[595, 600]`. One log event `auth.otp.requested` with `provider="console"`. |
+| 2 | Same response for unknown email | POST `{email: "never-registered@x.com"}` | 204. Spy recorded one call. `otp:<h>` stored. No DB read for users. |
+| 3 | Rate limit denies second request within 60 s | Two POSTs back-to-back | first 204; second 429 body `{"detail": "too_many_requests", "retry_after": <int>}`, header `Retry-After: <same int>`. Log event `auth.otp.rate_limited` with `window="minute"`. |
+| 4 | Rate limit hour window | `per_minute_limit=99`, `per_hour_limit=3`, 4 requests | 4th returns 429 with `window="hour"`. |
+| 5 | Email-shape validation | POST `{email: "not-an-email"}` | 400 or 422 (whichever the schema produces by default; assert it's a 4xx, not 5xx; this input is invalid before the shape-normalization path). |
+| 6 | `extra="forbid"` | POST `{email: "a@b.c", foo: "bar"}` | 422 (Pydantic). Not this feature's core concern; asserts the model config stays strict. |
+| 7 | Resend 500 still 204 | `email_provider="resend"`, MockTransport returns 500 | response 204. Log event `auth.otp.send_failed` with `reason="http_error"` and `http_status=500`. Redis `otp:<h>` still present. |
+| 8 | Resend timeout still 204 | MockTransport raises `ReadTimeout` | 204. Log event `auth.otp.send_failed` with `reason="timeout"`. |
+| 9 | Store-then-send ordering | Replace the spy to raise after recording — but the `auth.otp.send_failed` path must still observe a stored OTP | After the call, `otp:<h>` is present. Verify step (a subsequent `/verify` test in `test_auth_otp_verify.py`) can succeed. |
+| 10 | Case-insensitive email key | POST `{email: "Alice@X.com"}`, then POST `{email: "alice@x.com"}` | Second call denied by rate limit because both normalize to the same hash. |
+| 11 | Zero DB writes | Wrap the call in a SQLAlchemy query-recording context | Recorded list is empty. |
+| 12 | Email is not in the response body | inspect body bytes | empty body (204). |
+
+### `backend/tests/test_auth_otp_verify.py`
+
+Endpoint tests for `POST /api/v1/auth/otp/verify`. Uses the test-OTP
+fixture with `TEST_OTP_EMAIL="alice@x.com"`, `TEST_OTP_CODE="123456"`,
+`ENV=test` so the verify code is deterministic.
+
+| # | Case | Flow | Assertion |
+|---|---|---|---|
+| 1 | Happy path new user | POST `/otp/request {email: alice@x.com}`; POST `/otp/verify {email: alice@x.com, code: 123456}` | 200. `Set-Cookie` contains `session=<64 hex>; Path=/; HttpOnly; SameSite=Lax; Max-Age=86400`. Body is `MeResponse(user_id, email: 'alice@x.com', display_name: None, roles: ['user'])`. One `users` row and one `auth_identities` row (`provider='email'`). One `user_roles` row granting `user`. Log events: `auth.otp.verified new_user=true`, `auth.session.created`. |
+| 2 | `/me` round-trip after verify | case 1 cookie | `GET /auth/me` returns same `MeResponse`. |
+| 3 | Wrong code → 400 uniform body | request; verify with `code="999999"` | 400 body `{"detail": "invalid_or_expired_code"}`. Redis `otp:<h>` still present, `attempts=1`. Log event `auth.otp.failed reason=wrong_code attempts=1`. |
+| 4 | Five wrong codes then correct code locked | request; verify wrong ×5; verify correct | 6th call returns 400 same body. Redis `otp:<h>` now deleted (one-shot lockout). Log event `auth.otp.failed reason=attempts_exhausted`. |
+| 5 | One-shot on success | request; verify correct; verify correct again | second verify returns 400 `invalid_or_expired_code`. |
+| 6 | Never-requested email | `ENV=test`, fixture set; verify `{email: bob@x.com, code: 123456}` | 400 body identical to wrong-code. Log event `auth.otp.failed reason=missing`. |
+| 7 | Expired OTP | request; `DEL otp:<h>` manually to simulate TTL expiry; verify correct code | 400 `invalid_or_expired_code`. |
+| 8 | Non-six-digit code rejected as invalid_or_expired_code, not 422 | request; verify `{code: "1234"}` | 400 (not 422) with body `{"detail": "invalid_or_expired_code"}`. Route-level mapping is working. |
+| 9 | Non-digit code | verify `{code: "abcdef"}` | 400 `invalid_or_expired_code`. |
+| 10 | Case-insensitive email on verify | request with `{email: Alice@X.com}`; verify with `{email: alice@x.com, code: 123456}` | 200. Same `users` row (CITEXT). |
+| 11 | Auto-link existing user | Seed `users(alice@x.com)` directly via SQL; no pre-existing `auth_identities` row; request + verify | 200. Now exactly one `auth_identities(provider='email', provider_user_id='alice@x.com')` row. No duplicate `users` row. |
+| 12 | Reuse existing email-identity | Seed `users` + `auth_identities(email, alice@x.com, ...)`; request + verify | 200. No new `users` row, no new `auth_identities` row. |
+| 13 | `ADMIN_EMAILS` bootstrap on first login | `ADMIN_EMAILS="alice@x.com"`; new user flow | `MeResponse.roles == ["admin", "user"]` (sorted). `user_roles` has two rows. |
+| 14 | Second login does not duplicate roles | case 13, then a second request+verify for the same email (after rate-limit reset) | Still exactly two `user_roles` rows. Idempotent. |
+| 15 | Zero DB writes on /request path, DB writes only on /verify | Query-recorder around both calls | `/request` records zero. `/verify` records the expected find-or-create + identity inserts. |
+| 16 | Cookie Secure attribute reflects settings | verify with `SESSION_COOKIE_SECURE=true` | `Set-Cookie` contains `Secure`. With `false` (default), does not. |
+| 17 | Concurrent verify for a new email does not duplicate | fire two `/verify` calls in parallel for a new email with the test code | both succeed OR one 400s after the other consumed the OTP — either way, `users` has one row, `auth_identities` has one row. |
+| 18 | Verify failure does not create a user | request; verify wrong code | `users` row count unchanged. |
+| 19 | `_test/session` is gone | `POST /api/v1/_test/session` under `ENV=test` | 404 (endpoint deleted). |
+| 20 | Symbols deleted | `pytest.raises(ImportError)` on `from app.auth.schemas import TestSessionRequest`, `from app.auth.service import find_or_create_user_for_test`, `from app.auth.router import test_router` | all three raise. |
+
+### `backend/tests/test_auth_test_otp_fixture.py`
+
+Dedicated tests for the `TEST_OTP_EMAIL` / `TEST_OTP_CODE` env-gated
+affordance.
+
+| # | Case | Settings | Flow | Expected |
+|---|---|---|---|---|
+| 1 | Fixture active overwrites stored hash | `env=test`, both set, email matches | request, then inspect `otp:<h>.code_hash` | `verify_code(settings.test_otp_code, code_hash) is True` |
+| 2 | Fixture active, email does not match | `env=test`, both set, request for a different email | inspect stored hash | Hash is the **real** generated code's hash; test code does not verify. |
+| 3 | Fixture off in `env=test` when either var empty | `env=test`, `test_otp_email="x"`, `test_otp_code=""` | request for `x` | real generated code is stored; test code does not verify. |
+| 4 | Fixture off in `env=dev` even when both set would be refused at startup | separate subtest: `create_app(Settings(env="dev", test_otp_email="x", test_otp_code="y"))` | — | raises `EmailProviderConfigError` during lifespan startup (factory guard). |
+| 5 | Test-OTP path does not bypass rate limit | fixture active; two requests within 60 s | second is 429, regardless of fixture | |
+| 6 | Console sender still logs a decoy | fixture active; grab captured logs | `auth.email.console_otp_sent` event fired with `code` equal to the **generated** code, not the test code (intentional — so a human tailing logs cannot shortcut their way into the test account). |
+| 7 | Verify code matches fixture, not generated | fixture active; request; verify with `settings.test_otp_code` | 200 |
+| 8 | Verify code matches generated does NOT succeed | fixture active; request; scrape generated code from log; verify with that | 400 `invalid_or_expired_code` (because the hash was overwritten). |
+| 9 | `grep test_otp_ backend/app/` hits exactly three locations | walk the tree with `ast` | exactly: `settings.py` field definitions, `router.py` request handler branch, `email/factory.py` startup guard |
+
+Case 9 is a repo-hygiene assertion — it makes sure future contributors
+cannot sneak a fourth use of `test_otp_*` into production code without
+the test tripping.
+
+### Rewrites of 001 test files
+
+#### `backend/tests/test_auth_middleware.py` (rewrite)
+
+The six cases of 001's middleware tests are preserved. Only the
+cookie-minting step changes.
+
+| # | Case | Change from 001 | Assertion (unchanged) |
+|---|---|---|---|
+| 1 | Public endpoint, no cookie | unchanged | 200, no `Set-Cookie` |
+| 2 | Valid cookie populates context | Mint via `/otp/request` + `/otp/verify` (fixture) instead of `/_test/session` | 200, body echoes `roles` |
+| 3 | Expired session clears cookie | Mint via OTP; `DEL session:<id>`; call `/me` | 401, cookie cleared, log event `auth.session.expired_cookie_cleared reason=missing_key` |
+| 4 | Malformed payload clears cookie | Mint via OTP; overwrite session value with `b"not json"`; call `/me` | 401, cookie cleared, reason=`malformed_payload` |
+| 5 | Malformed cookie shape | Send arbitrary 60-hex cookie | 401, cookie cleared, reason=`malformed_cookie` |
+| 6 | Middleware runs after RequestID | Inspect case 3 log | carries `request_id` |
+
+#### `backend/tests/test_auth_me_logout.py` (rewrite)
+
+001's nine cases, all preserved. The "mint" step is replaced with the
+OTP flow.
+
+| # | Case | Change | Assertion (unchanged) |
+|---|---|---|---|
+| 1 | Happy path mint → `/me` → logout → `/me` | mint via OTP | as in 001 |
+| 2 | ADMIN_EMAILS bootstrap | mint via OTP | roles contains `admin` and `user` |
+| 3 | Non-bootstrap user | mint via OTP | roles exactly `["user"]` |
+| 4 | Extra roles parameter | **deleted** — `TestSessionRequest.roles` no longer exists | — |
+| 5 | Idempotent mint | Two OTP cycles for the same email | `users` has one row; now **one** `auth_identities` row (001 had zero because the mint path skipped identities). |
+| 6 | `revoke_sessions_for_user` end-to-end | two OTP cycles (separate requests, rate-limit-spaced) → revoke | both sessions 401 afterwards |
+| 7 | No cookie → 401 | unchanged | 401 |
+| 8 | Logout without session | unchanged | 401; no Redis delete command recorded |
+| 9 | Cookie attributes | inspect cookie set by `/otp/verify` | `HttpOnly; SameSite=Lax; Path=/; Max-Age=86400`; `Secure` only when settings say so |
+
+Case 4 being deleted is intentional: the removed `roles` field on the
+request body was a mint-endpoint convenience. Real login paths do not
+accept caller-specified roles. Test spec reflects reality.
+
+### `backend/tests/test_migration_0002_auth.py` (unchanged from 001)
+
+002 adds no migration, so 001's migration test file is **not edited**.
+
+## External REST tests — `test.sh` extensions
+
+Two new scenarios added to `tests/tests/test_auth.py`, using a new
+scoped `otp_fixture` fixture that sets `TEST_OTP_EMAIL` / `TEST_OTP_CODE`
+via the compose-side `.env` overlay.
+
+**Setup requirement.** The compose stack must be brought up with the
+two test vars set in `infra/.env`. The `test.sh` flow is unchanged;
+what changes is that the CI/local operator running `./test.sh` must
+either:
+
+- Set `TEST_OTP_EMAIL` + `TEST_OTP_CODE` in `infra/.env` before `make up`, or
+- Use a `docker compose override` file that the external-test suite
+  brings in (Vulcan's call; either is acceptable).
+
+The spec documents this and the test file skips gracefully with a
+clear reason when the vars are unset on the live backend (probed via
+an introspection endpoint? — **no, that would add a prod surface**;
+instead, the skip is conditional on the suite-side `TEST_OTP_EMAIL` /
+`TEST_OTP_CODE` env vars being set at `test.sh` launch time, mirroring
+the backend's settings).
+
+Existing 001 assertions stay:
+
+| # | Case | Steps | Assertion |
+|---|---|---|---|
+| 1 | `/auth/me` requires a cookie | GET with no cookie | 401 |
+| 2 | `/auth/logout` without a cookie | POST with no cookie | 401 |
+
+New 002 assertions:
+
+| # | Case | Steps | Assertion |
+|---|---|---|---|
+| 3 | OTP happy path | POST `/otp/request` for `TEST_OTP_EMAIL`; POST `/otp/verify` with `TEST_OTP_CODE`; GET `/me` | request 204, verify 200 + Set-Cookie, `/me` 200 with email matching `TEST_OTP_EMAIL` |
+| 4 | OTP wrong code | POST `/otp/request`; POST `/otp/verify` with `"999999"` | verify 400 body `{"error":{"message":"invalid_or_expired_code", ...}}` (envelope shape from `feat_backend_002`) |
+
+Scenarios 3–4 are skipped when the live backend's env does not have
+the fixture set — detected by a single discovery POST that records the
+result and short-circuits subsequent assertions.
+
+## Boundary conditions
+
+| Condition | Expected behavior |
+|---|---|
+| `OTP_CODE_TTL_SECONDS=1` | Mint + immediate verify succeeds. `sleep 2` + verify fails 400 (expired). |
+| `OTP_MAX_ATTEMPTS=1` | First wrong code → 400; second call (even with correct code) → 400 (attempts exhausted on first wrong). |
+| `OTP_RATE_PER_MINUTE=0` | Every request 429 (minute counter starts at 1, exceeds 0 immediately). |
+| `OTP_RATE_PER_HOUR=0` | Same — every request 429. |
+| `EMAIL_PROVIDER_TIMEOUT_SECONDS=0.001` | Resend path reliably times out → `EmailSendError(timeout)`; response 204 unchanged. |
+| `RESEND_API_KEY=""` + `EMAIL_PROVIDER=resend` | Factory raises `EmailProviderConfigError` on app startup. `make up` fails loudly. |
+| Email with 300 characters | Accepted by shape check (only requires `@` and length ≥ 3). `CITEXT` column has no length cap. |
+| Email with leading/trailing whitespace | Stripped by `_validate_email_shape`; hash is the stripped form. |
+| Email differing only in case | Same `otp_key`, same `users` row thanks to `CITEXT`. |
+| Code with leading zeros ("012345") | bcrypt preserves the string bytes; hash and verify round-trip. |
+| Code exactly "000000" / "999999" | Acceptable inputs; no special-case. |
+| `TEST_OTP_CODE="abcdef"` (non-digit) | Verify-side shape check still requires 6 digits. Trying to verify with the fixture code → 400. Effectively disables the fixture without a startup error. Documented as "operator footgun; set a numeric test code." |
+| `TEST_OTP_CODE` with leading/trailing whitespace | The fixture comparison trims on both sides (mirrors `_validate_email_shape` trim behavior), so padded values work. |
+| `TEST_OTP_EMAIL="ALICE@X.COM"` | Case-insensitive match on the inbound request; overwrite applies. |
+| Concurrent `/request` and `/verify` for the same email | Rate limit spans both endpoints? **No** — rate limit applies only to `/request`. `/verify` has no rate limit of its own but is gated by `OTP_MAX_ATTEMPTS`. |
+| Redis down during `/verify` | Exception bubbles up to the exception envelope → 500 `internal_error`. Not a user-facing path. |
+| Postgres down during `/verify` | Same. Exception envelope → 500. |
+
+## Security considerations
+
+The design doc §8 posture table is the full picture. This test spec
+verifies the slice of it that 002 actually implements.
+
+- **Account enumeration parity** — `test_auth_otp_request.py` case 2
+  asserts identical response for known and unknown emails, no DB
+  read on `/request`.
+- **Bad-code uniformity** — `test_auth_otp_verify.py` cases 3, 6, 7, 8
+  all assert body `{"detail": "invalid_or_expired_code"}` and HTTP
+  400. Missing, expired, wrong, and exhausted all indistinguishable.
+- **Rate-limit applies across case** — `test_auth_otp_request.py`
+  case 10.
+- **One-shot on success** — `test_auth_otp_verify.py` case 5.
+- **Attempt exhaustion lockout** — case 4.
+- **OTP stored as bcrypt hash** — `test_auth_otp_helpers.py` case 10
+  checks the `$2b$10$` prefix; `test_auth_otp_store.py` stores and
+  retrieves the hashed form.
+- **API key never logged** — `test_auth_email_senders.py` case 8.
+- **Code only in dev log event** — `test_auth_test_otp_fixture.py`
+  case 6 (console event) and `test_auth_email_senders.py` case 9
+  (no code in Resend path).
+- **Test-OTP fixture cannot run in prod** — `test_auth_email_factory.py`
+  cases 6–7; `test_auth_test_otp_fixture.py` case 4.
+- **Cookie flags on verify** — `test_auth_otp_verify.py` case 16,
+  plus `test_auth_me_logout.py` (rewrite) case 9.
+- **Session hashing in logs** — the session-creation log event
+  (`auth.session.created`) uses `session_id_hash`, not raw ID;
+  verified by inspecting captured logs in
+  `test_auth_otp_verify.py` case 1.
+
+## What is intentionally not tested
+
+- **Google OAuth.** No code for it exists in 002.
+- **Frontend OTP form.** `feat_frontend_002`.
+- **`last_login_at` / `last_used_at`.** Columns do not exist; design-
+  doc steps that would update them are documented no-ops per
+  `design_auth_002.md` "Deviations".
+- **`is_active=false` branch.** Column does not exist; the `403
+  account_disabled` failure mode is unreachable.
+- **Multi-provider email fallback.** Single provider at a time.
+- **Resend webhooks.** Future ops feature.
+- **Email rendering / HTML templating.** Body is a plain-text string.
+- **OTP code uniqueness across users.** Two users in different
+  requests can legally get the same six-digit code; the lookup is by
+  email hash, not code.
+- **Concurrent rate-limit writes.** The `EXPIRE ... NX` semantics
+  handle this correctly per Redis; retesting Redis's own atomicity is
+  out of scope.
+- **Alembic migration file.** None added.
+- **`conventions.md`.** Not modified by this feature.
+
+## Regression surface
+
+| Regression | What fails |
+|---|---|
+| `/request` response body differs between known and unknown email | `test_auth_otp_request.py` case 2 |
+| `/verify` bad-code conditions leak distinguishing information | `test_auth_otp_verify.py` cases 3, 6, 7, 8 (same-body assertion) |
+| OTP code stored in plaintext | `test_auth_otp_store.py` case 1 (asserts `code_hash` is bcrypt) |
+| Rate limit reset on every increment | `test_auth_otp_store.py` case 12 |
+| Test-OTP fixture leaks into dev/prod | `test_auth_email_factory.py` cases 6–7; `test_auth_test_otp_fixture.py` case 4 |
+| Removing the `/_test/session` endpoint accidentally kept in the tree | `test_auth_otp_verify.py` case 19 + case 20 |
+| Verify shape validation returns 422 instead of 400 | `test_auth_otp_verify.py` cases 8–9 |
+| Session cookie missing `HttpOnly` | `test_auth_otp_verify.py` case 16 |
+| Verify's one-shot semantic regresses | `test_auth_otp_verify.py` case 5 |
+| Attempts lockout not consumed on 6th call | `test_auth_otp_verify.py` case 4 |
+| Resend API key logged | `test_auth_email_senders.py` case 8 |
+| Settings field `test_otp_email` has a compiled-in default | `test_auth_email_factory.py` case 9 (empty-empty default) + `grep` hygiene in `test_auth_test_otp_fixture.py` case 9 |
+| Email sender is `print`-based instead of structlog | `test_auth_email_senders.py` case 2 |
+| `TEST_OTP_*` fixture also skips rate limit | `test_auth_test_otp_fixture.py` case 5 |
+| Symbols `TestSessionRequest`, `find_or_create_user_for_test`, `test_router` survive | `test_auth_otp_verify.py` case 20 |

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -9,3 +9,4 @@
 | feat_testing_001 | external REST functional test suite | Merged | #14 | #13 | #15 | - |
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
+| feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Specced | #22 | #23 | - | - |


### PR DESCRIPTION
## Specifications for feat_auth_002

First real login path on top of the `feat_auth_001` foundation: email
one-time-password (OTP). Adds the `EmailSender` abstraction with a
`ConsoleEmailSender` (dev) and `ResendEmailSender` (prod), the two OTP
endpoints (`POST /auth/otp/request`, `POST /auth/otp/verify`), and the
deployment documentation under `docs/deployment/`. Removes the temporary
`POST /api/v1/_test/session` endpoint shipped in 001.

### Spec Files
- Feature: `docs/specs/feat_auth_002/feat_auth_002.md`
- Design: `docs/specs/feat_auth_002/design_auth_002.md`
- Test: `docs/specs/feat_auth_002/test_auth_002.md`

### Highlights
- Two new endpoints on `/api/v1/auth/otp/*` with rate limiting and bcrypt-hashed codes per §7.1 of `docs/design/auth-login-and-roles.md`.
- `EmailSender` Protocol + `ConsoleEmailSender` + `ResendEmailSender` under `backend/app/auth/email/`. Resend uses `httpx` (no SDK). `bcrypt>=4.1` is the one new top-level Python dependency.
- Env-gated test fixture (`TEST_OTP_EMAIL` / `TEST_OTP_CODE`) for deterministic external-suite login. Active only under `ENV=test` + both values non-empty; backend refuses to start otherwise. No hardcoded defaults in `settings.py`.
- Deletes `POST /api/v1/_test/session`, `TestSessionRequest`, `find_or_create_user_for_test`, and `test_auth_test_mint_gating.py`. Rewrites `test_auth_middleware.py` + `test_auth_me_logout.py` to mint via OTP.
- Ships `docs/deployment/README.md` + `docs/deployment/email-otp-setup.md`, including the `docker compose logs backend | grep auth.email.console_otp_sent` dev login flow.
- No Alembic migration. `last_login_at` / `last_used_at` / `is_active` columns (present in the design doc §6.1 but not in 001's migration) stay absent; documented as deviations.