### PR TITLE
build(feat_frontend_002): login UI — AuthContext, /login page, dashboard, e2e

### DIFF
--- a/docs/deployment/email-otp-setup.md
+++ b/docs/deployment/email-otp-setup.md
@@ -187,3 +187,99 @@ test code sign in as the configured canary account.
 If you hit `EmailProviderConfigError: TEST_OTP_EMAIL / TEST_OTP_CODE
 are set but ENV != 'test'` on startup, clear both values in your
 `infra/.env` (or set `ENV=test`, in a genuinely test-only host).
+
+## E2E smoke test
+
+`feat_frontend_002` adds a Playwright e2e suite under
+`frontend/tests/e2e/` that drives the full OTP login flow through a
+real Chromium. The suite consumes the same `TEST_OTP_EMAIL` /
+`TEST_OTP_CODE` pair documented above. It is **not** invoked by
+`./test.sh` — it runs as a separate `bun run test:e2e` from the
+`frontend/` directory, mirroring how the external REST suite under
+`tests/` is invoked.
+
+### One-time setup per machine
+
+```bash
+cd frontend
+bun install
+bunx playwright install chromium
+```
+
+Only Chromium is required; the suite uses a single `chromium` project.
+Skip `firefox` and `webkit` unless you plan to cross-test manually.
+
+### Configure the fixture
+
+Edit `infra/.env` on the host that will run the stack:
+
+```ini
+ENV=test
+TEST_OTP_EMAIL=e2e@example.com
+TEST_OTP_CODE=424242
+
+# Optional: relax the OTP per-minute/per-hour limits so the suite can
+# re-run without tripping 429.
+OTP_RATE_PER_MINUTE=60
+OTP_RATE_PER_HOUR=600
+```
+
+`ENV=test` is required — the backend's `build_email_sender` refuses to
+start with the fixture pair set in any other environment.
+
+### Run the suite
+
+From the repo root:
+
+```bash
+make up   # brings up backend + postgres + redis + frontend on :5173
+```
+
+In another shell, export the same pair so the **Playwright runner**
+sees them (the backend reads them out of the compose `env_file`; the
+runner reads them out of its own process env, so you have to export
+them in the shell where you invoke `bun run test:e2e`):
+
+```bash
+export TEST_OTP_EMAIL=e2e@example.com
+export TEST_OTP_CODE=424242
+
+cd frontend
+bun run test:e2e
+```
+
+Expected output: one green test, roughly 10-20 seconds on a warm
+Docker host.
+
+### Behavior when the fixture is unset
+
+If you run `bun run test:e2e` without exporting the pair, the suite
+prints a clean skip and exits 0 — not a red failure. This mirrors
+`tests/tests/test_auth.py`'s `_otp_fixture_env` skip behavior.
+
+### Prod-profile frontend
+
+When the stack is brought up with `--profile prod`, the frontend is
+served by nginx on `:8080` instead of Vite on `:5173`. Point
+Playwright at the prod origin:
+
+```bash
+PLAYWRIGHT_BASE_URL=http://localhost:8080 bun run test:e2e
+```
+
+The suite does not hardcode `:5173` outside the Playwright config's
+default.
+
+### Rate-limit retry
+
+Two consecutive full runs against the same `TEST_OTP_EMAIL` will trip
+the per-minute rate limit. The suite detects a 429 on
+`/otp/request` and calls `test.skip('OTP rate limit hit; retry
+later')` so a back-to-back invocation does not report a red failure.
+Either wait out the `Retry-After` window or bump `OTP_RATE_PER_MINUTE`
+in `infra/.env` (both shown above).
+
+> The Playwright suite is **not** a regression gate in `./test.sh`. It
+> is an operator smoke test you run locally before merging a PR that
+> touches login UI or the OTP flow. Wiring it into CI is deferred to a
+> later feature.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -44,6 +44,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_backend_002`      | In Build   | Backend rules (`backend/RULES.md`), logging callsite + redaction, items domain move. |
 | `feat_auth_001`         | In Build   | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
 | `feat_auth_002`         | Merged     | Email OTP login: `EmailSender` abstraction, `/auth/otp/request` + `/auth/otp/verify`, Resend provider, deployment docs. |
-| `feat_frontend_002`     | Ready      | Login UI: `AuthContext`, `/login` OTP page with disabled Google-coming-soon button, authed dashboard + header strip, Playwright e2e suite. |
+| `feat_frontend_002`     | In Build   | Login UI: `AuthContext`, `/login` OTP page with disabled Google-coming-soon button, authed dashboard + header strip, Playwright e2e suite. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_frontend_002/changelog_frontend_002.md
+++ b/docs/specs/feat_frontend_002/changelog_frontend_002.md
@@ -1,0 +1,110 @@
+# Changelog — `feat_frontend_002`
+
+## Added
+
+- **Login UI.** `/login` route renders a two-step email-OTP form.
+  Step 1 calls `POST /api/v1/auth/otp/request`; step 2 calls
+  `POST /api/v1/auth/otp/verify`; a 200 navigates to `/`. Includes a
+  disabled "Sign in with Google (coming soon)" button as a placeholder
+  for `feat_auth_003`.
+- **AuthContext.** New context in `frontend/src/auth/AuthContext.tsx`
+  exposing `{ user, status, refresh, logout }`. States:
+  `loading | authenticated | anonymous`. Bootstraps from
+  `GET /api/v1/auth/me` on mount; a 401 is interpreted as anonymous,
+  not an error.
+- **RequireAuth route gate.** New `frontend/src/auth/RequireAuth.tsx`.
+  Renders a loading skeleton during bootstrap and
+  `<Navigate to="/login" replace />` when anonymous.
+- **Dashboard + Header strip.** New `/` route renders a persistent
+  header (email + role chips + logout) above a dashboard body
+  (greeting + role list + the preserved `HelloPanel` that still
+  exercises the `/api/v1/hello` Postgres+Redis demo).
+- **Auth API client.** New `frontend/src/api/auth.ts` exports
+  `getMe`, `logout`, `requestOtp`, `verifyOtp`, and the `Me` type.
+  `getMe` returns `null` on 401 so the context can handle the
+  anonymous happy path without an error-shaped return. `requestOtp`
+  throws a typed `RateLimitError` on 429 carrying the `retry_after`
+  seconds from the body.
+- **Playwright e2e harness.** New `frontend/playwright.config.ts`,
+  `frontend/tests/e2e/fixtures.ts`, and `frontend/tests/e2e/login.spec.ts`
+  driving the full round-trip (redirect → OTP request → verify →
+  dashboard → logout) in a real Chromium against the compose stack.
+  Includes a relative-URL-invariant assertion that catches any
+  absolute-URL regression in auth fetches.
+- **`bun run test:e2e` script** in `frontend/package.json`, separate
+  from `./test.sh`.
+- **Operator guide.** New "E2E smoke test" section in
+  `docs/deployment/email-otp-setup.md` covering one-time
+  `bunx playwright install chromium`, the `TEST_OTP_EMAIL` /
+  `TEST_OTP_CODE` fixture pair, prod-profile URL override, and
+  rate-limit retry guidance.
+- **Testing section in `frontend/README.md`** pointing at the
+  operator guide.
+
+## Changed
+
+- `frontend/src/App.tsx` is now the routing root (`<Routes>` shell)
+  rather than a standalone hello page. The hello-page logic moved
+  into `frontend/src/components/HelloPanel.tsx`, rendered unchanged
+  inside the authed `Dashboard`.
+- `frontend/src/main.tsx` wraps `<App />` in `<BrowserRouter>` and
+  `<AuthProvider>`.
+- `frontend/src/App.css` grew by ~140 lines: styles for the login
+  page, header strip, role chips, dashboard layout, and the
+  auth-bootstrap loading skeleton.
+- `frontend/.gitignore` now ignores `test-results/`,
+  `playwright-report/`, `playwright/.cache/`, and
+  `tests/e2e/.auth/`.
+- Tracker rows in `docs/tracking/features.md` and
+  `docs/specs/README.md` advanced `feat_frontend_002` from `Ready` to
+  `In Build`.
+
+## Dependencies
+
+- **Added runtime:** `react-router-dom@^7.0.0`.
+- **Added dev:** `@playwright/test@^1.49.0`. Dev-only by contract; the
+  production bundle has no knowledge of it.
+- **Added per-machine tool:** Playwright browser binaries installed
+  via `bunx playwright install chromium`. Not a package dep — a
+  binary download into `~/.cache/ms-playwright/`.
+
+## Unchanged (by design)
+
+- `backend/` — zero file edits. The backend already exposed exactly
+  what this UI needed (`/auth/me`, `/auth/logout`, `/auth/otp/request`,
+  `/auth/otp/verify`).
+- `./test.sh` — still runs only the backend + REST suites
+  (9 passed, 2 skipped). Playwright is a separate `bun run test:e2e`
+  invocation.
+- The `/api/v1/hello` endpoint and its Postgres+Redis wiring. The
+  `HelloPanel` still renders it end-to-end from inside the authed
+  dashboard.
+
+## Acceptance criteria status
+
+All 17 acceptance criteria from `feat_frontend_002.md` verified:
+
+- [x] `/` with no cookie redirects to `/login`; URL bar shows `/login`.
+- [x] `/login` renders email form + disabled "Sign in with Google
+      (coming soon)" button.
+- [x] Step-1 submit calls `/otp/request` exactly once and advances.
+- [x] Step-2 submit calls `/otp/verify` exactly once; 200 → navigate
+      to `/`.
+- [x] After verify, `/` renders header strip + dashboard body.
+- [x] Google click performs no network call (Playwright Happy #3).
+- [x] Logout clears auth + navigates to `/login`.
+- [x] Refresh with live cookie preserves authed UI.
+- [x] Refresh after cookie expiry → redirect to `/login`
+      (implicit — any 401 on `/auth/me` flows through the same
+      anonymous gate).
+- [x] No `credentials: 'include'`; no absolute URLs; verified by
+      Playwright Happy #11 and by `git grep`.
+- [x] `bun run build` passes with zero TS errors.
+- [x] `@playwright/test` only under `devDependencies`.
+- [x] `login.spec.ts` asserts the full flow including `/auth/me`
+      data in the DOM.
+- [x] Fixture-unset → clean skip, exit 0.
+- [x] `frontend/README.md` documents install + run commands + links
+      the operator guide.
+- [x] `./test.sh` unchanged; no Playwright invocation.
+- [x] No `backend/` files modified.

--- a/docs/specs/feat_frontend_002/impl_frontend_002.md
+++ b/docs/specs/feat_frontend_002/impl_frontend_002.md
@@ -1,0 +1,171 @@
+# Implementation Notes — `feat_frontend_002`
+
+## What landed
+
+The login UI over the already-shipping OTP backend. Seven new source
+files plus two rewritten ones under `frontend/src/`, a Playwright e2e
+harness under `frontend/tests/e2e/`, and two doc updates (frontend
+README, email-otp operator guide). **No backend files were touched.**
+
+### Source-tree additions
+
+```
+frontend/src/
+  api/auth.ts                       (NEW)  getMe, logout, requestOtp, verifyOtp
+  auth/AuthContext.tsx               (NEW)  provider + useAuth()
+  auth/RequireAuth.tsx               (NEW)  route gate
+  components/AuthedLayout.tsx        (NEW)  Header + <main>
+  components/Header.tsx              (NEW)  email + roles + logout
+  components/HelloPanel.tsx          (NEW)  extracted hello widget
+  pages/LoginPage.tsx                (NEW)  two-step OTP form
+  pages/Dashboard.tsx                (NEW)  greeting + roles + HelloPanel
+  App.tsx                            (REWRITE) routing root
+  main.tsx                           (MODIFY)  BrowserRouter + AuthProvider
+  App.css                            (MODIFY)  ~140 new lines of layout CSS
+
+frontend/
+  playwright.config.ts               (NEW)
+  tests/e2e/fixtures.ts              (NEW)
+  tests/e2e/login.spec.ts            (NEW)
+  package.json                       (MODIFY) +react-router-dom, +@playwright/test
+  README.md                          (MODIFY) Testing section
+  .gitignore                         (MODIFY) test-results/, playwright-report/
+```
+
+### Dependencies
+
+| Package              | Kind     | Version    |
+|----------------------|----------|------------|
+| `react-router-dom`   | dep      | `^7.0.0`   |
+| `@playwright/test`   | devDep   | `^1.49.0`  |
+
+No other runtime deps were added. No state-management or component
+libraries were pulled in — the feature uses plain `useState` / `useEffect`
+plus the one `AuthContext`.
+
+## AuthContext contract (as implemented)
+
+Three states: `loading | authenticated | anonymous`.
+
+- **Mount** → `status='loading'` + call `getMe()`.
+- **200** → `status='authenticated'`, `user=payload`.
+- **401** → `status='anonymous'`, `user=null`. *Not* an error. `getMe()`
+  returns `null` in this case; only non-401 non-2xx throws.
+- **Anything else** (network error, 5xx) → `console.warn` + fall back
+  to `anonymous`. The UI never gets stuck in `loading`.
+- `refresh()` re-runs the bootstrap. Used by `LoginPage` after verify.
+- `logout()` calls the API then clears local state + `navigate('/login')`.
+  Defensive: if the API call throws, we still clear state — a stale
+  cookie is less bad than a wedged UI.
+
+## Routing contract
+
+```
+<BrowserRouter>
+  <AuthProvider>
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/" element={
+        <RequireAuth>
+          <AuthedLayout>
+            <Dashboard />
+          </AuthedLayout>
+        </RequireAuth>
+      } />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  </AuthProvider>
+</BrowserRouter>
+```
+
+`<RequireAuth>` renders a loading skeleton during bootstrap, then either
+a `<Navigate to="/login" replace />` (anonymous) or children
+(authenticated). This avoids the "flash of login UI" on refresh for
+authed users.
+
+## Google button
+
+Plain `<button type="button" disabled aria-disabled="true"
+title="Google sign-in coming soon">Sign in with Google (coming soon)</button>`.
+No `onClick`, no `fetch`, no reference to any backend path. The Playwright
+suite clicks it with `force: true` and asserts zero `/api/v1/*` calls
+fire. `feat_auth_003` will replace the element wholesale.
+
+## Same-origin invariant
+
+All four auth calls (`getMe`, `logout`, `requestOtp`, `verifyOtp`) use
+relative URLs (`/api/v1/auth/...`) and pass **no** `credentials` option
+to `fetch`. The `HttpOnly; SameSite=Lax` session cookie rides along on
+same-origin requests by default; the Vite dev proxy (and the nginx
+origin in the prod profile) keep the page and API origins identical.
+
+The Playwright suite's "relative-URL invariant" assertion (Happy Path
+#11) records every `/api/v1/*` request URL during the full run and
+asserts each one's origin equals the page origin. An absolute-URL
+regression like `http://localhost:8000/api/...` would fail this check.
+
+## Playwright wiring
+
+- **Config:** `frontend/playwright.config.ts`. Single `chromium` project,
+  `fullyParallel: false`, `workers: 1`, `baseURL` from
+  `PLAYWRIGHT_BASE_URL` env var (default `http://localhost:5173`). No
+  `webServer` block — the operator runs `make up` first.
+- **Fixture:** `frontend/tests/e2e/fixtures.ts` exports `getOtpFixture()`
+  mirroring `_otp_fixture_env()` in `tests/tests/test_auth.py`. Empty env
+  → `null` → `test.skip` with exit 0.
+- **Coverage** (11 happy-path test cases from the test spec, plus
+  one malformed-email case):
+  - Landing redirect, login page elements, Google button inertness,
+    OTP request 204, wrong-code inline error, OTP verify 200,
+    dashboard + header render, refresh-preserves-auth, logout,
+    post-logout redirect, relative-URL invariant, OTP-code not
+    logged to browser console.
+  - `test.skip('OTP rate limit hit; retry later')` when the backend
+    returns 429 on `/otp/request` (mirrors
+    `tests/tests/test_auth.py`'s retry behavior).
+- **Install:** `bunx playwright install chromium` — one-time per
+  machine, documented in both `frontend/README.md` and
+  `docs/deployment/email-otp-setup.md#e2e-smoke-test`.
+- **Runner boundary:** `./test.sh` is unchanged. Playwright runs only
+  via `bun run test:e2e` from `frontend/`.
+
+## Tracker
+
+Row for `feat_frontend_002` moved from `Ready` → `In Build` at the
+start of this build in both `docs/tracking/features.md` and
+`docs/specs/README.md`. The `Status` column will flip to `Merged` and
+the `Impl PRs` column will be backfilled with the build PR number by
+Vulcan in follow-up commits on this branch (per `conventions.md` §7
+lifecycle).
+
+## Verification
+
+- `bun run build` — **pass**, zero TS errors, 51 modules transformed.
+- `./test.sh` — **pass**, 9 passed / 2 skipped. No regression; the
+  test driver runs unchanged.
+- `bun run test:e2e` with fixture set, against a live `make up` stack
+  — **pass**, 2/2 tests green in ~4.6 seconds on the author's machine.
+- `bun run test:e2e` with fixture unset — **clean skip**, exit 0.
+- `git grep credentials: frontend/src/` — returns only the doc-comment
+  mention inside `api/auth.ts` explaining why the option is *not* used.
+- `git grep http://localhost frontend/src/` — one hit in
+  `vite-env.d.ts` (pre-existing doc comment), zero new hits.
+- `git diff main...HEAD -- backend/` — empty.
+
+## Deviations from the spec
+
+None of material substance. Two small call-its-out-loud items:
+
+1. **Operator doc placement.** The design spec offered Vulcan a choice
+   between "subsection in `docs/deployment/email-otp-setup.md`" or a
+   new `docs/deployment/frontend-e2e.md`. I chose the subsection —
+   keeps the fixture documentation in one place, avoids a new top-level
+   operator doc for a single 90-line section.
+2. **Logout navigation on API failure.** The design spec says the
+   header "calls `POST /api/v1/auth/logout`, clears the in-memory
+   `AuthContext`, and navigates to `/login`." I added a defensive
+   `try/catch/finally` in `AuthContext.logout()` so that even if the
+   API call throws (network error or 5xx) we still clear state and
+   navigate. This matches the test spec's Error Case #5 ("Logout call
+   fails with 5xx — UI still clears in-memory auth state and navigates
+   to `/login`"). The UI surface stays identical.

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -10,4 +10,4 @@
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
-| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | Ready | #25 | #26 | - | - |
+| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Build | #25 | #26 | - | - |

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -10,4 +10,4 @@
 | feat_backend_002 | backend rules and logging discipline | Merged | #17 | #16 | #18 | - |
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
-| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Build | #25 | #26 | - | - |
+| feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | In Build | #25 | #26 | #27 | - |

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -13,6 +13,12 @@ dist-ssr/
 *.local
 *.tsbuildinfo
 
+# Playwright (feat_frontend_002)
+test-results/
+playwright-report/
+playwright/.cache/
+tests/e2e/.auth/
+
 # Dependency directories
 node_modules/
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,6 +42,7 @@ render a blank screen.
 | `bun run dev` | Start the Vite dev server (default port 5173) with HMR and the `/api` proxy. |
 | `bun run build` | Type-check (`tsc -b`) and produce a production bundle in `dist/`. |
 | `bun run preview` | Serve the built `dist/` locally for sanity checks. |
+| `bun run test:e2e` | Run the Playwright login e2e suite against the compose stack (requires `make up` first; see [Testing](#testing)). |
 
 A thin `start.sh` wrapper mirrors `backend/start.sh` and dispatches to the same
 commands, so local and (later) containerized entrypoints stay aligned:
@@ -88,14 +89,78 @@ frontend/
   tsconfig.app.json          # App-side TS config (strict mode on)
   tsconfig.node.json         # TS config for vite.config.ts itself
   vite.config.ts             # Vite + React plugin + /api proxy
+  playwright.config.ts       # Playwright e2e config (feat_frontend_002)
   .env.example               # VITE_API_BASE_URL default
-  .gitignore                 # Ignores node_modules/, dist/, .env (not .env.example, not bun.lockb)
+  .gitignore                 # Ignores node_modules/, dist/, .env, test-results/, playwright-report/
   src/
-    main.tsx                 # React entry point
-    App.tsx                  # Hello page (loading / error / success)
+    main.tsx                 # React entry point (BrowserRouter + AuthProvider)
+    App.tsx                  # Routing root (/login public, / authed)
     App.css
     index.css
     vite-env.d.ts            # ImportMetaEnv augmentation for VITE_API_BASE_URL
     api/
       client.ts              # Typed getHello() + HelloResponse type
+      auth.ts                # getMe(), logout(), requestOtp(), verifyOtp() + Me type
+    auth/
+      AuthContext.tsx        # {user, status, refresh, logout} provider + useAuth()
+      RequireAuth.tsx        # Route gate (loading / redirect / render)
+    components/
+      AuthedLayout.tsx       # Header + <main> wrapper for authed routes
+      Header.tsx              # Email + role chips + logout button
+      HelloPanel.tsx         # Extracted hello widget (rendered in Dashboard)
+    pages/
+      LoginPage.tsx          # /login — two-step OTP form
+      Dashboard.tsx          # / — greeting + roles + HelloPanel
+  tests/
+    e2e/
+      fixtures.ts            # getOtpFixture() — reads TEST_OTP_EMAIL/CODE
+      login.spec.ts          # End-to-end login flow + relative-URL invariant
 ```
+
+## Testing
+
+### End-to-end (Playwright)
+
+`feat_frontend_002` ships a Playwright login e2e suite that drives a real
+browser against the compose stack. It is **not** part of `./test.sh` — it runs
+via a separate `bun run test:e2e` invocation, mirroring how the external REST
+suite under `tests/` is invoked.
+
+One-time setup per machine:
+
+```bash
+cd frontend
+bun install
+bunx playwright install chromium
+```
+
+Set the test OTP fixture (consumed both by the backend when `ENV=test` and by
+the Playwright runner itself). Edit `infra/.env`:
+
+```ini
+ENV=test
+TEST_OTP_EMAIL=e2e@example.com
+TEST_OTP_CODE=424242
+```
+
+Then start the stack and run the suite:
+
+```bash
+# from repo root
+make up
+
+# in another shell, export the same pair so the runner sees them too
+export TEST_OTP_EMAIL=e2e@example.com
+export TEST_OTP_CODE=424242
+
+cd frontend
+bun run test:e2e
+```
+
+When either env var is unset, the suite prints a clean skip and exits 0 —
+mirroring the behavior of `tests/tests/test_auth.py`. See
+[`docs/deployment/email-otp-setup.md#e2e-smoke-test`](../docs/deployment/email-otp-setup.md#e2e-smoke-test)
+for the full operator flow including prod-profile overrides.
+
+> Playwright is intentionally a **dev dependency only** in `package.json`. The
+> production bundle has no knowledge of the test runner or its browsers.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -7,8 +7,10 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.0.0",
       },
       "devDependencies": {
+        "@playwright/test": "^1.49.0",
         "@types/node": "^22.10.0",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
@@ -119,6 +121,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.1", "", { "os": "android", "cpu": "arm" }, "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA=="],
@@ -197,6 +201,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -231,6 +237,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
@@ -239,11 +249,17 @@
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
+    "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
+
+    "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
+
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -258,5 +274,7 @@
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,16 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "@types/node": "^22.10.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,39 @@
+/**
+ * Playwright config for feat_frontend_002 e2e suite.
+ *
+ * Runs against the compose stack the operator brings up with `make up`.
+ * There is deliberately no `webServer` block — starting a separate
+ * `bun run dev` + `uvicorn` pair would drift from the real deployment
+ * path we want to exercise. See `docs/deployment/email-otp-setup.md`
+ * section "E2E smoke test" for the operator flow.
+ *
+ * `baseURL` defaults to the Vite dev-server origin that compose
+ * publishes on :5173. Operators running the prod profile (nginx on
+ * :8080) override via `PLAYWRIGHT_BASE_URL=http://localhost:8080`.
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    // Same-origin by contract — don't let the runner silently elevate
+    // anything.
+    ignoreHTTPSErrors: false,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -49,3 +49,194 @@
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
+
+/* ---- feat_frontend_002: login page ------------------------------------ */
+
+.login-page {
+  max-width: 26rem;
+  margin: 4rem auto;
+  padding: 2rem;
+  border: 1px solid rgba(127, 127, 127, 0.3);
+  border-radius: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.login-page__title {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  font-size: 1.5rem;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-form__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.login-form input {
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background-color: transparent;
+  color: inherit;
+  font-family: inherit;
+}
+
+.login-form input:focus-visible {
+  outline: 2px solid rgba(100, 160, 255, 0.6);
+  outline-offset: 1px;
+}
+
+.login-form__submit,
+.login-form__back,
+.google-btn {
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background-color: rgba(100, 160, 255, 0.12);
+  color: inherit;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.login-form__submit:disabled,
+.google-btn:disabled,
+.google-btn--disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.login-form__back {
+  background-color: transparent;
+  opacity: 0.75;
+}
+
+.login-form__error {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(220, 50, 50, 0.5);
+  background-color: rgba(220, 50, 50, 0.08);
+  font-size: 0.95rem;
+}
+
+.login-form__info {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(50, 180, 100, 0.5);
+  background-color: rgba(50, 180, 100, 0.08);
+  font-size: 0.95rem;
+}
+
+.login-form__divider {
+  text-align: center;
+  font-size: 0.8rem;
+  opacity: 0.55;
+  margin: 0.25rem 0;
+}
+
+/* ---- feat_frontend_002: header strip + authed layout ------------------ */
+
+.authed-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.authed-layout__main {
+  padding: 1.5rem;
+}
+
+.auth-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.auth-header__email {
+  font-weight: 600;
+}
+
+.auth-header__roles {
+  list-style: none;
+  display: flex;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 0;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.role-chip {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  font-size: 0.8rem;
+  opacity: 0.85;
+}
+
+.auth-header__logout {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.9rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.auth-header__logout:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+/* ---- feat_frontend_002: dashboard ------------------------------------- */
+
+.dashboard {
+  max-width: 42rem;
+}
+
+.dashboard__greeting {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.dashboard__subtitle {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.role-list {
+  list-style: disc;
+  padding-left: 1.25rem;
+  margin: 0.25rem 0 1rem;
+}
+
+.hello-panel {
+  margin-top: 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(127, 127, 127, 0.3);
+}
+
+.hello-panel__title {
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.auth-bootstrap {
+  margin: 4rem auto;
+  max-width: 20rem;
+  text-align: center;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,70 +1,43 @@
-import { useEffect, useState } from 'react';
-import './App.css';
-import { getHello, type HelloResponse } from './api/client';
-
 /**
- * Single-page hello app. On mount, calls the backend's `/api/v1/hello`
- * endpoint through the typed API client and renders exactly one of three
- * states: loading, error, or success.
+ * Routing root.
+ *
+ * `feat_frontend_001` shipped a single-page hello view here. With
+ * `feat_frontend_002` the hello view moves into `HelloPanel` and is
+ * rendered from the authed `Dashboard`. This file now only wires the
+ * routes.
+ *
+ * Route table:
+ *   /login       — public, the two-step OTP form (LoginPage)
+ *   /            — authed, dashboard wrapped in <AuthedLayout>
+ *   *            — redirect to `/` so typos flow through the auth gate
+ *
+ * `<BrowserRouter>` and `<AuthProvider>` are applied at `main.tsx` one
+ * level up, so the routes below can call `useAuth()` and `useNavigate()`
+ * freely.
  */
+
+import { Navigate, Route, Routes } from 'react-router-dom';
+import './App.css';
+import { RequireAuth } from './auth/RequireAuth';
+import { AuthedLayout } from './components/AuthedLayout';
+import Dashboard from './pages/Dashboard';
+import LoginPage from './pages/LoginPage';
+
 export default function App() {
-  const [data, setData] = useState<HelloResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    setLoading(true);
-    setError(null);
-    setData(null);
-
-    getHello()
-      .then((response) => {
-        if (cancelled) return;
-        setData(response);
-        setLoading(false);
-      })
-      .catch((cause: unknown) => {
-        if (cancelled) return;
-        const message = cause instanceof Error ? cause.message : String(cause);
-        setError(message);
-        setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   return (
-    <div className="app">
-      <h1>minimalist-app</h1>
-      <p className="subtitle">frontend talking to the backend hello endpoint</p>
-
-      {loading && (
-        <div className="state state--loading" role="status" aria-live="polite">
-          Loading...
-        </div>
-      )}
-
-      {!loading && error !== null && (
-        <div className="state state--error" role="alert">
-          Failed to load: {error}
-        </div>
-      )}
-
-      {!loading && error === null && data !== null && (
-        <div className="state state--success">
-          <strong>{data.message}</strong>
-          <dl>
-            <dt>item_name</dt>
-            <dd>{data.item_name}</dd>
-            <dt>hello_count</dt>
-            <dd>{data.hello_count}</dd>
-          </dl>
-        </div>
-      )}
-    </div>
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        path="/"
+        element={
+          <RequireAuth>
+            <AuthedLayout>
+              <Dashboard />
+            </AuthedLayout>
+          </RequireAuth>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
   );
 }

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,188 @@
+/**
+ * Typed client for the auth endpoints exposed by `backend/app/auth/router.py`.
+ *
+ * All four functions use **relative URLs** (e.g. `/api/v1/auth/me`) so the
+ * `HttpOnly; SameSite=Lax` session cookie set by `/otp/verify` rides along
+ * on subsequent calls without any `credentials: 'include'` fetch option.
+ * The page origin matches the API origin in both dev (Vite proxy) and
+ * prod (nginx origin), which is the invariant the whole auth story rests
+ * on.
+ *
+ * `getMe()` is the one intentional non-throwing branch: a 401 returns
+ * `null` so the `AuthContext` provider can treat "no session cookie" as
+ * the anonymous happy path rather than an error state. All other non-2xx
+ * responses (and the other three calls on any non-2xx) throw.
+ */
+
+/**
+ * Shape of `GET /api/v1/auth/me` — mirrors `app.auth.schemas.MeResponse`
+ * in the backend (`backend/app/auth/schemas.py`). If the backend contract
+ * drifts, update this type to match.
+ */
+export interface Me {
+  user_id: number;
+  email: string;
+  display_name: string | null;
+  roles: string[];
+}
+
+/**
+ * Thrown by `requestOtp()` when the backend returns 429. Carries the
+ * number of seconds the server asked us to wait (from the response
+ * body's `retry_after` field, which mirrors the `Retry-After` header).
+ *
+ * `LoginPage` catches this and renders a user-visible "try again in N
+ * seconds" message.
+ */
+export class RateLimitError extends Error {
+  readonly retryAfterSeconds: number;
+
+  constructor(retryAfterSeconds: number, message?: string) {
+    super(message ?? `rate limit exceeded; retry after ${retryAfterSeconds}s`);
+    this.name = 'RateLimitError';
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+/** Parse a backend 429 body. Missing/malformed `retry_after` defaults to 60. */
+function parseRetryAfter(payload: unknown): number {
+  if (payload && typeof payload === 'object' && 'retry_after' in payload) {
+    const raw = (payload as { retry_after: unknown }).retry_after;
+    if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+      return Math.ceil(raw);
+    }
+  }
+  return 60;
+}
+
+/**
+ * Fetch the current principal.
+ *
+ * - 200: returns the parsed `Me` payload.
+ * - 401: returns `null`. The caller (AuthProvider) interprets this as
+ *        "anonymous" — *not* an error.
+ * - anything else: throws.
+ *
+ * Never retries, never caches, never sets auth headers.
+ */
+export async function getMe(): Promise<Me | null> {
+  const url = '/api/v1/auth/me';
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`network error calling ${url}: ${message}`);
+  }
+
+  if (response.status === 401) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `request to ${url} failed with HTTP ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+
+  const payload = (await response.json()) as Me;
+  return payload;
+}
+
+/**
+ * End the session.
+ *
+ * Calls `POST /api/v1/auth/logout`. The backend returns 204 and clears
+ * the session cookie. Throws on any non-2xx response.
+ */
+export async function logout(): Promise<void> {
+  const url = '/api/v1/auth/logout';
+
+  let response: Response;
+  try {
+    response = await fetch(url, { method: 'POST' });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`network error calling ${url}: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `request to ${url} failed with HTTP ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+}
+
+/**
+ * Request an OTP code for `email`.
+ *
+ * Calls `POST /api/v1/auth/otp/request`. On 204 (or any 2xx) resolves.
+ * On 429, throws `RateLimitError` with the `retry_after` seconds parsed
+ * from the body. Any other non-2xx throws a generic `Error`.
+ */
+export async function requestOtp(email: string): Promise<void> {
+  const url = '/api/v1/auth/otp/request';
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`network error calling ${url}: ${message}`);
+  }
+
+  if (response.status === 429) {
+    let payload: unknown = null;
+    try {
+      payload = await response.json();
+    } catch {
+      // Body may be empty or non-JSON; fall back to the default.
+    }
+    throw new RateLimitError(parseRetryAfter(payload));
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `request to ${url} failed with HTTP ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+}
+
+/**
+ * Verify an OTP code.
+ *
+ * Calls `POST /api/v1/auth/otp/verify`. On 200 returns the parsed `Me`
+ * payload and the backend's `Set-Cookie: session=...` header has already
+ * been applied by the browser. On any non-2xx throws — the LoginPage
+ * maps all errors to the uniform "bad code" inline message per the
+ * anti-enumeration rule in `feat_auth_002`.
+ */
+export async function verifyOtp(email: string, code: string): Promise<Me> {
+  const url = '/api/v1/auth/otp/verify';
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, code }),
+    });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(`network error calling ${url}: ${message}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `request to ${url} failed with HTTP ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+
+  const payload = (await response.json()) as Me;
+  return payload;
+}

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,135 @@
+/**
+ * AuthContext — single source of truth for "am I signed in".
+ *
+ * Contract (from `design_frontend_002.md` §AuthContext contract):
+ *
+ * - On provider mount: set `status = 'loading'`, call `getMe()`.
+ * - On 200 (Me payload): `user = payload`, `status = 'authenticated'`.
+ * - On 401 (null): `user = null`, `status = 'anonymous'`. Not an error.
+ * - On any other failure: log a `console.warn`, set `status = 'anonymous'`
+ *   — conservative fallback so a transient backend hiccup never wedges
+ *   the UI in 'loading' forever.
+ * - `refresh()` re-runs `getMe()`. Used by `LoginPage` after a 200
+ *   `/otp/verify` so the dashboard renders with the fresh principal.
+ * - `logout()` calls the API, clears in-memory state, and navigates to
+ *   `/login`. The cookie is `HttpOnly`, so JS never reads it; the server
+ *   is the source of truth.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getMe, logout as apiLogout, type Me } from '../api/auth';
+
+export type AuthStatus = 'loading' | 'authenticated' | 'anonymous';
+
+export interface AuthContextValue {
+  user: Me | null;
+  status: AuthStatus;
+  refresh: () => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [user, setUser] = useState<Me | null>(null);
+  const [status, setStatus] = useState<AuthStatus>('loading');
+
+  // Guards against late setState after unmount (React 19 StrictMode mounts
+  // twice in dev).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const navigate = useNavigate();
+
+  const runBootstrap = useCallback(async () => {
+    try {
+      const me = await getMe();
+      if (!mountedRef.current) return;
+      if (me === null) {
+        setUser(null);
+        setStatus('anonymous');
+      } else {
+        setUser(me);
+        setStatus('authenticated');
+      }
+    } catch (cause) {
+      // Conservative: any non-401 failure lands the user in 'anonymous'.
+      // Never leave the UI stuck in 'loading' — that would blank the
+      // screen indefinitely on a backend outage.
+      // eslint-disable-next-line no-console
+      console.warn('auth bootstrap failed; treating as anonymous', cause);
+      if (!mountedRef.current) return;
+      setUser(null);
+      setStatus('anonymous');
+    }
+  }, []);
+
+  // Bootstrap on mount. No dependencies — we want exactly one kick-off
+  // per provider lifetime (StrictMode's double-mount in dev is fine:
+  // both runs end up with the same final state).
+  useEffect(() => {
+    void runBootstrap();
+  }, [runBootstrap]);
+
+  const refresh = useCallback(async () => {
+    setStatus('loading');
+    await runBootstrap();
+  }, [runBootstrap]);
+
+  const logout = useCallback(async () => {
+    try {
+      await apiLogout();
+    } catch (cause) {
+      // Defensive: even on a failed server-side logout, clear local
+      // state and bounce the user to /login. A stuck cookie is less
+      // bad than a stuck UI — the cookie TTL (and any subsequent
+      // /auth/me 401) will finish the job.
+      // eslint-disable-next-line no-console
+      console.warn('logout API call failed; clearing local state anyway', cause);
+    } finally {
+      if (mountedRef.current) {
+        setUser(null);
+        setStatus('anonymous');
+      }
+      navigate('/login', { replace: true });
+    }
+  }, [navigate]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, status, refresh, logout }),
+    [user, status, refresh, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+/**
+ * Read the current `AuthContext`. Must be called from a descendant of
+ * `<AuthProvider>`; throws otherwise so mistakes fail loudly in dev.
+ */
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (ctx === null) {
+    throw new Error('useAuth() must be used inside an <AuthProvider>');
+  }
+  return ctx;
+}

--- a/frontend/src/auth/RequireAuth.tsx
+++ b/frontend/src/auth/RequireAuth.tsx
@@ -1,0 +1,41 @@
+/**
+ * Gate component for authed routes.
+ *
+ * - status === 'loading' — render a visible loading skeleton. We do NOT
+ *   redirect here; a refresh on an authed page would briefly flash
+ *   `/login` otherwise for users who actually have a valid cookie.
+ * - status === 'anonymous' — `<Navigate to="/login" replace />` so the
+ *   URL bar shows `/login` (not `/`) per Acceptance Criterion.
+ * - status === 'authenticated' — render children.
+ */
+
+import type { ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+export function RequireAuth({ children }: RequireAuthProps) {
+  const { status } = useAuth();
+
+  if (status === 'loading') {
+    return (
+      <div
+        className="state state--loading auth-bootstrap"
+        role="status"
+        aria-live="polite"
+        data-testid="auth-bootstrap"
+      >
+        Loading...
+      </div>
+    );
+  }
+
+  if (status === 'anonymous') {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/AuthedLayout.tsx
+++ b/frontend/src/components/AuthedLayout.tsx
@@ -1,0 +1,23 @@
+/**
+ * Structural wrapper applied to every authed route.
+ *
+ * Renders the persistent `<Header>` strip above a `<main>` element that
+ * receives the route's children. Kept in `src/components/` (not
+ * `src/pages/`) because it is layout, not content.
+ */
+
+import type { ReactNode } from 'react';
+import { Header } from './Header';
+
+interface AuthedLayoutProps {
+  children: ReactNode;
+}
+
+export function AuthedLayout({ children }: AuthedLayoutProps) {
+  return (
+    <div className="authed-layout">
+      <Header />
+      <main className="authed-layout__main">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,59 @@
+/**
+ * Persistent header strip rendered on authed routes.
+ *
+ * Shows the signed-in email, role chips, and a logout button. The button
+ * calls the context's `logout()` which clears local state and navigates
+ * to `/login`. While the logout request is in flight the button is
+ * disabled so a double-click cannot fire two POSTs.
+ */
+
+import { useState } from 'react';
+import { useAuth } from '../auth/AuthContext';
+
+export function Header() {
+  const { user, logout } = useAuth();
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  if (user === null) {
+    // Shouldn't happen — <RequireAuth> guards the routes that render
+    // this header — but render nothing rather than crash if misused.
+    return null;
+  }
+
+  const handleLogout = async () => {
+    if (loggingOut) return;
+    setLoggingOut(true);
+    try {
+      await logout();
+    } finally {
+      // `logout()` is defensive and always clears state + navigates, so
+      // resetting here is mostly cosmetic; covers the edge case where
+      // the component remains mounted after an error path.
+      setLoggingOut(false);
+    }
+  };
+
+  return (
+    <header className="auth-header" data-testid="auth-header">
+      <span className="auth-header__email" data-testid="auth-header-email">
+        {user.email}
+      </span>
+      <ul className="auth-header__roles" data-testid="auth-header-roles">
+        {user.roles.map((role) => (
+          <li key={role} className="role-chip" data-role={role}>
+            {role}
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        className="auth-header__logout"
+        onClick={handleLogout}
+        disabled={loggingOut}
+        data-testid="auth-header-logout"
+      >
+        {loggingOut ? 'Signing out…' : 'Logout'}
+      </button>
+    </header>
+  );
+}

--- a/frontend/src/components/HelloPanel.tsx
+++ b/frontend/src/components/HelloPanel.tsx
@@ -1,0 +1,74 @@
+/**
+ * The original `feat_frontend_001` hello-world view, extracted from
+ * `App.tsx` into a reusable panel so the authed `Dashboard` can render
+ * it inside the broader layout. Behavior is unchanged — same `getHello()`
+ * call, same three-state render (loading / error / success).
+ *
+ * Keeping this panel alive matters: `getHello()` is what exercises the
+ * Postgres + Redis wiring end-to-end. If the panel renders an error, the
+ * backend's data plane is broken even if auth is fine.
+ */
+
+import { useEffect, useState } from 'react';
+import { getHello, type HelloResponse } from '../api/client';
+
+export function HelloPanel() {
+  const [data, setData] = useState<HelloResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setLoading(true);
+    setError(null);
+    setData(null);
+
+    getHello()
+      .then((response) => {
+        if (cancelled) return;
+        setData(response);
+        setLoading(false);
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        const message = cause instanceof Error ? cause.message : String(cause);
+        setError(message);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section className="hello-panel" data-testid="hello-panel">
+      <h2 className="hello-panel__title">backend hello</h2>
+
+      {loading && (
+        <div className="state state--loading" role="status" aria-live="polite">
+          Loading...
+        </div>
+      )}
+
+      {!loading && error !== null && (
+        <div className="state state--error" role="alert">
+          Failed to load: {error}
+        </div>
+      )}
+
+      {!loading && error === null && data !== null && (
+        <div className="state state--success">
+          <strong data-testid="hello-panel-message">{data.message}</strong>
+          <dl>
+            <dt>item_name</dt>
+            <dd>{data.item_name}</dd>
+            <dt>hello_count</dt>
+            <dd>{data.hello_count}</dd>
+          </dl>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
+import { AuthProvider } from './auth/AuthContext';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -10,6 +12,10 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,47 @@
+/**
+ * `/` — the authed dashboard.
+ *
+ * Renders a greeting, a role list, and the `HelloPanel` (which still
+ * exercises the `/api/v1/hello` endpoint end-to-end so the Postgres +
+ * Redis demo the project ships with stays alive).
+ *
+ * Read-only relative to the AuthContext — never mutates `user` or
+ * `status`. Logout lives in the `<Header>`.
+ */
+
+import { useAuth } from '../auth/AuthContext';
+import { HelloPanel } from '../components/HelloPanel';
+
+export default function Dashboard() {
+  const { user } = useAuth();
+
+  if (user === null) {
+    // Defensive — <RequireAuth> guarantees this never fires in practice.
+    return null;
+  }
+
+  const greetingName = user.display_name ?? user.email;
+
+  return (
+    <div className="dashboard" data-testid="dashboard">
+      <h1 className="dashboard__greeting" data-testid="dashboard-greeting">
+        Welcome, {greetingName}
+      </h1>
+
+      <section className="dashboard__roles">
+        <h2 className="dashboard__subtitle">Your roles</h2>
+        {user.roles.length === 0 ? (
+          <p data-testid="dashboard-no-roles">No roles assigned.</p>
+        ) : (
+          <ul className="role-list" data-testid="dashboard-role-list">
+            {user.roles.map((role) => (
+              <li key={role}>{role}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <HelloPanel />
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,244 @@
+/**
+ * `/login` — the two-step email-OTP form.
+ *
+ * Step 1 (request): user enters email, submit calls
+ *   `POST /api/v1/auth/otp/request`. On success advance to step 2.
+ *   On 429, render a "try again in N seconds" message. On any other
+ *   error, render a generic "try again" message.
+ *
+ * Step 2 (verify): user enters six-digit code, submit calls
+ *   `POST /api/v1/auth/otp/verify`. On 200, call
+ *   `AuthContext.refresh()` (awaited, so the dashboard sees the fresh
+ *   principal on first render) and navigate to `/` with replace so the
+ *   back button doesn't land them back on `/login`. On any error, render
+ *   a uniform "code didn't work" message and stay on step 2 — the user
+ *   can retype or click the back link to re-request.
+ *
+ * The Google button is a disabled placeholder for `feat_auth_003`. It
+ * is a plain `<button type="button" disabled>` with no `onClick`, no
+ * `fetch`, and no reference to any backend path. `feat_auth_003` will
+ * replace this element wholesale.
+ */
+
+import { useState, type FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { requestOtp, verifyOtp, RateLimitError } from '../api/auth';
+import { useAuth } from '../auth/AuthContext';
+
+type Step = 'request' | 'verify';
+
+export default function LoginPage() {
+  const { refresh } = useAuth();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState<Step>('request');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setError(null);
+    setInfo(null);
+  };
+
+  const goBackToEmail = () => {
+    reset();
+    setCode('');
+    setStep('request');
+  };
+
+  const onRequestSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitting) return;
+
+    reset();
+
+    const trimmed = email.trim();
+    // Minimal client-side shape check — the backend does the real
+    // validation (and returns the same 400 regardless on verify, per the
+    // anti-enumeration rule). Blocking obviously-malformed input here
+    // avoids a pointless network round-trip and satisfies the
+    // boundary-case test for "malformed email".
+    if (!trimmed.includes('@') || trimmed.length < 3) {
+      setError('Please enter a valid email address.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await requestOtp(trimmed);
+      setEmail(trimmed);
+      setStep('verify');
+      setInfo(`We sent a code to ${trimmed}.`);
+    } catch (cause) {
+      if (cause instanceof RateLimitError) {
+        setError(
+          `Too many requests. Try again in ${cause.retryAfterSeconds} second${
+            cause.retryAfterSeconds === 1 ? '' : 's'
+          }.`,
+        );
+      } else {
+        setError("Couldn't send the code. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onVerifySubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitting) return;
+
+    reset();
+
+    const trimmedCode = code.trim();
+    if (trimmedCode.length !== 6 || !/^\d{6}$/.test(trimmedCode)) {
+      setError('Enter the 6-digit code from your email.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await verifyOtp(email.trim(), trimmedCode);
+      // Refresh AuthContext BEFORE navigating so the dashboard renders
+      // with the fresh principal on first mount (avoids a loading-flash
+      // or, worse, a redirect back to /login if StrictMode re-runs the
+      // bootstrap before the cookie propagates).
+      await refresh();
+      navigate('/', { replace: true });
+    } catch {
+      // Uniform error: we never distinguish "wrong code" from "expired"
+      // from "too many attempts" at the UI layer — the backend enforces
+      // this at the API layer too (anti-enumeration, see
+      // `feat_auth_002`).
+      setError("That code didn't work. Try again, or request a new one.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="login-page" data-testid="login-page">
+      <h1 className="login-page__title">Sign in</h1>
+
+      {step === 'request' && (
+        <form
+          className="login-form"
+          onSubmit={onRequestSubmit}
+          data-testid="login-request-form"
+          noValidate
+        >
+          <label className="login-form__label" htmlFor="login-email">
+            Email
+          </label>
+          <input
+            id="login-email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            autoFocus
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={submitting}
+            data-testid="login-email-input"
+          />
+
+          {error !== null && (
+            <div className="login-form__error" role="alert" data-testid="login-error">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="login-form__submit"
+            disabled={submitting}
+            data-testid="login-request-submit"
+          >
+            {submitting ? 'Sending…' : 'Send code'}
+          </button>
+
+          <div className="login-form__divider" aria-hidden="true">
+            or
+          </div>
+
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            title="Google sign-in coming soon"
+            className="google-btn google-btn--disabled"
+            data-testid="login-google-button"
+          >
+            Sign in with Google (coming soon)
+          </button>
+        </form>
+      )}
+
+      {step === 'verify' && (
+        <form
+          className="login-form"
+          onSubmit={onVerifySubmit}
+          data-testid="login-verify-form"
+          noValidate
+        >
+          {info !== null && (
+            <div
+              className="login-form__info"
+              role="status"
+              aria-live="polite"
+              data-testid="login-code-sent"
+            >
+              {info}
+            </div>
+          )}
+
+          <label className="login-form__label" htmlFor="login-code">
+            6-digit code
+          </label>
+          <input
+            id="login-code"
+            name="code"
+            type="text"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            pattern="[0-9]{6}"
+            maxLength={6}
+            autoFocus
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            disabled={submitting}
+            data-testid="login-code-input"
+          />
+
+          {error !== null && (
+            <div className="login-form__error" role="alert" data-testid="login-error">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="login-form__submit"
+            disabled={submitting}
+            data-testid="login-verify-submit"
+          >
+            {submitting ? 'Verifying…' : 'Verify'}
+          </button>
+
+          <button
+            type="button"
+            className="login-form__back"
+            onClick={goBackToEmail}
+            disabled={submitting}
+            data-testid="login-back-to-email"
+          >
+            Back to email
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -1,0 +1,23 @@
+/**
+ * Test fixtures for the Playwright e2e suite.
+ *
+ * Mirrors `_otp_fixture_env()` in `tests/tests/test_auth.py`: the OTP
+ * fixture is `{ email, code }` when both env vars are non-empty, and
+ * `null` otherwise. The spec file calls `test.skip(fixture === null,
+ * …)` so running Playwright without the fixture prints a clean skip,
+ * not a red failure.
+ */
+
+export interface OtpFixture {
+  email: string;
+  code: string;
+}
+
+export function getOtpFixture(): OtpFixture | null {
+  const email = (process.env.TEST_OTP_EMAIL ?? '').trim();
+  const code = (process.env.TEST_OTP_CODE ?? '').trim();
+  if (email === '' || code === '') {
+    return null;
+  }
+  return { email, code };
+}

--- a/frontend/tests/e2e/login.spec.ts
+++ b/frontend/tests/e2e/login.spec.ts
@@ -48,12 +48,13 @@ test.describe('login flow', () => {
     // --- set up network listeners up front so we see every request
     // including the initial navigation + bootstrap /auth/me call ------
     const apiOrigins: string[] = [];
-    const googleClickRequests: string[] = [];
+    const allRequests: string[] = [];
     const consoleLines: string[] = [];
     const pageOrigin = new URL(baseURL ?? 'http://localhost:5173').origin;
 
     page.on('request', (req: Request) => {
       const url = req.url();
+      allRequests.push(url);
       if (url.includes('/api/v1/')) {
         apiOrigins.push(new URL(url).origin);
       }
@@ -84,11 +85,7 @@ test.describe('login flow', () => {
     // exercise the click + assert no network request went out. Use
     // force:true so Playwright doesn't refuse to click a disabled
     // element.
-    page.on('request', (req: Request) => {
-      // Record any request emitted during the narrow click window.
-      googleClickRequests.push(req.url());
-    });
-    const googleClickBefore = googleClickRequests.length;
+    const beforeClick = allRequests.length;
     await googleBtn.click({ force: true }).catch(() => {
       // Some Playwright versions throw when click-targets are disabled;
       // either way, a disabled element produces no network side-effect,
@@ -97,11 +94,11 @@ test.describe('login flow', () => {
     // Give any would-be fetch a tick to settle, then assert nothing
     // new-fetchable fired on the click.
     await page.waitForTimeout(100);
-    const googleClickAfter = googleClickRequests.length;
-    const newRequests = googleClickRequests.slice(googleClickBefore, googleClickAfter);
-    // Filter noise: browsers sometimes prefetch, retry favicons, etc.
+    const newRequests = allRequests.slice(beforeClick);
     // We only care that no /api/v1/* call (nor any URL containing
     // "google") fired because the user clicked the disabled button.
+    // HMR/dev-server traffic (/@vite/, /src/*, /node_modules/.vite/) is
+    // ignored as noise.
     const googleAuthHits = newRequests.filter(
       (url) => url.includes('/api/v1/') || url.toLowerCase().includes('google'),
     );

--- a/frontend/tests/e2e/login.spec.ts
+++ b/frontend/tests/e2e/login.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Login e2e test for feat_frontend_002.
+ *
+ * Drives the full round trip in a real Chromium against the compose
+ * stack the operator has brought up with `make up`. Fixture pair
+ * (`TEST_OTP_EMAIL` / `TEST_OTP_CODE`) is read from the runner env —
+ * the backend honors the same pair inside `request_otp` only when
+ * `ENV=test`, so an operator intentionally wires them up before the
+ * stack starts.
+ *
+ * The spec covers:
+ *   - Happy path #1: Unauthenticated landing redirect to /login.
+ *   - Happy path #2: Login page renders key elements (email input,
+ *     Send-code button, disabled Google button).
+ *   - Happy path #3: Google button is inert — clicking produces no
+ *     network request.
+ *   - Happy path #4: OTP request advances to step 2.
+ *   - Happy path #5: OTP verify lands on dashboard.
+ *   - Happy path #6: Dashboard shows profile data + HelloPanel.
+ *   - Happy path #7: Header strip shows identity + role chip.
+ *   - Happy path #8: Refresh preserves auth.
+ *   - Happy path #9: Logout ends session.
+ *   - Happy path #10: After logout, / redirects to /login again.
+ *   - Happy path #11: Relative-URL invariant — every /api/v1/* request
+ *     targets the page origin (never http://localhost:8000 or similar).
+ *   - Boundary #2: 429 on OTP request triggers a clean test.skip so the
+ *     suite is re-runnable back-to-back without a red failure.
+ *
+ * Error-case coverage (#1 wrong code, #2 malformed email) is folded in
+ * as secondary assertions where the happy-path state already gives us
+ * the right starting point without a second full login.
+ */
+
+import { test, expect, type Page, type Request } from '@playwright/test';
+import { getOtpFixture } from './fixtures';
+
+const fixture = getOtpFixture();
+
+test.describe('login flow', () => {
+  test.skip(fixture === null, 'TEST_OTP_EMAIL / TEST_OTP_CODE not set');
+
+  test('end-to-end: landing redirect -> OTP -> dashboard -> logout', async ({
+    page,
+    baseURL,
+  }) => {
+    if (fixture === null) return; // unreachable under test.skip; narrows TS
+
+    // --- set up network listeners up front so we see every request
+    // including the initial navigation + bootstrap /auth/me call ------
+    const apiOrigins: string[] = [];
+    const googleClickRequests: string[] = [];
+    const consoleLines: string[] = [];
+    const pageOrigin = new URL(baseURL ?? 'http://localhost:5173').origin;
+
+    page.on('request', (req: Request) => {
+      const url = req.url();
+      if (url.includes('/api/v1/')) {
+        apiOrigins.push(new URL(url).origin);
+      }
+    });
+
+    page.on('console', (msg) => {
+      consoleLines.push(msg.text());
+    });
+
+    // --- Happy path #1 + boundary #3: landing on / with no cookie
+    //     redirects to /login. The AuthContext bootstrap hits
+    //     /api/v1/auth/me, receives 401, and <RequireAuth> routes us. --
+
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login$/);
+
+    // --- Happy path #2: login page renders key elements -------------
+    await expect(page.getByTestId('login-email-input')).toBeVisible();
+    await expect(page.getByTestId('login-request-submit')).toBeVisible();
+
+    const googleBtn = page.getByTestId('login-google-button');
+    await expect(googleBtn).toBeVisible();
+    await expect(googleBtn).toBeDisabled();
+    await expect(googleBtn).toHaveText(/coming soon/i);
+
+    // --- Happy path #3: Google button is inert ----------------------
+    // A `disabled` button's click handler never fires, but we still
+    // exercise the click + assert no network request went out. Use
+    // force:true so Playwright doesn't refuse to click a disabled
+    // element.
+    page.on('request', (req: Request) => {
+      // Record any request emitted during the narrow click window.
+      googleClickRequests.push(req.url());
+    });
+    const googleClickBefore = googleClickRequests.length;
+    await googleBtn.click({ force: true }).catch(() => {
+      // Some Playwright versions throw when click-targets are disabled;
+      // either way, a disabled element produces no network side-effect,
+      // which is what the assertion below measures.
+    });
+    // Give any would-be fetch a tick to settle, then assert nothing
+    // new-fetchable fired on the click.
+    await page.waitForTimeout(100);
+    const googleClickAfter = googleClickRequests.length;
+    const newRequests = googleClickRequests.slice(googleClickBefore, googleClickAfter);
+    // Filter noise: browsers sometimes prefetch, retry favicons, etc.
+    // We only care that no /api/v1/* call (nor any URL containing
+    // "google") fired because the user clicked the disabled button.
+    const googleAuthHits = newRequests.filter(
+      (url) => url.includes('/api/v1/') || url.toLowerCase().includes('google'),
+    );
+    expect(googleAuthHits).toEqual([]);
+
+    // --- Happy path #4: OTP request advances to step 2 --------------
+    await page.getByTestId('login-email-input').fill(fixture.email);
+
+    const otpRequestPromise = page.waitForResponse(
+      (res) => res.url().endsWith('/api/v1/auth/otp/request'),
+    );
+    await page.getByTestId('login-request-submit').click();
+    const otpRequestResponse = await otpRequestPromise;
+
+    // Boundary #2: rate-limited OTP request -> clean skip so a
+    // repeat run doesn't flail.
+    test.skip(
+      otpRequestResponse.status() === 429,
+      'OTP rate limit hit; retry later',
+    );
+    expect(otpRequestResponse.status()).toBe(204);
+
+    await expect(page.getByTestId('login-code-input')).toBeVisible();
+    await expect(page.getByTestId('login-code-sent')).toContainText(fixture.email);
+
+    // --- Error case #1: wrong code -> inline error, no navigation ---
+    await page.getByTestId('login-code-input').fill('999999');
+    const wrongVerifyPromise = page.waitForResponse((res) =>
+      res.url().endsWith('/api/v1/auth/otp/verify'),
+    );
+    await page.getByTestId('login-verify-submit').click();
+    const wrongVerify = await wrongVerifyPromise;
+    expect([400, 401]).toContain(wrongVerify.status());
+    await expect(page.getByTestId('login-error')).toBeVisible();
+    await expect(page).toHaveURL(/\/login$/);
+
+    // --- Happy path #5: submit the correct code ---------------------
+    await page.getByTestId('login-code-input').fill(fixture.code);
+    const verifyPromise = page.waitForResponse((res) =>
+      res.url().endsWith('/api/v1/auth/otp/verify'),
+    );
+    await page.getByTestId('login-verify-submit').click();
+    const verify = await verifyPromise;
+    expect(verify.status()).toBe(200);
+
+    // URL lands on / (the dashboard).
+    await page.waitForURL(/\/$/);
+
+    // --- Happy path #6 + #7: dashboard renders profile + header ----
+    await expect(page.getByTestId('auth-header')).toBeVisible();
+    await expect(page.getByTestId('auth-header-email')).toHaveText(fixture.email);
+    // At minimum, every signed-in user holds the `user` role
+    // (feat_auth_001 bootstrap); admin emails may hold additional roles.
+    await expect(
+      page.getByTestId('auth-header-roles').locator('.role-chip[data-role="user"]'),
+    ).toBeVisible();
+
+    await expect(page.getByTestId('dashboard')).toBeVisible();
+    await expect(page.getByTestId('dashboard-greeting')).toContainText(/Welcome,/);
+    // Role list must include "user".
+    await expect(page.getByTestId('dashboard-role-list')).toContainText('user');
+    // HelloPanel renders its success block (message visible).
+    await expect(page.getByTestId('hello-panel-message')).toBeVisible();
+
+    // --- Happy path #8: refresh preserves auth ----------------------
+    await page.reload();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByTestId('auth-header-email')).toHaveText(fixture.email);
+
+    // --- Happy path #9: logout ends session -------------------------
+    const logoutPromise = page.waitForResponse((res) =>
+      res.url().endsWith('/api/v1/auth/logout'),
+    );
+    await page.getByTestId('auth-header-logout').click();
+    const logoutResponse = await logoutPromise;
+    expect([200, 204]).toContain(logoutResponse.status());
+    await page.waitForURL(/\/login$/);
+    await expect(page.getByTestId('login-email-input')).toBeVisible();
+
+    // --- Happy path #10: after logout, / redirects again -----------
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login$/);
+
+    // --- Happy path #11: relative-URL invariant --------------------
+    // Every /api/v1/* request observed during the run must have
+    // originated from the same origin as the page (baseURL). An
+    // absolute-URL regression (e.g. http://localhost:8000) would fail
+    // here even in dev.
+    expect(apiOrigins.length).toBeGreaterThan(0);
+    for (const origin of apiOrigins) {
+      expect(origin).toBe(pageOrigin);
+    }
+
+    // --- Security: OTP code is not logged by the frontend ----------
+    // Light-touch check per test spec §Security. The backend may
+    // still log the decoy code per feat_auth_002 — that's out of
+    // scope; we only assert the browser console stays clean.
+    const leaked = consoleLines.filter((line) => line.includes(fixture.code));
+    expect(leaked).toEqual([]);
+  });
+
+  test('malformed email blocks step 1 without a network call', async ({ page }) => {
+    if (fixture === null) return;
+
+    let apiHits = 0;
+    page.on('request', (req: Request) => {
+      if (req.url().includes('/api/v1/auth/otp/')) apiHits += 1;
+    });
+
+    await page.goto('/login');
+    await expect(page.getByTestId('login-email-input')).toBeVisible();
+
+    await page.getByTestId('login-email-input').fill('notanemail');
+    await page.getByTestId('login-request-submit').click();
+
+    // Give a potential fetch a tick to settle.
+    await page.waitForTimeout(100);
+
+    await expect(page.getByTestId('login-error')).toBeVisible();
+    await expect(page.getByTestId('login-email-input')).toBeVisible();
+    // Step 2 (code input) must NOT appear.
+    await expect(page.getByTestId('login-code-input')).toHaveCount(0);
+    // No OTP endpoint calls fired.
+    expect(apiHits).toBe(0);
+  });
+});
+
+// Helper kept at module scope so the top-level describe stays readable.
+// Intentionally unused in prod code paths; retained so future spec
+// authors can opt into it.
+export async function waitForApiIdle(page: Page, ms = 200): Promise<void> {
+  await page.waitForTimeout(ms);
+}


### PR DESCRIPTION
## Summary

Adds the login UI over the already-shipping OTP backend (`feat_auth_001` + `feat_auth_002`):

- `AuthContext` bootstrapping from `GET /auth/me` (three-state: loading / authenticated / anonymous)
- `/login` two-step email-OTP form with a disabled "Sign in with Google (coming soon)" placeholder
- `/` authed dashboard with a persistent header strip (email + role chips + logout)
- Playwright e2e suite that drives the full round-trip in Chromium against the compose stack
- Zero backend changes

Closes #26

## Spec references

- Feature: `docs/specs/feat_frontend_002/feat_frontend_002.md`
- Design: `docs/specs/feat_frontend_002/design_frontend_002.md`
- Test:   `docs/specs/feat_frontend_002/test_frontend_002.md`
- Impl notes: `docs/specs/feat_frontend_002/impl_frontend_002.md`
- Changelog:  `docs/specs/feat_frontend_002/changelog_frontend_002.md`

## Changes

- **New frontend modules:** `src/api/auth.ts`, `src/auth/AuthContext.tsx`, `src/auth/RequireAuth.tsx`, `src/components/{AuthedLayout,Header,HelloPanel}.tsx`, `src/pages/{LoginPage,Dashboard}.tsx`.
- **Rewrite:** `src/App.tsx` becomes the routing root; `src/main.tsx` wraps the tree in `<BrowserRouter>` + `<AuthProvider>`; `src/App.css` grows ~140 lines of layout CSS.
- **Playwright wiring:** `frontend/playwright.config.ts`, `frontend/tests/e2e/{fixtures,login.spec}.ts`, `bun run test:e2e` script. `@playwright/test` is a dev-dep only. `./test.sh` is untouched.
- **Deps:** `react-router-dom@^7` (dep), `@playwright/test@^1.49` (devDep).
- **Docs:** new "E2E smoke test" section in `docs/deployment/email-otp-setup.md`; `frontend/README.md` gets a Testing section pointing at it.
- **Tracker:** `docs/tracking/features.md` and `docs/specs/README.md` advance the row from `Ready` to `In Build`.

## Hard-invariant checks (from the spec)

- [x] No file under `backend/` modified (`git diff main...HEAD -- backend/` is empty).
- [x] All new auth fetches use relative URLs; no `credentials: 'include'`. Enforced by Playwright Happy Path #11 (relative-URL invariant assertion) and by `git grep`.
- [x] `@playwright/test` only under `devDependencies`.
- [x] Google button is a plain `<button disabled>` with no `onClick` and no reference to any backend path — Playwright asserts zero `/api/v1/*` hits on click.
- [x] Fixture-unset → clean `test.skip`, exit 0 (mirrors `tests/tests/test_auth.py`).

## Test results

- `./test.sh` — **9 passed, 2 skipped** (backend + external REST suite). No regression.
- `bun run build` — **pass**, zero TS errors.
- `bun run test:e2e` with `TEST_OTP_EMAIL=e2e@example.com` / `TEST_OTP_CODE=424242` against a live `make up` stack — **2 passed (4.6s)**: full round-trip + malformed-email guard.
- `bun run test:e2e` without the fixture — **2 skipped, exit 0**.

## Self-review notes

- **Operator doc placement.** Chose the subsection in `docs/deployment/email-otp-setup.md` over a new `docs/deployment/frontend-e2e.md` (the design spec left this up to Vulcan). The fixture pair is already introduced in that file; keeping everything in one place avoids doc fan-out for a single operator topic.
- **Defensive logout.** `AuthContext.logout()` wraps the `POST /auth/logout` call in `try/catch/finally` so the UI still clears local state and navigates to `/login` on a 5xx or network error. This matches Error Case #5 in the test spec.
- **Google button force-click in the Playwright test.** Used `click({ force: true })` because Playwright refuses to click a `disabled` button by default. The assertion is still "zero `/api/v1/*` or `/google*/` requests emitted during the click window," which is the behavior the spec cares about.
- **`display_name` fallback.** OTP-created users are persisted with `display_name=NULL`; the `Dashboard` greeting falls back to `user.email` in that case, per the spec's boundary condition #7.

## How to try it locally

```bash
# terminal 1: stack
make up

# terminal 2: playwright
export TEST_OTP_EMAIL=e2e@example.com
export TEST_OTP_CODE=424242
cd frontend
bunx playwright install chromium   # one-time per machine
bun run test:e2e
```