### PR TITLE
spec(feat_frontend_003): profile page: /profile route, header Profile button, email-only view

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -45,5 +45,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_auth_001`         | In Build   | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
 | `feat_auth_002`         | Merged     | Email OTP login: `EmailSender` abstraction, `/auth/otp/request` + `/auth/otp/verify`, Resend provider, deployment docs. |
 | `feat_frontend_002`     | Ready      | Login UI: `AuthContext`, `/login` OTP page with disabled Google-coming-soon button, authed dashboard + header strip, Playwright e2e suite. |
+| `feat_frontend_003`     | In Spec    | Profile page: `/profile` authed route, plain-text Profile button at the leftmost slot of `<Header>`, email-only page body, Playwright e2e. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_frontend_003/design_frontend_003.md
+++ b/docs/specs/feat_frontend_003/design_frontend_003.md
@@ -1,0 +1,398 @@
+# Design: Profile page — `/profile` route, header Profile button, email-only view
+
+## Approach
+
+This feature reuses every shell that `feat_frontend_002` already shipped:
+
+- `AuthProvider` already exposes `user` (`Me | null`) and `status`.
+- `<RequireAuth>` already gates authed routes.
+- `<AuthedLayout>` already wraps authed routes with the persistent
+  `<Header>`.
+- `react-router-dom@^7` already drives navigation.
+
+What changes:
+
+1. `<Header>` gets a new leftmost element: a plain-text **Profile**
+   button that calls `useNavigate()` to push `/profile`.
+2. `App.tsx` gains one more `<Route>` at `/profile`, gated identically
+   to `/`.
+3. A new page component `ProfilePage` reads the email from
+   `useAuth().user.email` and renders it. It also handles the
+   `status === 'loading'` case with a plain-text placeholder, even
+   though `<RequireAuth>` will normally never let it render in that
+   state — the placeholder is a defensive belt-and-braces (the user
+   asked for a visible loading affordance, so we provide one even
+   though the gate already covers most cases).
+4. A new Playwright spec `profile.spec.ts` exercises the round trip.
+
+The implementation is intentionally tiny. There is no new API client,
+no new hook, no new context. The data already lives in
+`AuthContext.user`; the page only reads it.
+
+## Files to Modify
+
+| File | Change Description |
+|---|---|
+| `frontend/src/components/Header.tsx` | Prepend a plain-text **Profile** button as the leftmost child of the `<header>` element. The button is `<button type="button" onClick={() => navigate('/profile')}>Profile</button>` (or an equivalent `<Link>`; see "Profile button: `<button>` vs `<Link>`" below for the choice). Add a `data-testid="auth-header-profile"` for the e2e spec. The existing email span, roles list, and logout button move one slot to the right but otherwise are unchanged. |
+| `frontend/src/App.tsx` | Add `import ProfilePage from './pages/ProfilePage';` and a new `<Route path="/profile" element={<RequireAuth><AuthedLayout><ProfilePage /></AuthedLayout></RequireAuth>} />`. Order it after the `/` route and before the `*` catch-all. Do not touch the existing `/` and `/login` routes. |
+| `frontend/src/App.css` | Add a `.auth-header__profile` class mirroring `.auth-header__logout` (plain-text-styled button: same padding, same border, same background-transparent, same cursor). Add `.profile-page` styles consistent with `.dashboard` (left-aligned, max-width container). The new classes do not touch any existing selector. |
+| `frontend/README.md` | In the existing **Testing** section (added by `feat_frontend_002`), update the bullet that lists the e2e specs to include `profile.spec.ts` alongside `login.spec.ts`. No other README changes. |
+| `docs/specs/README.md` | Append a row to the feature roster table for `feat_frontend_003`. |
+| `docs/tracking/features.md` | Append a row for `feat_frontend_003`. Backfill the Spec PR + Issues columns after `gh pr create` and `gh issue create`. |
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `frontend/src/pages/ProfilePage.tsx` | The `/profile` route component. Reads `useAuth()`. Renders `<h1>Profile</h1>` plus a single element holding the email value. Renders a `Loading…` placeholder when `status === 'loading'`. Renders nothing (or a defensive null) if `user === null` while `status === 'authenticated'` — should not happen in practice. Default-export so it matches the `Dashboard.tsx` and `LoginPage.tsx` import style in `App.tsx`. |
+| `frontend/tests/e2e/profile.spec.ts` | The new Playwright spec. Mirrors the structure of `login.spec.ts`: imports `getOtpFixture()` from `./fixtures.ts`, calls `test.skip(fixture === null, …)`, then runs one or more tests covering the profile flow. See the **Playwright spec contract** section below for assertion details. |
+
+No file is deleted. No file under `backend/`, `infra/`, or `tests/`
+(REST suite) is touched.
+
+## Profile button: `<button>` vs `<Link>`
+
+Two reasonable shapes for the Profile element exist in
+`react-router-dom@7`:
+
+1. `<button type="button" onClick={() => navigate('/profile')}>Profile</button>`
+2. `<Link to="/profile">Profile</Link>` styled to look like the
+   existing buttons.
+
+**Vulcan picks option 1 (`<button>`)** for symmetry with the existing
+Logout element in `<Header>`, which is also a `<button>` that hooks
+into router state via a callback. The two adjacent header elements
+should look and behave the same; using `<Link>` for one and `<button>`
+for the other would produce subtly different keyboard / focus
+semantics.
+
+If a future feature adds nav-active styling (highlighting the current
+route), that change can switch both to `<Link>` / `<NavLink>` in one
+go. This feature does not pre-emptively make that change.
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Browser
+    participant Header
+    participant Router as react-router-dom
+    participant Profile as ProfilePage
+    participant AuthCtx as AuthContext
+
+    Note over User,Browser: Already on / (dashboard)
+    User->>Header: click "Profile"
+    Header->>Router: navigate('/profile')
+    Router->>Router: push history entry
+    Router->>Profile: mount
+    Profile->>AuthCtx: useAuth()
+    AuthCtx-->>Profile: { user, status: 'authenticated' }
+    Profile->>Profile: render <h1>Profile</h1> + email
+    Profile-->>User: page rendered
+
+    Note over User,Browser: Click Profile again on /profile
+    User->>Header: click "Profile" (still rendered)
+    Header->>Router: navigate('/profile')
+    Router->>Router: same URL — no-op (no remount, no extra render
+                     beyond router internals)
+    Router-->>User: still on /profile
+```
+
+Note the absence of any `fetch` call in the diagram. The profile page
+neither hits `/auth/me` nor any other backend endpoint — it reads from
+`AuthContext.user`, which was already populated during the
+`AuthProvider` bootstrap.
+
+## Component sketch — `ProfilePage.tsx`
+
+```tsx
+import { useAuth } from '../auth/AuthContext';
+
+export default function ProfilePage() {
+  const { user, status } = useAuth();
+
+  if (status === 'loading') {
+    return (
+      <div
+        className="state state--loading profile-loading"
+        role="status"
+        aria-live="polite"
+        data-testid="profile-loading"
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (user === null) {
+    // Defensive — <RequireAuth> guarantees this never fires under
+    // normal flow. Render nothing rather than crash.
+    return null;
+  }
+
+  return (
+    <div className="profile-page" data-testid="profile-page">
+      <h1 className="profile-page__title">Profile</h1>
+      <p className="profile-page__email" data-testid="profile-page-email">
+        {user.email}
+      </p>
+    </div>
+  );
+}
+```
+
+A `<p>` is a reasonable element choice because the value sits on its
+own line as a paragraph. Vulcan may use `<span>` or `<div>` if a stronger
+case emerges; the test spec keys off the `data-testid`, not the tag.
+
+## Component sketch — updated `Header.tsx`
+
+The existing `<Header>` body becomes:
+
+```tsx
+return (
+  <header className="auth-header" data-testid="auth-header">
+    <button
+      type="button"
+      className="auth-header__profile"
+      onClick={() => navigate('/profile')}
+      data-testid="auth-header-profile"
+    >
+      Profile
+    </button>
+    <span className="auth-header__email" data-testid="auth-header-email">
+      {user.email}
+    </span>
+    <ul className="auth-header__roles" data-testid="auth-header-roles">
+      {user.roles.map((role) => (
+        <li key={role} className="role-chip" data-role={role}>
+          {role}
+        </li>
+      ))}
+    </ul>
+    <button
+      type="button"
+      className="auth-header__logout"
+      onClick={handleLogout}
+      disabled={loggingOut}
+      data-testid="auth-header-logout"
+    >
+      {loggingOut ? 'Signing out…' : 'Logout'}
+    </button>
+  </header>
+);
+```
+
+`useNavigate()` is added at the top of the component:
+
+```tsx
+import { useNavigate } from 'react-router-dom';
+
+export function Header() {
+  const { user, logout } = useAuth();
+  const [loggingOut, setLoggingOut] = useState(false);
+  const navigate = useNavigate();
+  // ...
+}
+```
+
+The `flex: 1` rule on `.auth-header__roles` already pushes the role
+list to take the remaining space, which keeps Logout at the right
+edge after the new Profile element is prepended at the left edge. No
+flex layout changes are needed.
+
+## CSS additions — App.css
+
+```css
+/* ---- feat_frontend_003: profile button + page ------------------------- */
+
+.auth-header__profile {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.9rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.auth-header__profile:focus-visible {
+  outline: 2px solid rgba(100, 160, 255, 0.6);
+  outline-offset: 1px;
+}
+
+.profile-page {
+  max-width: 42rem;
+}
+
+.profile-page__title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.profile-page__email {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin: 0;
+}
+
+.profile-loading {
+  margin: 4rem auto;
+  max-width: 20rem;
+  text-align: center;
+}
+```
+
+The `.auth-header__profile` selector deliberately mirrors
+`.auth-header__logout` so the two header buttons read as a matched
+pair. The monospace font on `.profile-page__email` is consistent with
+the existing `.state dd` rule (the only other place in the app where a
+raw value is rendered without a label).
+
+## Routing contract update
+
+After this feature, `App.tsx` declares:
+
+```tsx
+<Routes>
+  <Route path="/login" element={<LoginPage />} />
+  <Route
+    path="/"
+    element={
+      <RequireAuth>
+        <AuthedLayout>
+          <Dashboard />
+        </AuthedLayout>
+      </RequireAuth>
+    }
+  />
+  <Route
+    path="/profile"
+    element={
+      <RequireAuth>
+        <AuthedLayout>
+          <ProfilePage />
+        </AuthedLayout>
+      </RequireAuth>
+    }
+  />
+  <Route path="*" element={<Navigate to="/" replace />} />
+</Routes>
+```
+
+The `<RequireAuth>` and `<AuthedLayout>` wrappers are duplicated rather
+than hoisted into a layout route. Vulcan may refactor to a layout route
+(`<Route element={<RequireAuth><AuthedLayout /></RequireAuth>}>` with
+`<Outlet />` inside `AuthedLayout`) **only if** the change can be made
+without behavior drift and without touching `feat_frontend_002`'s
+existing route assertions. If in doubt, keep the duplicated form — the
+two-route version is still small enough that the duplication cost is
+lower than the refactor cost.
+
+## Playwright spec contract — `profile.spec.ts`
+
+The new spec follows the same structural pattern as `login.spec.ts`:
+
+```ts
+import { test, expect, type Request } from '@playwright/test';
+import { getOtpFixture } from './fixtures';
+
+const fixture = getOtpFixture();
+
+test.describe('profile flow', () => {
+  test.skip(fixture === null, 'TEST_OTP_EMAIL / TEST_OTP_CODE not set');
+
+  test('navigate to /profile, see email, logout', async ({ page, baseURL }) => {
+    if (fixture === null) return;
+
+    // 1. Sign in via the OTP fixture (helper extracted into the spec
+    //    body or imported from a small shared module — Vulcan picks).
+    // 2. Assert we are on / (the dashboard).
+    // 3. Assert the header has a Profile button at the leftmost slot
+    //    (data-testid="auth-header-profile") and that it is enabled.
+    // 4. Click Profile.
+    // 5. Assert page.url() ends with /profile.
+    // 6. Assert the profile page heading and email are visible:
+    //    expect(page.getByTestId('profile-page-email')).toHaveText(fixture.email)
+    // 7. Click Profile again (still on /profile). Assert URL is still
+    //    /profile, no error toast, no console error.
+    // 8. Click Logout. Assert URL becomes /login.
+    // 9. Optional but recommended: also assert the relative-URL
+    //    invariant for any /api/v1/* requests that fired during the run
+    //    (mirrors login.spec.ts happy-path #11).
+  });
+});
+```
+
+The login helper (steps 1–2) may be:
+
+- Inlined in this spec file (simplest, ~15 lines, copy from
+  `login.spec.ts`), **or**
+- Extracted into a new `frontend/tests/e2e/helpers.ts` module and
+  imported by both specs.
+
+Vulcan picks based on diff size at build time. A shared helper is
+preferred if the inline copy would exceed ~20 lines; otherwise inlined
+is fine. Either choice is acceptable; the test spec asserts behavior,
+not file structure.
+
+### Why the spec re-runs the login flow
+
+The Playwright runner does not share storage state between `*.spec.ts`
+files by default, and we deliberately do **not** introduce a global
+auth fixture in this feature (that's a future test-infra refactor).
+Each spec drives login itself. The cost is small — login is about ~5
+seconds — and isolating specs avoids inter-test ordering pitfalls.
+
+## Edge Cases & Risks
+
+| Risk | Mitigation |
+|---|---|
+| `<Header>` is rendered before `user` is populated and the Profile button appears with a stale email next to it. | The existing `<Header>` early-returns `null` when `user === null`, so the Profile button never renders without a populated `user`. New code preserves this guard. |
+| User clicks Profile rapidly multiple times — does it pile up history entries? | `useNavigate()` defaults to `push`. Multiple identical pushes (`/profile` -> `/profile` -> `/profile`) are no-ops at the URL level (same pathname); browsers and `react-router-dom` do not stack identical history entries beyond the first. Acceptable. |
+| Click on Profile while on `/profile` triggers a re-render of `ProfilePage` and re-fires any side effects. | `ProfilePage` has no `useEffect` and no fetch, so a re-render is observably free (just re-reads `useAuth()`). |
+| The user's email contains characters that need escaping (e.g. `<`, `>`, `"`). | React escapes text-children automatically. Rendering `{user.email}` is safe. No `dangerouslySetInnerHTML` is used. |
+| `feat_frontend_002` is not yet merged when Vulcan starts the build. | Build branch is cut **after** `feat_frontend_002` lands on `main`. Atlas explicitly notes the dependency in the feature spec. |
+| `feat_frontend_002`'s files diverge before merge (e.g. Header restructuring), invalidating this design's edit anchors. | Design references file *names* and component shapes, not line numbers. If a fundamental restructuring lands (e.g. Header is renamed, or AuthContext stops exposing `user.email`), Vulcan stops and escalates. |
+| `<RequireAuth>` is bypassed somehow and `ProfilePage` renders with `user === null`. | `ProfilePage` returns `null` defensively in that branch. No crash, no exception. |
+| Tab-order regression: the new Profile button at the left changes keyboard navigation order in the header. | This is the desired behavior. The leftmost element is the first focusable; a user tabbing through the header now hits Profile first, then email span (not focusable), then role chips (not focusable), then Logout. The order matches visual reading order. |
+| Loading-text wording diverges from the rest of the app. | The text `Loading…` (with the ellipsis character) matches `<RequireAuth>`'s existing copy and the project's bland-Vite tone. Vulcan keeps it consistent. |
+| Test fixture (`TEST_OTP_*`) is not set when running the e2e suite locally. | `test.skip` mirrors `login.spec.ts`. The test prints a clean skip; no red failure. |
+| Two e2e specs both drive login and rate-limit each other (`POST /auth/otp/request` 429s on the second one). | `feat_frontend_002` already documents this risk and mitigation: each spec calls `test.skip('rate-limited; retry later')` if it sees a 429 on the OTP request. The new spec follows the same pattern. |
+| `react-router-dom@7`'s `<Link>` and `useNavigate()` mixed in the same component cause subtle history bugs. | Not a concern — the new `useNavigate()` call is in a click handler, no `<Link>` is added. |
+
+## Dependencies
+
+- **Hard:** `feat_frontend_002` merged to `main` first.
+- **Runtime (no new):** `react-router-dom@^7` (already a dependency
+  after `feat_frontend_002`).
+- **Dev (no new):** `@playwright/test@^1` (already a dev dependency
+  after `feat_frontend_002`).
+- **External tools (no new):** Playwright browsers, already installed
+  by operators per `feat_frontend_002`'s README instructions.
+- **Backend:** unchanged. No new endpoints, no schema changes.
+
+## Deviations
+
+- **Email rendered without a label.** The user explicitly asked for
+  "just email" — the page shows the email value as a bare paragraph.
+  A label like `Email:` was considered and rejected per the user's
+  guidance. The page-level `<h1>Profile</h1>` heading is kept for
+  accessibility and page-title semantics; this is the only piece of
+  framing text on the page body.
+- **Profile button stays active on `/profile`.** The user explicitly
+  confirmed this. Adding nav-active styling is deferred to a future
+  feature (likely whichever feature lands a third authed route).
+- **No duplicate logout on the profile page.** Logout remains in
+  `<Header>`, which is on every authed page including `/profile`. The
+  user confirmed this interpretation.
+- **Loading-state placeholder is plain text.** The user explicitly
+  rejected a spinner library; a `Loading…` text placeholder matches
+  the existing `<RequireAuth>` skeleton and the bland Vite default
+  styling.
+- **Directory and filename use `feat_<domain>_<NNN>` only.** Matches
+  `conventions.md` §2 and every existing sibling. No slug suffix.
+- **Branch name has no slug.** `spec/feat_frontend_003`, per
+  `conventions.md` §3.

--- a/docs/specs/feat_frontend_003/feat_frontend_003.md
+++ b/docs/specs/feat_frontend_003/feat_frontend_003.md
@@ -1,0 +1,217 @@
+# Feature: Profile page — `/profile` route, header Profile button, email-only view
+
+## Problem Statement
+
+`feat_frontend_002` landed the auth shell: `AuthProvider` bootstraps from
+`GET /api/v1/auth/me`, `<RequireAuth>` gates the dashboard, and
+`<Header>` renders the signed-in email, role chips, and a logout button
+on every authed route. The current authed surface is exactly **one
+route** (`/`, the dashboard). There is no dedicated place to surface
+identity-shaped information — even though the backend already returns
+the user's email on `/auth/me` — and there is no second authed route to
+prove the routing shell is generalisable.
+
+This feature adds the smallest possible **profile page** on top of that
+shell. It introduces a second authed route (`/profile`), wires a plain-
+text **Profile** button as the leftmost element of `<Header>` so it is
+reachable from every authed page, and renders the user's email on the
+page body. Logout remains in `<Header>` (so it is still one click away
+from `/profile` without needing a duplicate logout button on the page
+itself). No backend changes; the page consumes the same `Me` payload the
+`AuthContext` already holds.
+
+## Requirements
+
+- A new authed route at `/profile` renders a minimal profile page that
+  shows the signed-in user's email.
+- `<Header>` gains a **Profile** button as its **leftmost** element. The
+  button is plain text (no avatar, no icon, no styling beyond what the
+  existing `<Header>` already uses for `Logout`). It navigates to
+  `/profile` via `react-router-dom`'s client-side routing — it does not
+  reload the page.
+- The Profile button is rendered on **every authed page**, including
+  `/profile` itself. On `/profile` the button stays active (clickable,
+  no disabled state); clicking it on the profile page is a no-op-shaped
+  re-navigation to the same URL — acceptable.
+- The profile page body shows **only the email value**. No `Email:`
+  label is added in front of the value. A page-level `<h1>Profile</h1>`
+  heading is permitted (and recommended) for accessibility / page-title
+  semantics; no other body text is added.
+- While `AuthContext.status === 'loading'` the profile page renders a
+  visible loading placeholder (plain text — `Loading…` or equivalent —
+  no spinner library, matching the bland Vite default styling already
+  used elsewhere). In practice `<RequireAuth>` already handles the
+  bootstrap case, so this loading state covers any in-page reload of
+  the auth state (e.g. after a future `refresh()` call) rather than
+  the first-mount bootstrap.
+- `<Header>` continues to render the existing email + role chips +
+  logout. The existing element ordering is preserved **except** that
+  Profile is prepended at position 0. Logout stays at the rightmost
+  slot.
+- Logout from `/profile` works exactly as it does from `/`: clicking
+  `Logout` in `<Header>` calls `POST /api/v1/auth/logout`, clears
+  in-memory auth state, and navigates to `/login`.
+- Navigating to `/profile` while unauthenticated routes the user to
+  `/login` via the existing `<RequireAuth>` gate (no new redirect logic
+  is introduced).
+- After successful login the user lands on `/` (the dashboard) — the
+  default landing page is unchanged. `/profile` is reachable only by
+  clicking the new header button or by direct URL.
+- All new client-side calls — if any — use **relative URLs** and the
+  same-origin invariant established in `feat_frontend_002`. In practice
+  this feature adds zero new API calls; the email is read from the
+  existing `AuthContext.user.email`.
+- A new **Playwright e2e spec** at `frontend/tests/e2e/profile.spec.ts`
+  drives `/profile` end-to-end against the compose stack: log in via
+  the OTP fixture, click the header Profile button, assert the URL,
+  assert the email is visible on the page body, click Profile a second
+  time on `/profile` (no-op), click Logout, assert redirect to `/login`.
+  It uses the same `getOtpFixture()` skip pattern as `login.spec.ts`.
+- No changes to `backend/`, `infra/`, or `tests/` (the REST suite).
+  `./test.sh` remains unchanged in behavior.
+
+## User Stories
+
+- As a signed-in user, I want a Profile button visible in the header on
+  every authed page so I can reach my profile from anywhere in one click.
+- As a signed-in user, I want the Profile button to be the leftmost
+  element of the header so its placement matches the convention used in
+  most web apps.
+- As a signed-in user, I want the profile page to show my account email
+  so I can verify which account I am currently signed in with.
+- As a signed-in user, I want logout to remain reachable from the
+  profile page (via the same header strip) so I can sign out without
+  navigating back to the dashboard first.
+- As an unauthenticated visitor who pastes a `/profile` URL, I want to
+  be redirected to `/login` first, so I cannot see profile content
+  without authenticating.
+
+## User Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Header
+    participant Router as react-router-dom
+    participant ProfilePage
+    participant AuthCtx as AuthContext
+
+    Note over User,Header: Already authenticated, on /
+    User->>Header: click "Profile"
+    Header->>Router: navigate('/profile')
+    Router->>ProfilePage: render
+    ProfilePage->>AuthCtx: useAuth() — read user
+    AuthCtx-->>ProfilePage: { user: {email, ...}, status: 'authenticated' }
+    ProfilePage-->>User: render <h1>Profile</h1> + email value
+
+    Note over User,Header: Logout from /profile
+    User->>Header: click "Logout"
+    Header->>AuthCtx: logout()
+    AuthCtx->>AuthCtx: POST /api/v1/auth/logout, clear state
+    AuthCtx->>Router: navigate('/login', { replace: true })
+    Router-->>User: /login renders
+```
+
+## Scope
+
+### In Scope
+
+- New page component `frontend/src/pages/ProfilePage.tsx` rendering a
+  page heading and the email value.
+- New route entry `/profile` in `frontend/src/App.tsx`, gated by the
+  existing `<RequireAuth>` and wrapped in the existing
+  `<AuthedLayout>` so the header strip is rendered.
+- Edit to `frontend/src/components/Header.tsx` to prepend a plain-text
+  Profile button at position 0. The button uses
+  `react-router-dom`'s `useNavigate()` (consistent with the rest of
+  the app) to push `/profile` onto history.
+- Minimal CSS additions in `frontend/src/App.css` for the new Profile
+  button (matching the existing `.auth-header__logout` plain-text
+  style) and the profile page layout (matching the dashboard's bland
+  Vite-default look).
+- New Playwright spec `frontend/tests/e2e/profile.spec.ts` covering the
+  navigation + email-rendered + logout flow. Uses
+  `frontend/tests/e2e/fixtures.ts` (already shipped by `feat_frontend_002`).
+- Minor `frontend/README.md` update mentioning the new spec under the
+  Testing section so operators know `bun run test:e2e` now runs both
+  `login.spec.ts` and `profile.spec.ts`.
+- Update `docs/specs/README.md` feature roster row.
+- Update `docs/tracking/features.md` with a new row.
+
+### Out of Scope
+
+- **Backend changes of any kind.** The feature reads from
+  `AuthContext.user`, which is already populated from `/auth/me`.
+- A new `/api/v1/auth/profile` (or similar) endpoint. Not needed; the
+  `Me` payload already carries `email`, `display_name`, and `roles`.
+- Profile **editing** — no form, no PATCH, no PUT. Read-only view.
+- Avatar upload, image rendering, gravatar lookup, or any image-
+  handling UI.
+- Password change, email change, MFA enrolment, session-management UI.
+- Showing `display_name`, roles, `user_id`, or any other field beyond
+  `email`. The user explicitly asked for "just email" on the page.
+- A duplicate Logout button on the profile page body. Logout stays in
+  `<Header>` only.
+- A 404 page for `/profile/<anything>` deeper paths — the existing
+  catch-all `<Route path="*" />` already redirects unknown paths to
+  `/`, which then routes through `<RequireAuth>` to the right place.
+- An icon library, design system, or any new runtime dependency. The
+  Profile button is a plain `<button>` (or `<a>` styled like one)
+  rendered with text only.
+- Persisting an "active route" highlight on the Profile button when
+  the user is on `/profile`. The button stays visually identical
+  whether or not the user is on the profile page. (A future feature
+  may add nav-active styling once a third route exists.)
+- Loading-spinner libraries (e.g. `react-spinners`, `nprogress`). The
+  loading state is plain text.
+- Component / unit tests with Vitest or RTL. Coverage is e2e-only,
+  consistent with the testing posture set in `feat_frontend_002`.
+- Adding the new spec to `./test.sh`. Playwright remains a separate
+  invocation (`bun run test:e2e`).
+
+## Acceptance Criteria
+
+- [ ] Visiting `/profile` while signed in renders a page with a visible
+      `Profile` heading and the user's email displayed in the body.
+- [ ] Visiting `/profile` while signed out redirects to `/login` (via
+      the existing `<RequireAuth>` gate).
+- [ ] `<Header>` renders a Profile button as the **leftmost** element on
+      both `/` and `/profile`. The order is: Profile, email, role chips,
+      Logout.
+- [ ] Clicking the Profile button on `/` navigates to `/profile` without
+      a full page reload (the `AuthContext` provider does not unmount,
+      observable via no extra `GET /auth/me` request firing on click).
+- [ ] Clicking the Profile button on `/profile` keeps the user on
+      `/profile` (re-navigation to the same URL). No crash, no error.
+- [ ] Clicking Logout on `/profile` calls `POST /api/v1/auth/logout`,
+      clears auth state, and navigates to `/login`.
+- [ ] The profile page body contains the email **value** as bare text;
+      no `Email:` label precedes it.
+- [ ] No new API endpoints are added; no file under `backend/` is
+      modified.
+- [ ] Every new `fetch` (if any) in this feature uses a **relative URL**
+      and does **not** set `credentials: 'include'`. (Expected count of
+      new fetches: zero.)
+- [ ] `bun run build` passes with zero TypeScript errors.
+- [ ] `frontend/tests/e2e/profile.spec.ts` exists and asserts: header
+      has a Profile button at the leftmost position, click navigates to
+      `/profile`, email is visible on the page body, second Profile
+      click stays on `/profile`, logout from `/profile` redirects to
+      `/login`.
+- [ ] The Playwright spec calls `test.skip` when `TEST_OTP_EMAIL` /
+      `TEST_OTP_CODE` are unset, mirroring `login.spec.ts`.
+- [ ] `./test.sh` continues to pass with no behavior change. Running
+      `./test.sh` does not invoke Playwright.
+- [ ] `docs/specs/README.md` and `docs/tracking/features.md` are
+      updated with a `feat_frontend_003` row.
+
+## Dependencies
+
+- **Hard dependency:** `feat_frontend_002` must land first. This
+  feature edits files (`App.tsx`, `Header.tsx`, `App.css`,
+  `tests/e2e/fixtures.ts`) that `feat_frontend_002` introduces. Vulcan
+  must wait for `feat_frontend_002` to merge into `main` before cutting
+  the `build/feat_frontend_003` branch. If `feat_frontend_002` is
+  revised before merge, this spec's file references stay valid because
+  they target the file *names*, not commit-pinned line ranges.
+- No new runtime or dev dependencies are added.

--- a/docs/specs/feat_frontend_003/test_frontend_003.md
+++ b/docs/specs/feat_frontend_003/test_frontend_003.md
@@ -1,0 +1,133 @@
+# Test Spec: Profile page — `/profile` route, header Profile button, email-only view
+
+## Test harness
+
+This feature ships **Playwright e2e tests only** — consistent with
+`feat_frontend_002`. No Vitest, no React Testing Library, no component
+tests. The runner targets the compose-brought-up stack (`make up` from
+the repo root) and drives Chromium against `http://localhost:5173` (or
+`PLAYWRIGHT_BASE_URL`).
+
+- Location: `frontend/tests/e2e/profile.spec.ts` (new, this feature).
+- Existing infrastructure reused (no changes):
+  - `frontend/playwright.config.ts`
+  - `frontend/tests/e2e/fixtures.ts` (`getOtpFixture()`)
+  - `bun run test:e2e` script in `frontend/package.json`
+- Env: same `TEST_OTP_EMAIL` / `TEST_OTP_CODE` pair as `login.spec.ts`.
+  When unset, the new spec calls `test.skip` and exits cleanly.
+- `./test.sh` is unchanged and does **not** invoke Playwright.
+
+## Happy Path
+
+| # | Test Case | Input | Expected Output |
+|---|---|---|---|
+| 1 | Header has a Profile button at leftmost slot | After login on `/` | `page.getByTestId('auth-header-profile')` is visible, enabled, and is the first child of `[data-testid="auth-header"]`. |
+| 2 | Profile button label | After login on `/` | The Profile button's text content is exactly `Profile`. |
+| 3 | Click Profile navigates to `/profile` | Login -> click Profile button | URL becomes `/profile`. The auth bootstrap (`/api/v1/auth/me`) is NOT re-fired by this navigation (only client-side route change). |
+| 4 | Profile page renders heading | On `/profile` | A heading with text `Profile` is visible. |
+| 5 | Profile page renders email value | On `/profile`, fixture email = `e2e@example.com` | `page.getByTestId('profile-page-email')` has text exactly `e2e@example.com`. |
+| 6 | Profile page does NOT render `Email:` label | On `/profile` | No element on the profile page contains the literal text `Email:`. (The header still shows the email separately; the assertion is scoped to `[data-testid="profile-page"]`.) |
+| 7 | Header still rendered on `/profile` | On `/profile` | `[data-testid="auth-header"]` is visible; Profile, email span, role chips, and Logout are all present. |
+| 8 | Header order is Profile, email, roles, Logout | On `/profile` | The four `data-testid` elements appear in this DOM order under `[data-testid="auth-header"]`: `auth-header-profile`, `auth-header-email`, `auth-header-roles`, `auth-header-logout`. |
+| 9 | Click Profile while on `/profile` is a no-op | On `/profile`, click Profile button | URL is still `/profile`. No console error. The page does not flicker into a loading state (because `<AuthContext>` does not re-bootstrap on a same-URL push). |
+| 10 | Logout from `/profile` ends session | On `/profile`, click Logout | `POST /api/v1/auth/logout` returns 204; URL becomes `/login`; the email input from the login page is visible. |
+| 11 | After logout, `/profile` redirects | After logout, `await page.goto('/profile')` | URL becomes `/login` (the `<RequireAuth>` gate redirects). |
+| 12 | Relative-URL invariant | Inspect network log over the entire run | Every `/api/v1/...` request targets the same origin as the page. No `http://localhost:8000` origin appears. (Mirrors `login.spec.ts` happy-path #11; folded in as a safety net.) |
+| 13 | Dashboard still works after this feature | Navigate `/profile` -> back-button -> `/` | Dashboard renders normally, header still has the Profile button at the leftmost slot. (Regression check that the `feat_frontend_002` flow is undisturbed.) |
+
+The spec ships a single `test()` that performs the whole round trip
+(login -> Profile click -> assertions on `/profile` -> Profile re-click
+-> Logout -> redirect re-check). This matches the structural choice in
+`login.spec.ts`. Splitting into multiple tests is acceptable but each
+test would have to repeat the login dance, which is slow and adds rate-
+limit risk.
+
+## Error Cases
+
+| # | Test Case | Input | Expected Behavior |
+|---|---|---|---|
+| 1 | Direct visit to `/profile` while signed out | Open a fresh page, `await page.goto('/profile')` | URL becomes `/login` (via `<RequireAuth>` -> `<Navigate to="/login" replace />`). The profile page heading does not flash on screen. |
+| 2 | Backend 5xx on `/auth/me` while signed out, user opens `/profile` | Simulate 500 on `/auth/me` (or stop the backend container) | `<AuthContext>` lands in `'anonymous'`; `<RequireAuth>` redirects to `/login`. No crash, no infinite redirect loop. (Optional — covered implicitly by the existing `feat_frontend_002` design.) |
+| 3 | Logout API returns 5xx from `/profile` | Backend errors on `POST /auth/logout` while user clicks Logout from `/profile` | UI still clears in-memory auth state and navigates to `/login` (defensive — mirrors `feat_frontend_002`'s logout error handling). Optional Playwright assertion. |
+| 4 | Email contains HTML-special characters | User row has `email = 'a<b>"c"@example.com'` (synthetic — not a real fixture) | React escapes text children, so the literal string is rendered verbatim with no HTML interpretation. The element's `textContent` matches the raw email exactly. (Documented as expected behavior; not tested in CI because no operator-set fixture matches this shape.) |
+| 5 | `user === null` while `status === 'authenticated'` | Defensive code path; cannot occur via normal flow | `ProfilePage` returns `null` (renders nothing). Documented; not asserted in Playwright. |
+
+Cases 2 and 3 are documented for future testers but are **not** required
+to land this feature. Case 1 IS required and is asserted by Happy
+Path #11. Case 4 is documented as a property of React's text-child
+escaping; no test infrastructure for synthetic email shapes is built.
+
+## Boundary Conditions
+
+| # | Test Case | Condition | Expected Behavior |
+|---|---|---|---|
+| 1 | Fixture not set | `TEST_OTP_EMAIL` or `TEST_OTP_CODE` empty on the Playwright runner | Spec calls `test.skip`; Playwright prints a clean skip; exit code 0. |
+| 2 | OTP request rate-limited | `POST /auth/otp/request` returns 429 (e.g. because a prior run just ran) | Spec calls `test.skip('rate-limited; retry later')`, mirroring `login.spec.ts`. |
+| 3 | Stack not up | Backend is not running when Playwright launches | First navigation times out; Playwright reports the network error cleanly. Operator is expected to run `make up` before `bun run test:e2e`. |
+| 4 | Prod-profile frontend | Operator runs compose with `--profile prod` (frontend on :8080) | `PLAYWRIGHT_BASE_URL=http://localhost:8080 bun run test:e2e` runs the same spec against the prod bundle. The spec must not hardcode `:5173` outside config. |
+| 5 | Refresh on `/profile` | User reloads the page while on `/profile` | Loading skeleton flashes (from `<RequireAuth>` during bootstrap), then `/profile` re-renders with email visible. URL is preserved (no redirect to `/`). |
+| 6 | Click Profile on `/login` | Should not be possible — Profile button is in `<Header>`, which is only rendered on authed routes | Test is N/A. Documented for completeness: the Profile button does not exist on `/login`. |
+| 7 | `display_name` is set | User row has `display_name = 'Ada Lovelace'` | The dashboard greeting still uses `display_name`, but the profile page shows the **email**, not the display name (per the user's "just email" requirement). |
+| 8 | Email of unusual length | Email is 60+ chars long | The email renders without truncation. CSS does not introduce `text-overflow: ellipsis` or `overflow: hidden` on `.profile-page__email`. Horizontal overflow at very narrow viewports is acceptable; this feature does not add responsive layouts. |
+| 9 | Browser back-button after navigating to `/profile` | On `/profile`, click browser Back | URL becomes `/`; dashboard renders. The history stack contains both entries, so Forward returns to `/profile`. |
+| 10 | Manual URL edit to `/profile/sub` (non-existent sub-route) | Type `/profile/foo` into URL bar | Catches the `*` route in `App.tsx`, redirects to `/`, which then renders the dashboard. (No test asserts this; it's a property of the existing route table.) |
+
+## Security Considerations
+
+- **No new API surface.** This feature adds zero `fetch` calls. There
+  is no new endpoint to authenticate, no new request body to validate,
+  no new response shape to interpret. The threat model from
+  `feat_frontend_002` is unchanged by this feature.
+- **HttpOnly cookie still untouched.** The Playwright spec does not
+  read `document.cookie`. Login state is asserted via observable UI
+  (header strip, profile email, dashboard URL).
+- **Relative-URL invariant.** Happy Path #12 carries the same
+  assertion `login.spec.ts` ships: every `/api/v1/*` request targets
+  the page origin. No accidental absolute-URL regression can slip in
+  via this feature because it does not add any new `fetch`, but the
+  test fires the assertion regardless, which guards the entire run
+  including the login dance.
+- **Profile button is not a URL injection vector.** The `onClick`
+  handler hard-codes the path `/profile`. There is no user-supplied
+  data flowing into the navigation target.
+- **Email rendering is safe.** React escapes text children. No
+  `dangerouslySetInnerHTML` is used. The email value, even if pre-
+  populated by an attacker through some upstream flow, cannot inject
+  script tags into the page.
+- **No cross-origin requests.** This feature does not introduce any
+  cross-origin call, redirect, or `<iframe>`.
+- **No PII expansion.** The page renders only `email`, which the user
+  is already authenticated as — the same value the `<Header>`
+  already shows. No additional PII (e.g. phone numbers, addresses, IP)
+  is surfaced.
+- **No CSRF surface.** The feature adds zero state-mutating endpoints.
+- **No console leak of sensitive data.** The new code does not
+  `console.log` any auth state. The Playwright console listener
+  inherited from the spec scaffolding (if used) asserts no fixture
+  email or code appears in console output during the run; a copy-
+  paste of the convention from `login.spec.ts` is acceptable but
+  optional.
+
+## Verification checklist for Vulcan
+
+Before opening the build PR, Vulcan should confirm:
+
+- [ ] `bun run build` passes with zero TS errors.
+- [ ] `bun run test:e2e` passes locally with the fixture env set and
+      `make up` running. Both `login.spec.ts` and `profile.spec.ts`
+      green.
+- [ ] `bun run test:e2e` skips cleanly (exit 0, no red tests) when the
+      fixture env is unset.
+- [ ] `./test.sh` still passes (backend + REST suite). No regression.
+- [ ] Git grep for `credentials: 'include'` in `frontend/src/` returns
+      zero hits (unchanged from `feat_frontend_002`).
+- [ ] Git grep for `http://localhost` or absolute `http://` URLs in
+      `frontend/src/` returns zero new hits.
+- [ ] No new dependency added to `frontend/package.json` (the feature
+      uses only deps already pulled in by `feat_frontend_002`).
+- [ ] No file under `backend/`, `infra/`, or `tests/` is modified.
+- [ ] `frontend/src/components/Header.tsx` shows Profile as the
+      **first** JSX child of the `<header>` element (verified visually
+      and via the e2e spec's DOM-order assertion).
+- [ ] Spec README and `docs/tracking/features.md` rows are appended
+      and the Spec PR + Issues columns are backfilled.

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -11,3 +11,4 @@
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
 | feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | Ready | #25 | #26 | - | - |
+| feat_frontend_003 | profile page: /profile route, header Profile button, email-only view | Specced | #28 | #29 | - | - |


### PR DESCRIPTION
## Specifications for feat_frontend_003

Adds a minimal authenticated `/profile` page that displays the signed-in user's email, plus a Profile button in the header for navigation. Read-only, email-only view; no editing.

### Spec Files
- Feature: `docs/specs/feat_frontend_003/feat_frontend_003.md`
- Design: `docs/specs/feat_frontend_003/design_frontend_003.md`
- Test: `docs/specs/feat_frontend_003/test_frontend_003.md`