### PR TITLE
spec(feat_frontend_002): login UI — AuthContext, /login, dashboard, Playwright e2e

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -44,5 +44,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_backend_002`      | In Build   | Backend rules (`backend/RULES.md`), logging callsite + redaction, items domain move. |
 | `feat_auth_001`         | In Build   | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
 | `feat_auth_002`         | Merged     | Email OTP login: `EmailSender` abstraction, `/auth/otp/request` + `/auth/otp/verify`, Resend provider, deployment docs. |
+| `feat_frontend_002`     | In Spec    | Login UI: `AuthContext`, `/login` OTP page with disabled Google-coming-soon button, authed dashboard + header strip, Playwright e2e suite. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_frontend_002/design_frontend_002.md
+++ b/docs/specs/feat_frontend_002/design_frontend_002.md
@@ -1,0 +1,410 @@
+# Design: Login UI — AuthContext, `/login` page, dashboard, and Playwright e2e
+
+## Approach
+
+Layer a thin routing + auth-context shell on top of the existing Vite +
+React + TypeScript scaffold. Preserve the same-origin Vite-proxy
+architecture verbatim so the `HttpOnly` session cookie set by
+`/otp/verify` flows automatically on subsequent `/auth/me` and
+`/auth/logout` calls — no `credentials: 'include'`, no absolute URLs.
+
+At a component level:
+
+- `main.tsx` wraps the app in `<BrowserRouter>` and `<AuthProvider>`.
+- `App.tsx` is repurposed from a standalone hello page into a **routing
+  root** that renders `<Routes>`. Its old hello-page content moves into
+  a small `HelloPanel` component and is included inside the new
+  `Dashboard` page.
+- `AuthContext` is the single source of truth for "am I signed in". It
+  bootstraps by calling `GET /api/v1/auth/me` on mount. A 200 stashes
+  the response; a 401 is interpreted as "anonymous"; anything else is a
+  hard error. During the in-flight bootstrap the app renders a loading
+  skeleton — no route redirect yet — to avoid flashing the login page
+  for a logged-in user on a fresh tab.
+- A `<RequireAuth>` wrapper component gates routes that need a
+  principal. When `AuthContext.status === 'anonymous'`, it renders a
+  `<Navigate to="/login" replace />`. When `status === 'loading'` it
+  defers to the skeleton. When `status === 'authenticated'` it renders
+  children.
+- `/login` is public. It renders the two-step OTP form plus the
+  disabled Google button. After `/auth/otp/verify` returns 200, the
+  login page calls `auth.refresh()` (which re-hits `/auth/me`) and then
+  `navigate('/', { replace: true })`.
+- `/` is authed. It renders a `<Header>` strip plus a `<Dashboard>`
+  body.
+
+The auth API surface stays trivial — four functions over `fetch`, same
+relative-URL idiom as the existing `getHello()`. Vulcan places them in
+a **new sibling file `frontend/src/api/auth.ts`** rather than growing
+`client.ts`, because the existing `client.ts` docstring is explicit
+that it is the hello-endpoint client; mixing auth into it would muddy
+that contract. Both files live in the same `frontend/src/api/`
+directory and follow the same code conventions (relative URL, no auth
+headers, throw-on-non-2xx with `/auth/me`'s 401 as the one deliberate
+exception — see below).
+
+Playwright is wired as a **frontend dev dependency** with its tests
+under `frontend/tests/e2e/` and a `bun run test:e2e` script. It drives
+the compose-stack-served frontend on port 5173 (which in turn proxies
+`/api` to the backend on 8000), which mirrors how a real user uses the
+app and is the same boundary the external REST suite exercises. The
+spec reads `TEST_OTP_EMAIL` / `TEST_OTP_CODE` from its own process env
+and `test.skip`s when either is unset, matching the pattern in
+`tests/tests/test_auth.py`.
+
+## Files to Modify
+
+| File | Change Description |
+|---|---|
+| `frontend/package.json` | Add `react-router-dom@^7` under `dependencies`. Add `@playwright/test@^1` under `devDependencies`. Add a `test:e2e` script (`playwright test`). No runtime-dep bloat beyond these. |
+| `frontend/src/main.tsx` | Wrap `<App />` in `<BrowserRouter>` and `<AuthProvider>`. |
+| `frontend/src/App.tsx` | Replace the standalone hello-page content with a routing root: `<Routes>` listing `/login` (public) and `/` (gated via `<RequireAuth>` around `<Dashboard>`). The hello-page logic moves into `src/components/HelloPanel.tsx`. |
+| `frontend/src/App.css` | Add minimal styles for the login page, header strip, and dashboard layout. Existing `.state`, `.state--loading`, `.state--error`, `.state--success` classes are reused by the hello panel. |
+| `frontend/README.md` | Add a **Testing** section describing `bun run test:e2e`, `bunx playwright install`, the `TEST_OTP_*` env-var pair, and an explicit note that Playwright is **not** part of `./test.sh`. Link to the operator note on the fixture. |
+| `docs/tracking/features.md` | Append the `feat_frontend_002` row. Backfill Spec PR + Issues after PR and issue creation. |
+| `docs/specs/README.md` | Append a row to the feature roster table (`Status: In Spec` initially, promoted via later PRs). |
+| `docs/deployment/email-otp-setup.md` *(or a new `docs/deployment/frontend-e2e.md`)* | Add an operator subsection documenting the `TEST_OTP_EMAIL` / `TEST_OTP_CODE` pair as the fixture consumed by the Playwright e2e suite. Vulcan picks one: a subsection in `email-otp-setup.md` is preferred because that doc already introduces the pair. |
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `frontend/src/api/auth.ts` | Typed client for the auth endpoints. Exports `getMe()`, `logout()`, `requestOtp(email)`, `verifyOtp(email, code)`, and the `Me` type. All relative URLs. `getMe()` returns `Me \| null` (null on 401); the others throw on non-2xx. |
+| `frontend/src/auth/AuthContext.tsx` | The context + provider. Holds `{ user, status, refresh, logout }` where `status ∈ {'loading','authenticated','anonymous'}`. `useAuth()` hook exposes it. |
+| `frontend/src/auth/RequireAuth.tsx` | Tiny wrapper that reads `useAuth()` and gates its children with either the loading skeleton, a `<Navigate to="/login" replace />`, or the children. |
+| `frontend/src/components/Header.tsx` | Persistent header strip for authed pages: email + role chips + logout button. |
+| `frontend/src/components/HelloPanel.tsx` | The existing `getHello()` widget extracted from `App.tsx` as a reusable panel rendered inside the dashboard. Behavior is unchanged. |
+| `frontend/src/pages/LoginPage.tsx` | The `/login` route. Two-step form + disabled Google button. Owns the local step state, per-field errors, and the post-verify redirect. |
+| `frontend/src/pages/Dashboard.tsx` | The `/` route for authed users. Greeting, role list, HelloPanel. |
+| `frontend/playwright.config.ts` | Playwright config: `testDir: './tests/e2e'`, `baseURL: http://localhost:5173` (override via env), one Chromium project, `retries: 0` in local runs, `use.trace: 'on-first-retry'`. No `webServer` block — the operator brings the stack up via `make up` before running. |
+| `frontend/tests/e2e/login.spec.ts` | The one e2e test. Skips when `TEST_OTP_EMAIL`/`TEST_OTP_CODE` are unset. Navigates to `/`, asserts redirect to `/login`, fills email, submits, fills code, submits, asserts dashboard URL, asserts email + roles in header, clicks logout, asserts back on `/login`. |
+| `frontend/tests/e2e/fixtures.ts` | Exports `getOtpFixture()` that reads the two env vars and returns `{email, code} \| null`, mirroring `_otp_fixture_env()` in `tests/tests/test_auth.py`. |
+| `frontend/.gitignore` (amend, not create) | Ensure `test-results/`, `playwright-report/`, `playwright/.cache/`, and `tests/e2e/.auth/` are ignored. |
+
+## Data Flow
+
+### Bootstrap on fresh tab / refresh
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant AuthProvider
+    participant API as /api/v1/auth
+
+    Browser->>AuthProvider: mount
+    AuthProvider->>AuthProvider: status = 'loading'
+    AuthProvider->>API: GET /me (cookie auto-attached if present)
+    alt 200 OK
+        API-->>AuthProvider: {user_id, email, display_name, roles}
+        AuthProvider->>AuthProvider: status = 'authenticated'; user = payload
+    else 401
+        API-->>AuthProvider: 401 not_authenticated
+        AuthProvider->>AuthProvider: status = 'anonymous'; user = null
+    else other
+        API-->>AuthProvider: 5xx
+        AuthProvider->>AuthProvider: status = 'anonymous' + log; user = null
+    end
+    AuthProvider-->>Browser: render routes
+```
+
+### Login (two-step OTP)
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant LoginPage
+    participant AuthProvider
+    participant API as /api/v1/auth
+
+    User->>LoginPage: enter email, submit
+    LoginPage->>API: POST /otp/request {email}
+    alt 204 No Content
+        API-->>LoginPage: 204
+        LoginPage->>LoginPage: step = 'verify'; clear code input
+    else 429
+        API-->>LoginPage: 429 {detail, retry_after}
+        LoginPage->>User: show rate-limit message with retry_after
+    else other
+        API-->>LoginPage: error
+        LoginPage->>User: show generic "try again"
+    end
+
+    User->>LoginPage: enter code, submit
+    LoginPage->>API: POST /otp/verify {email, code}
+    alt 200 OK
+        API-->>LoginPage: 200 + Set-Cookie: session=...
+        LoginPage->>AuthProvider: refresh()
+        AuthProvider->>API: GET /me
+        API-->>AuthProvider: 200 payload
+        AuthProvider->>AuthProvider: status = 'authenticated'
+        LoginPage->>Browser: navigate('/', {replace: true})
+    else 400 invalid_or_expired_code
+        API-->>LoginPage: 400
+        LoginPage->>User: inline "code didn't work; try again or request a new one"
+    end
+```
+
+### Logout
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Header
+    participant AuthProvider
+    participant API as /api/v1/auth
+
+    User->>Header: click Logout
+    Header->>AuthProvider: logout()
+    AuthProvider->>API: POST /logout
+    API-->>AuthProvider: 204 + cookie cleared
+    AuthProvider->>AuthProvider: status = 'anonymous'; user = null
+    AuthProvider->>Browser: navigate('/login', {replace: true})
+```
+
+### API-surface sketch (`frontend/src/api/auth.ts`)
+
+```ts
+export interface Me {
+  user_id: number;
+  email: string;
+  display_name: string | null;
+  roles: string[];
+}
+
+// Returns null on 401 so the provider can translate "no session" into
+// 'anonymous' without treating it as an error. Any other non-2xx is
+// an error.
+export async function getMe(): Promise<Me | null> { /* ... */ }
+
+export async function logout(): Promise<void> { /* POST /api/v1/auth/logout */ }
+
+export async function requestOtp(email: string): Promise<void> {
+  /* POST /api/v1/auth/otp/request; throws on non-204 except 429 which
+     maps to a typed RateLimitError the LoginPage catches. */
+}
+
+export async function verifyOtp(email: string, code: string): Promise<Me> {
+  /* POST /api/v1/auth/otp/verify; returns parsed Me on 200; throws on
+     non-200 (the LoginPage maps 400 to the uniform "bad code" message). */
+}
+```
+
+All four use **relative URLs** (e.g. `/api/v1/auth/me`) and **no**
+`credentials` option. The session cookie rides along because the page
+origin matches the API origin (same-origin via the Vite proxy in dev,
+same nginx origin in `frontend-prod`).
+
+## `AuthContext` contract (verbatim, as confirmed in the kickoff)
+
+- On provider mount: set `status = 'loading'` and call `getMe()`.
+- On 200: set `user = payload`, `status = 'authenticated'`.
+- On 401 (null return): set `user = null`, `status = 'anonymous'`. Do
+  **not** render an error UI; this is the unauthenticated happy path.
+  Let `<RequireAuth>` decide whether to redirect.
+- On any other failure: log a `console.warn`, set `status = 'anonymous'`
+  (conservative — never leave a user stuck in a non-deterministic
+  state).
+- `refresh()` re-runs `getMe()` and updates state. Used by
+  `LoginPage` after verify returns 200, and available for any future
+  caller that wants to re-sync.
+- `logout()` calls the API then clears in-memory state and navigates
+  to `/login`. Because the cookie is `HttpOnly`, JavaScript never
+  reads it — the server is the source of truth.
+
+## Routing contract
+
+```
+<BrowserRouter>
+  <AuthProvider>
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/"
+        element={
+          <RequireAuth>
+            <AuthedLayout>
+              <Dashboard />
+            </AuthedLayout>
+          </RequireAuth>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  </AuthProvider>
+</BrowserRouter>
+```
+
+`<AuthedLayout>` is a tiny wrapper: `<Header />` on top, `<main>` for
+children. Kept in `src/components/` (not `src/pages/`) because it's
+structural. `*` catches typos and sends them through the auth gate
+— no dead "404" page in this feature.
+
+## Visual design
+
+Intentionally bland, matching the existing dark-on-`#242424` Vite
+default look. No design-system dependency. Approximate layout:
+
+```
++---------------------------------------------+
+| user@example.com   [user]   [admin]   Logout|   <- <Header>
++---------------------------------------------+
+|                                             |
+|  Welcome, Ada Lovelace                      |   <- greeting
+|                                             |
+|  Roles: user, admin                         |   <- role list
+|                                             |
+|  +---------------------------+              |
+|  | hello panel               |              |
+|  | message: hello            |              |
+|  | item_name: default        |              |
+|  | hello_count: 42           |              |
+|  +---------------------------+              |
+|                                             |
++---------------------------------------------+
+```
+
+Login page:
+
+```
++------------- Step 1 --------------+
+| Email: [____________________]     |
+| [ Send code ]                     |
+|                                   |
+| Sign in with Google (coming soon) |   <- disabled, tooltip / aria-label
++-----------------------------------+
+
++------------- Step 2 --------------+
+| We sent a code to ada@example.com |
+| Code: [______]                    |
+| [ Verify ]                        |
+| (Back to email)                   |
++-----------------------------------+
+```
+
+## Disabled Google button — concrete shape
+
+```tsx
+<button
+  type="button"
+  disabled
+  aria-disabled="true"
+  title="Google sign-in coming soon"
+  className="google-btn google-btn--disabled"
+>
+  Sign in with Google (coming soon)
+</button>
+```
+
+The button is an ordinary `<button type="button" disabled>`. Disabled
+buttons in HTML do not fire click handlers and do not submit forms.
+No `onClick`, no `fetch`, no reference to any backend path. A native
+browser tooltip (`title`) plus a visible "(coming soon)" suffix covers
+affordance without adding a tooltip library.
+
+## Playwright wiring
+
+- **Runner location.** `frontend/tests/e2e/` keeps the test next to
+  the code it exercises. Playwright respects `testDir` in the config
+  regardless of package root.
+- **Browsers.** Installed on-demand with `bunx playwright install`
+  (one-time per machine). Documented in `frontend/README.md`. Not
+  committed to the repo; binaries live under Playwright's default
+  cache.
+- **Target.** `baseURL: http://localhost:5173` (the Vite dev server,
+  also what compose publishes). Overridable via `PLAYWRIGHT_BASE_URL`
+  env var for operators running the prod-profile frontend on 8080.
+- **Fixture detection.** Identical pattern to
+  `tests/tests/test_auth.py::_otp_fixture_env`:
+
+  ```ts
+  // frontend/tests/e2e/fixtures.ts
+  export function getOtpFixture(): { email: string; code: string } | null {
+    const email = (process.env.TEST_OTP_EMAIL ?? '').trim();
+    const code = (process.env.TEST_OTP_CODE ?? '').trim();
+    return email && code ? { email, code } : null;
+  }
+  ```
+
+  In the spec body: `test.skip(fixture === null, 'TEST_OTP_* not set')`.
+
+- **Why not log scraping.** The fixture pair was *designed* for this:
+  when the pair is set and the request email matches, `request_otp`
+  overwrites the stored hash with one derived from the configured
+  test code (see `backend/app/auth/router.py`, the section marked
+  "Test-OTP fixture overwrite"). The e2e test exploits this exactly
+  as the REST suite in `tests/tests/test_auth.py` does.
+- **`test.sh` boundary.** `test.sh` is unchanged. `bun run test:e2e`
+  is a separate invocation. This mirrors how `tests/` is a separate
+  subtree invoked through a dedicated driver and does not get pulled
+  into frontend-local workflows.
+
+### Operator invocation contract
+
+The documented flow in `frontend/README.md` is:
+
+```bash
+# one-time per machine
+cd frontend
+bun install
+bunx playwright install
+
+# set the fixture (edit infra/.env, then bring the stack up)
+#   TEST_OTP_EMAIL=e2e@example.com
+#   TEST_OTP_CODE=123456
+# (Env is consumed by both the backend — via compose — and the
+# Playwright runner. Export it in your shell before running the
+# test so the runner sees it, too.)
+export TEST_OTP_EMAIL=e2e@example.com
+export TEST_OTP_CODE=123456
+
+# bring the stack up (from repo root)
+make up
+
+# run the e2e suite
+cd frontend
+bun run test:e2e
+```
+
+## Edge Cases & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Users see the login form flash for an instant before `/auth/me` resolves on refresh. | Render a loading skeleton while `status === 'loading'`. `<RequireAuth>` defers to the skeleton, not to `<Navigate>`, during loading. |
+| 401 from `/auth/me` is interpreted as an error, clobbering the UI. | `getMe()` returns `null` on 401 (typed as `Me \| null`). Only non-401 non-2xx throws. |
+| `credentials: 'include'` introduced by accident. | Explicit in the design and the test spec. Code review must reject any diff that sets `credentials` on a `fetch` call in this feature. |
+| Absolute URL (e.g. `http://localhost:8000/api/...`) sneaks in and breaks the same-origin cookie assumption. | All new callers reuse the `/api/v1/...` relative-URL pattern from `getHello`. The e2e test would fail on the dashboard render because the cookie would not attach. |
+| Dashboard renders before `/auth/me` resolves after login, showing a stale loading state. | `LoginPage` calls `auth.refresh()` (awaited) **before** `navigate('/')`, so by the time the dashboard mounts, `status === 'authenticated'` and `user` is populated. |
+| Rate-limit response (429) on OTP request is not surfaced to the user. | `requestOtp` parses the 429 body (`{detail, retry_after}`) and throws a typed `RateLimitError(retryAfterSeconds)`. `LoginPage` renders a user-visible "try again in N seconds" message. |
+| Playwright binaries are not installed and the first run fails with an opaque error. | `frontend/README.md` documents `bunx playwright install` as a one-time setup step. The `test:e2e` script does **not** auto-install (that would silently download hundreds of MB). |
+| Playwright pulls in Node types that conflict with app code. | Playwright tests live under `frontend/tests/e2e/` with their own compile unit (Playwright handles this by default). App TS config (`tsconfig.app.json`) keeps `tests/` excluded. Vulcan verifies `bun run build` still passes. |
+| Google-button "coming soon" wording diverges from the final Google-OAuth feature copy. | This is cosmetic. `feat_auth_003` will replace the button wholesale — there is no contract to honor. |
+| User refreshes during step 2 (post-email, pre-verify) and loses the email value. | Acceptable. The UX recovers: user clicks "back to email", re-types, re-requests, re-verifies. Persisting partial form state is out of scope. A `/login?email=...` query-param seed is also out of scope. |
+| `tests/e2e/` directory confuses developers expecting unit tests. | The README section is explicit: "e2e only; no unit tests in this feature." If a unit-test harness lands later, it goes in `frontend/src/` colocated (the conventional place for Vitest), not in `frontend/tests/`. |
+| The Playwright test races against `make up` readiness. | The test does not own readiness — the operator runs `make up` first, which already blocks on backend healthchecks. Playwright config has no `webServer` block, so there is nothing to race. |
+| Session cookie's `SameSite=Lax` blocks the e2e test if Playwright somehow visits a cross-site origin before login. | The test only ever visits the same origin (`baseURL`). `SameSite=Lax` permits top-level navigations and same-site subrequests; this is the exact case. |
+
+## Dependencies
+
+- **Runtime (new):** `react-router-dom@^7`.
+- **Dev (new):** `@playwright/test@^1`.
+- **External tool (one-time, per-machine):** Playwright browsers
+  installed via `bunx playwright install`. Not a package dependency
+  — a binary download.
+- **Unchanged:** the existing Vite + React + TypeScript + `@types/*`
+  stack. No new Vite plugins. No new backend deps (backend is not
+  touched).
+
+## Deviations
+
+- **Directory name has no slug.** `docs/specs/feat_frontend_002/` and
+  the three filename stems use `feat_<domain>_<NNN>` only, matching
+  `conventions.md` §2 and every existing sibling directory
+  (`feat_auth_001`, `feat_auth_002`, `feat_frontend_001`). The kickoff
+  prompt's slug-in-filename template is superseded by `conventions.md`,
+  which the user's memory note names as authoritative.
+- **Branch name has no slug.** `spec/feat_frontend_002`, per
+  `conventions.md` §3. Same reasoning.
+- **Operator doc placement is Vulcan's call.** Either a subsection in
+  `docs/deployment/email-otp-setup.md` or a new
+  `docs/deployment/frontend-e2e.md`. The subsection is preferred
+  because the fixture pair is already introduced in that file.

--- a/docs/specs/feat_frontend_002/feat_frontend_002.md
+++ b/docs/specs/feat_frontend_002/feat_frontend_002.md
@@ -1,0 +1,231 @@
+# Feature: Login UI — AuthContext, `/login` page, dashboard, and Playwright e2e
+
+## Problem Statement
+
+The backend ships an end-to-end authentication flow today: `feat_auth_001`
+provides sessions, `/api/v1/auth/me`, and `/api/v1/auth/logout`, and
+`feat_auth_002` adds the two OTP endpoints (`/api/v1/auth/otp/request`,
+`/api/v1/auth/otp/verify`) together with the env-gated
+`TEST_OTP_EMAIL` / `TEST_OTP_CODE` fixture. On the frontend, however,
+`feat_frontend_001` only renders a single hello-world page — there is no
+way for a user to sign in through the browser, no notion of an
+authenticated session in the UI, and no test that exercises the OTP flow
+end-to-end against a real browser.
+
+This feature adds the smallest possible **login UI** over the already-
+shipping OTP backend, plus a minimal authenticated landing page and a
+Playwright e2e test that drives the whole round trip through a browser.
+It deliberately does not expand backend surface area — it only consumes
+what `feat_auth_001` and `feat_auth_002` already exposed.
+
+## Requirements
+
+- A `/login` route renders a two-step email-OTP form:
+  1. Step 1 (request): the user enters their email. Submitting calls
+     `POST /api/v1/auth/otp/request` and advances to step 2 on 204 (or on
+     any response that indicates the request was accepted).
+  2. Step 2 (verify): the user enters a six-digit code. Submitting calls
+     `POST /api/v1/auth/otp/verify` and, on 200, navigates to `/`.
+- The `/login` page also renders a **disabled "Sign in with Google"
+  button** labeled "coming soon" (tooltip or adjacent text). It must not
+  call any backend endpoint and must not reference any route that does
+  not yet exist. `feat_auth_003` will wire it up.
+- Unauthenticated visits to `/` redirect to `/login`. Authenticated
+  visits to `/` render a **dashboard** page with a persistent header
+  strip (signed-in email + roles + logout button) and the dashboard
+  content below.
+- The dashboard body shows:
+  - A greeting line (`Welcome, <display_name or email>`).
+  - The list of roles from `GET /api/v1/auth/me`.
+  - The existing `getHello()` widget from `feat_frontend_001`, folded
+    into a small panel so the Postgres + Redis demo the project ships
+    with stays exercised.
+- An **`AuthContext`** provides the current-user state to the app. On
+  mount it calls `GET /api/v1/auth/me`. A 200 stashes the response; a
+  401 routes the user to `/login`; a loading skeleton renders during the
+  in-flight request. A 401 is **not** rendered as an error state — it
+  is interpreted as "anonymous user, go to `/login`".
+- The logout button calls `POST /api/v1/auth/logout`, clears the
+  in-memory `AuthContext`, and navigates to `/login`.
+- All new API calls use **relative URLs** via the same-origin pattern
+  established by `frontend/src/api/client.ts`. The `HttpOnly; SameSite=Lax`
+  session cookie set by `/otp/verify` is therefore sent automatically on
+  subsequent `/auth/me` and `/auth/logout` calls without any
+  `credentials: 'include'` fetch option.
+- Routing uses `react-router-dom@7` as a new dependency.
+- A **Playwright e2e test** under `frontend/tests/e2e/` drives the full
+  login flow in a browser against the compose stack, using the
+  `TEST_OTP_EMAIL` / `TEST_OTP_CODE` fixture (no log scraping). It is
+  **not** part of the default `./test.sh` path.
+- `@playwright/test` is added as a frontend **dev dependency** only.
+  Browser binaries are installed per-machine via `bunx playwright install`.
+- `frontend/README.md` (and `docs/deployment/` if a separate operator
+  page is warranted) documents how to run Playwright and how to set
+  `TEST_OTP_EMAIL` / `TEST_OTP_CODE` in `infra/.env` before `make up`.
+- **No backend changes.** The backend exposes exactly what this UI
+  needs today.
+
+## User Stories
+
+- As a user clicking into the site for the first time, I want to hit
+  `/` and be taken to a login page, so I always know how to authenticate.
+- As a returning user with a live session cookie, I want `/` to render
+  the dashboard directly without a login round-trip, so the app does
+  not force me to sign in twice.
+- As a user signing in, I want to enter my email, receive a six-digit
+  code, enter the code, and land on the dashboard, so the whole flow
+  takes one minute.
+- As a user who typed the wrong code, I want a clear error on the code
+  form with the ability to retry (or go back and request a new code),
+  so a typo does not force me to restart.
+- As a user curious about Google sign-in, I want to see the Google
+  button visibly rendered but clearly marked "coming soon", so I know
+  the provider is on the roadmap.
+- As a signed-in user, I want a logout button in the header of every
+  authed page so I can end my session without hunting for it.
+- As a developer running `make up` locally, I want a Playwright test
+  I can run with a single command that covers the full login flow
+  against the running stack, so login regressions get caught before a
+  PR lands.
+
+## User Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as Browser (React)
+    participant API as Backend (/api/v1/auth)
+
+    Note over User,UI: First visit, no session cookie
+    User->>UI: GET /
+    UI->>API: GET /auth/me
+    API-->>UI: 401 not_authenticated
+    UI-->>User: redirect to /login
+
+    Note over User,UI: Login flow (email OTP)
+    User->>UI: enter email, submit
+    UI->>API: POST /auth/otp/request {email}
+    API-->>UI: 204 No Content
+    UI-->>User: show "code sent" + 6-digit form
+    User->>UI: enter 6-digit code, submit
+    UI->>API: POST /auth/otp/verify {email, code}
+    API-->>UI: 200 + Set-Cookie: session=...
+    UI-->>User: navigate to /
+    UI->>API: GET /auth/me (cookie attached)
+    API-->>UI: 200 {user_id, email, display_name, roles}
+    UI-->>User: render dashboard + header strip
+
+    Note over User,UI: Logout
+    User->>UI: click Logout
+    UI->>API: POST /auth/logout
+    API-->>UI: 204 + clear cookie
+    UI-->>User: navigate to /login
+```
+
+## Scope
+
+### In Scope
+
+- New route layer using `react-router-dom@7` with at least:
+  `/` (authed dashboard), `/login` (public), and an implicit redirect
+  for unauthed `/` to `/login`.
+- New `AuthContext` that bootstraps from `GET /auth/me` and exposes
+  `{ user, status, refresh, logout }` to descendants.
+- New `/login` page with a two-step email-OTP form and a disabled
+  "Sign in with Google (coming soon)" button.
+- New `Dashboard` page reusing the existing `getHello()` call as a
+  panel, plus a greeting + role list.
+- New persistent **header strip** component rendered on all authed
+  routes: signed-in email, role chips, logout button.
+- Auth API client additions (either `frontend/src/api/client.ts`
+  extensions or a sibling `frontend/src/api/auth.ts` — Vulcan picks
+  per existing convention). All calls use relative URLs.
+- Minimal CSS for the login form, header strip, and dashboard layout,
+  in the same default-styled Vite idiom the hello page already uses
+  (no design-system dependency).
+- `@playwright/test` as a **dev dependency** in `frontend/package.json`.
+- `frontend/tests/e2e/` directory with at least a `login.spec.ts` that
+  drives `/login` -> OTP request -> OTP verify -> dashboard -> logout
+  using the `TEST_OTP_EMAIL` / `TEST_OTP_CODE` fixture against a
+  running compose stack. The test reads those env vars from the
+  Playwright runner (not from the UI).
+- `frontend/playwright.config.ts` pointing `baseURL` at the
+  Vite-served frontend origin (default `http://localhost:5173`).
+- `frontend/README.md` additions: how to install browsers
+  (`bunx playwright install`), how to run the e2e suite
+  (`bun run test:e2e`), how to set `TEST_OTP_EMAIL` /
+  `TEST_OTP_CODE` in `infra/.env` before `make up`.
+- A short operator note in `docs/deployment/` (file name chosen by
+  Vulcan — either a new `docs/deployment/frontend-e2e.md` or a
+  subsection appended to the existing `docs/deployment/email-otp-setup.md`
+  covering the `TEST_OTP_*` fixture pair, since that fixture is what
+  the e2e suite consumes).
+
+### Out of Scope
+
+- Backend changes of any kind (routes, schemas, settings). If Vulcan
+  finds it needs a backend edit, stop and escalate — it means a spec
+  boundary was drawn wrong.
+- Google OAuth — the button is a visible "coming soon" placeholder.
+  Wiring it to a real backend route is `feat_auth_003`.
+- UI component libraries, design systems, Tailwind, shadcn, MUI, etc.
+- State-management libraries (Redux, Zustand, Jotai, React Query,
+  SWR). Plain `useState` / `useEffect` plus the `AuthContext` suffice
+  for the surface area in this feature.
+- Unit / component / Vitest tests. The only test harness added is
+  Playwright e2e, per the user's explicit decision.
+- Adding Playwright to the default `./test.sh` path. It runs as a
+  separate invocation, mirroring how the external REST suite under
+  `tests/` is invoked.
+- Profile editing, password management, account deletion, session-
+  management UI beyond the logout button.
+- Server-side rendering, static pre-rendering, or any non-Vite build
+  path.
+- CI wiring (GitHub Actions) for Playwright. The test is runnable
+  locally in this feature; CI hookup is deferred.
+- Error-boundary / toast-notification infrastructure beyond
+  per-form inline errors.
+- i18n or accessibility beyond the baseline (visible focus, labelled
+  inputs, `aria-live` for the OTP "code sent" message).
+
+## Acceptance Criteria
+
+- [ ] Visiting `/` with no session cookie redirects to `/login` and
+      the URL bar shows `/login` (not `/`).
+- [ ] Visiting `/login` renders the email form and a disabled Google
+      button labeled "coming soon".
+- [ ] Submitting a valid email to step 1 calls
+      `POST /api/v1/auth/otp/request` exactly once and advances the UI
+      to the code-entry step.
+- [ ] Submitting a valid code to step 2 calls
+      `POST /api/v1/auth/otp/verify` exactly once, receives a 200, and
+      navigates to `/`.
+- [ ] After step 2 succeeds, `/` renders the header strip (email +
+      roles + logout) and the dashboard body (greeting + roles + hello
+      panel).
+- [ ] Clicking the Google button performs no network call.
+- [ ] The logout button calls `POST /api/v1/auth/logout`, clears the
+      in-memory auth state, and navigates back to `/login`.
+- [ ] A refresh of any authed route with a live cookie still renders
+      the authed UI (not the login form), because `AuthContext` re-
+      bootstraps from `/auth/me`.
+- [ ] A refresh of any authed route after the cookie expires (or after
+      logout) redirects to `/login`.
+- [ ] No new API call in the frontend uses an absolute URL or the
+      `credentials: 'include'` option. All auth calls are relative
+      like the existing `getHello()`.
+- [ ] `bun run build` passes with zero TypeScript errors.
+- [ ] `@playwright/test` appears only under `devDependencies` in
+      `frontend/package.json`.
+- [ ] `frontend/tests/e2e/login.spec.ts` exists and asserts: landing
+      redirect, OTP request, OTP verify, dashboard render,
+      `/auth/me` data visible in the DOM, successful logout.
+- [ ] The Playwright spec reads `TEST_OTP_EMAIL` / `TEST_OTP_CODE`
+      from the runner env and `skip`s (not fails) when either is unset
+      — mirroring the behavior in `tests/tests/test_auth.py`.
+- [ ] `frontend/README.md` documents `bunx playwright install` and
+      `bun run test:e2e`, and links to the operator note on
+      `TEST_OTP_*` wiring.
+- [ ] `./test.sh` remains unchanged in behavior — running it does not
+      invoke Playwright.
+- [ ] No file under `backend/` is modified by this feature.

--- a/docs/specs/feat_frontend_002/test_frontend_002.md
+++ b/docs/specs/feat_frontend_002/test_frontend_002.md
@@ -1,0 +1,136 @@
+# Test Spec: Login UI — AuthContext, `/login` page, dashboard, and Playwright e2e
+
+## Test harness
+
+This feature ships **Playwright e2e tests only** — no Vitest, no React
+Testing Library, no component tests. The one harness runs against the
+compose-brought-up stack (`make up` from the repo root) and drives
+the browser end-to-end against `http://localhost:5173`.
+
+- Location: `frontend/tests/e2e/`
+- Config: `frontend/playwright.config.ts`
+- Script: `bun run test:e2e` (= `playwright test`)
+- Browsers: installed per-machine with `bunx playwright install` (one-
+  time; documented in `frontend/README.md`).
+- Env: the runner reads `TEST_OTP_EMAIL` and `TEST_OTP_CODE` from its
+  own process env. These must match the backend's settings (set
+  through `infra/.env` before `make up`). When either is empty, the
+  test suite calls `test.skip` (mirroring `tests/tests/test_auth.py`),
+  so running Playwright without the fixture prints a clean skip, not
+  a red failure.
+- `./test.sh` is unchanged and does **not** invoke Playwright. That is
+  a deliberate boundary.
+
+## Happy Path
+
+| # | Test Case | Input | Expected Output |
+|---|---|---|---|
+| 1 | Unauthenticated landing redirect | Visit `/` with no session cookie | URL becomes `/login`; email input visible. |
+| 2 | Login page renders key elements | Visit `/login` | Email input, "Send code" button, disabled "Sign in with Google (coming soon)" button, all present. |
+| 3 | Google button is inert | Click the Google button | No network call made; URL unchanged; step state unchanged. |
+| 4 | OTP request advances to step 2 | On `/login`, fill email = `TEST_OTP_EMAIL`, click "Send code" | `POST /api/v1/auth/otp/request` returns 204; UI shows the 6-digit code input and a "code sent" affordance. |
+| 5 | OTP verify lands on dashboard | Fill code = `TEST_OTP_CODE`, click "Verify" | `POST /api/v1/auth/otp/verify` returns 200; browser navigates to `/`; header strip + dashboard body visible. |
+| 6 | Dashboard shows profile data | After happy-path login | Greeting line contains the email (or `display_name` if set); role list includes `user`; HelloPanel renders the `message` field from `/api/v1/hello`. |
+| 7 | Header strip shows identity | After happy-path login | Header contains the signed-in email and the `user` role chip; Logout button is enabled. |
+| 8 | Refresh preserves auth | After happy-path login, press F5 on `/` | Loading skeleton flashes, then dashboard re-renders (no redirect to `/login`). |
+| 9 | Logout ends session | Click Logout on the dashboard | `POST /api/v1/auth/logout` returns 204; browser navigates to `/login`; email input visible again. |
+| 10 | After logout, `/` redirects again | After logout, manually navigate to `/` | Browser redirects to `/login`. |
+| 11 | Relative-URL invariant | Inspect the network log for the whole happy-path run | Every `/api/v1/...` request targets the same origin as the page (no `http://localhost:8000` origin). |
+
+Case 11 is enforced by attaching a `page.on('request', …)` listener in
+the Playwright spec and asserting `new URL(req.url()).origin === new
+URL(baseURL).origin` for every request whose path starts with
+`/api/v1/`. If any absolute-URL regression slips in, this test fails.
+
+## Error Cases
+
+| # | Test Case | Input | Expected Behavior |
+|---|---|---|---|
+| 1 | Wrong OTP code | Request a code, then submit `999999` | `POST /api/v1/auth/otp/verify` returns 400; inline error on the code form; URL stays on `/login`; user can retype and re-submit without refreshing. |
+| 2 | Malformed email on step 1 | Enter `notanemail`, click "Send code" | Client-side validation blocks submit (no network call), or backend returns 422/400 and the inline error is rendered. Either behavior is acceptable; the test just asserts the UI does not advance to step 2 and no cookie is set. |
+| 3 | Backend 5xx on `/auth/me` | Bootstrap hits a simulated 500 (route the browser at a mock or stop the backend container) | App treats it as anonymous: redirects to `/login`; no error overlay; no infinite-loop retries. |
+| 4 | Network failure on verify | Code submit interrupted at the network layer | UI shows a "try again" affordance; no redirect; no cookie set. |
+| 5 | Logout call fails with 5xx | Backend errors on `POST /auth/logout` | UI still clears in-memory auth state and navigates to `/login` (defensive — stale cookie is less bad than stuck UI). |
+
+Error cases 3–5 are documented as **optional** Playwright assertions.
+The Playwright spec that ships with this feature covers cases 1–2
+(happy-adjacent failures that the real backend produces naturally) and
+asserts `/auth/me` 401 -> redirect implicitly via the "unauthenticated
+landing redirect" test in the Happy Path table. Cases 3–5 require
+network interception or backend manipulation and are **not** required
+for the feature to land. They are listed here so a future tester knows
+the intended behavior.
+
+## Boundary Conditions
+
+| # | Test Case | Condition | Expected Behavior |
+|---|---|---|---|
+| 1 | Fixture not set | `TEST_OTP_EMAIL` or `TEST_OTP_CODE` empty on the Playwright runner | Spec calls `test.skip`; Playwright prints a clean skip; exit code 0. |
+| 2 | Rate-limited OTP request | `POST /auth/otp/request` returns 429 (e.g. because a prior run just ran) | Spec calls `test.skip('rate-limited; retry later')`, mirroring the REST suite's behavior. |
+| 3 | Stack not up | Backend is not running when Playwright launches | First navigation times out; Playwright reports the network error cleanly. Operator is expected to run `make up` before `bun run test:e2e`; the README documents this. |
+| 4 | Prod-profile frontend | Operator runs compose with `--profile prod` (frontend on :8080) | `PLAYWRIGHT_BASE_URL=http://localhost:8080 bun run test:e2e` runs the same spec against the prod bundle. The spec must not hardcode `:5173` outside config. |
+| 5 | Refresh mid-step-2 | User reloads the page while on the OTP-code step | Email is lost; UI returns to step 1. Acceptable. Documented in the design risks table. Not asserted in the Playwright spec. |
+| 6 | Expired cookie mid-session | Cookie TTL elapses while the dashboard is open; next API call 401s | Next `refresh()` (or next manual action that hits `/auth/me`) routes the user to `/login`. Asserted at the unit-level only if a component test harness is added later. |
+| 7 | `display_name` missing | User row has `display_name = NULL` | Dashboard greeting falls back to the email. HelloPanel still renders. |
+| 8 | User with many roles | `roles = ['user', 'admin', 'moderator', ...]` | Header strip renders each role as a chip; no overflow crash (horizontal overflow is allowed — this feature does not add responsive layouts). |
+
+## Security Considerations
+
+- **HttpOnly cookie is never inspected by JS.** The Playwright spec
+  does **not** read `document.cookie` to assert login. It asserts login
+  via observable UI (header strip visible, dashboard URL, role chips
+  rendered). Reading the cookie from JS would be impossible anyway —
+  it's `HttpOnly` — but stating it explicitly avoids a reviewer
+  questioning the test design.
+- **`credentials: 'include'` is forbidden.** The Playwright "relative-
+  URL invariant" test (Happy Path #11) plus code review catch any
+  accidental introduction.
+- **Absolute-URL leak.** Same assertion covers it. A regression
+  that uses `http://localhost:8000/api/...` would be same-origin in
+  dev (accident) but cross-origin in prod (broken) — Happy Path #11
+  catches it in dev.
+- **Google button is network-inert.** The "Google button is inert"
+  test (Happy Path #3) asserts no network request is emitted when
+  the button is clicked. If a future diff wires it up prematurely,
+  this test fails.
+- **OTP code is not logged by the frontend.** The UI never logs the
+  code to the console. Playwright's console listener asserts no log
+  line contains the 6-digit `TEST_OTP_CODE`. (This is a light-touch
+  check, not a proof — the backend console provider still logs the
+  decoy code per `feat_auth_002` design; that's backend behavior and
+  out of scope here.)
+- **Fixture email domain.** Operators must set `TEST_OTP_EMAIL` to a
+  throwaway address under a domain they own (e.g. `e2e@example.com`).
+  With the console provider, the real OTP is only in logs; with a
+  live provider (Resend, SendGrid), the fixture flow still **sends an
+  email to the real address**. Documented in the operator note.
+- **Session scope.** The Playwright spec does not attempt privilege
+  escalation or role probing. Role-gate tests land when a role-gated
+  UI element is added in a later feature.
+- **No test for CSRF.** OTP endpoints are CSRF-resistant by design
+  (they require a one-time code the attacker cannot guess; see
+  `feat_auth_002` security notes). No CSRF surface is added in this
+  feature.
+- **Input sanitization.** React escapes text children by default, so
+  the dashboard greeting and header strip cannot be XSS vectors via
+  the `email` or `display_name` fields. No raw-HTML injection escape
+  hatches are introduced.
+
+## Verification checklist for Vulcan
+
+Before opening the build PR, Vulcan should confirm:
+
+- [ ] `bun run build` passes with zero TS errors.
+- [ ] `bun run test:e2e` passes locally with the fixture env set and
+      `make up` running.
+- [ ] `bun run test:e2e` **skips cleanly** (exit 0, no red tests) when
+      the fixture env is unset.
+- [ ] `./test.sh` still passes (backend + REST suite). No regression.
+- [ ] Git grep for `credentials: 'include'` in `frontend/src/` returns
+      zero hits.
+- [ ] Git grep for `http://localhost` or absolute `http://` URLs in
+      `frontend/src/` returns zero new hits outside
+      `vite-env.d.ts` comments and `vite.config.ts` fallbacks.
+- [ ] `frontend/package.json` has `@playwright/test` only under
+      `devDependencies` and `react-router-dom` under `dependencies`.
+- [ ] No file under `backend/` is modified.

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -10,3 +10,4 @@
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
+| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Spec | - | - | - | - |

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -10,4 +10,4 @@
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
-| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Spec | - | - | - | - |
+| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Spec | #25 | - | - | - |

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -10,4 +10,4 @@
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
-| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Spec | #25 | - | - | - |
+| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Spec | #25 | #26 | - | - |


### PR DESCRIPTION
## Specifications for feat_frontend_002

Adds the login UI over the already-shipping OTP backend (`feat_auth_001` + `feat_auth_002`). Introduces an `AuthContext` that bootstraps from `GET /auth/me`, a `/login` page with a two-step email-OTP form and a disabled "Sign in with Google (coming soon)" button, an authed `/` dashboard with a persistent header strip (email + roles + logout), and a Playwright e2e suite that drives the flow against the compose stack using the existing `TEST_OTP_EMAIL` / `TEST_OTP_CODE` fixture. No backend changes.

### Spec Files
- Feature: `docs/specs/feat_frontend_002/feat_frontend_002.md`
- Design: `docs/specs/feat_frontend_002/design_frontend_002.md`
- Test: `docs/specs/feat_frontend_002/test_frontend_002.md`

### Key decisions locked in with the human
- **Google button:** visible but disabled with a "coming soon" affordance. No network call. Wired for real in `feat_auth_003`.
- **Routing:** `react-router-dom@7` as a new runtime dep.
- **Post-login landing:** authed `/` renders a dashboard (greeting + roles + the existing `getHello()` widget folded in as a panel so the Postgres+Redis demo stays exercised). Unauthed `/` redirects to `/login`.
- **E2E harness:** `@playwright/test` as a **dev dep only**. Lives under `frontend/tests/e2e/`, runs via `bun run test:e2e`, targets the compose stack. Not part of `./test.sh`. Uses the `TEST_OTP_*` fixture — no log scraping.
- **AuthContext contract:** bootstraps with `GET /auth/me` on mount; 200 → authenticated; 401 → anonymous (no error UI); logout = `POST /auth/logout` then clear in-memory state then `/login`.
- **Same-origin invariant preserved:** all new auth calls use relative URLs through the existing Vite-proxy pattern. No absolute URLs, no `credentials: 'include'`.

### Tracker
Appends row to `docs/tracking/features.md` and `docs/specs/README.md` (status `In Spec`).