### PR TITLE
build(feat_frontend_003): profile page + header Profile button

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -45,6 +45,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_auth_001`         | In Build   | Auth foundation: users/roles/identities schema, Redis sessions, `SessionMiddleware`, `/auth/me`, `/auth/logout`. |
 | `feat_auth_002`         | Merged     | Email OTP login: `EmailSender` abstraction, `/auth/otp/request` + `/auth/otp/verify`, Resend provider, deployment docs. |
 | `feat_frontend_002`     | Merged     | Login UI: `AuthContext`, `/login` OTP page with disabled Google-coming-soon button, authed dashboard + header strip, Playwright e2e suite. |
-| `feat_frontend_003`     | In Spec    | Profile page: `/profile` authed route, plain-text Profile button at the leftmost slot of `<Header>`, email-only page body, Playwright e2e. |
+| `feat_frontend_003`     | In Build   | Profile page: `/profile` authed route, plain-text Profile button at the leftmost slot of `<Header>`, email-only page body, Playwright e2e. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_frontend_003/changelog_frontend_003.md
+++ b/docs/specs/feat_frontend_003/changelog_frontend_003.md
@@ -1,0 +1,86 @@
+# Changelog: feat_frontend_003
+
+## Added
+
+- **`/profile` authed route.** A second authed route landed in
+  `frontend/src/App.tsx`, gated by the existing `<RequireAuth>` and
+  wrapped in the existing `<AuthedLayout>`. Direct visits while
+  signed out are redirected to `/login` with no new redirect logic.
+- **Profile button in the header strip.** `<Header>` gains a
+  plain-text **Profile** button as the leftmost element. It uses
+  `useNavigate()` from `react-router-dom` for client-side navigation
+  to `/profile`. The button is rendered on every authed route,
+  including `/profile` itself; clicking it from `/profile` is a
+  harmless re-navigation to the same URL.
+- **`ProfilePage` component** at `frontend/src/pages/ProfilePage.tsx`.
+  Renders `<h1>Profile</h1>` plus the signed-in user's email value
+  (no `Email:` label, no other PII). The page reads the email
+  straight off `AuthContext.user`, so it issues zero `fetch` calls.
+  Defensively handles the `status === 'loading'` and
+  `user === null` branches with a plain-text `Loading…` placeholder
+  and a silent `null` return, respectively — neither branch is
+  reachable under normal flow because `<RequireAuth>` upstream
+  handles those states.
+- **Playwright e2e spec** at `frontend/tests/e2e/profile.spec.ts`.
+  One round-trip test: log in via the OTP fixture, click the header
+  Profile button, assert the URL becomes `/profile` and the email is
+  visible on the page body, click Profile a second time on `/profile`
+  (no-op), use the browser back-button to return to `/` and forward
+  back to `/profile`, click Logout, assert redirect to `/login`,
+  and finally assert that visiting `/profile` after logout redirects
+  to `/login`. Includes the relative-URL invariant (every observed
+  `/api/v1/*` request targets the page origin) and a console-leak
+  check for the OTP code. Calls `test.skip` cleanly when
+  `TEST_OTP_EMAIL` / `TEST_OTP_CODE` are unset and on a 429 from
+  `/auth/otp/request`.
+
+## Changed
+
+- **`<Header>` layout.** The existing email span, role chips, and
+  logout button move one slot to the right; their order is preserved
+  among themselves. Final DOM order under `[data-testid="auth-header"]`:
+  Profile, email, roles, Logout.
+- **`App.tsx` route table.** The new `/profile` route is registered
+  after `/` and before the `*` catch-all. The catch-all behavior is
+  unchanged — typo paths still bounce to `/`, then through
+  `<RequireAuth>` to the right place.
+- **`App.css`.** Six new selectors: `.auth-header__profile`,
+  `.auth-header__profile:focus-visible`, `.profile-page`,
+  `.profile-page__title`, `.profile-page__email`, `.profile-loading`.
+  No existing rule is altered.
+- **`frontend/README.md`.** Updates the `bun run test:e2e` row in the
+  scripts table to mention both Playwright specs, updates the Testing
+  section blurb, and adds `ProfilePage.tsx` and `profile.spec.ts`
+  rows to the project-layout tree.
+- **`docs/tracking/features.md` and `docs/specs/README.md`.** The
+  `feat_frontend_003` row advances from `Ready` / `In Spec` to
+  `In Build`.
+
+## Unchanged
+
+- **Zero backend changes.** No file under `backend/` is modified, no
+  new endpoints, no schema changes. The page reads from the existing
+  `/auth/me` payload that `AuthContext` already holds.
+- **Zero infrastructure or REST-suite changes.** `infra/` and `tests/`
+  are untouched. `./test.sh` behavior is unchanged.
+- **Zero new dependencies.** `frontend/package.json` is unmodified.
+  All work uses `react-router-dom@^7` and `@playwright/test@^1`,
+  both already pulled in by `feat_frontend_002`.
+- **Existing `/login` and `/` flows.** No assertion in `login.spec.ts`
+  needed to change. The dashboard greeting still uses `display_name`
+  with a fallback to email; the profile page deliberately uses the
+  email regardless of `display_name`, per the user's "just email"
+  requirement.
+
+## Security
+
+- No new API surface. Zero new `fetch` calls; zero new request bodies;
+  zero new response shapes. The threat model from `feat_frontend_002`
+  carries forward unchanged.
+- Email rendering is safe (React-escaped text child; no
+  `dangerouslySetInnerHTML`).
+- Profile-button `onClick` hard-codes the path `/profile`; no
+  user-supplied data flows into the navigation target.
+- The Playwright spec re-asserts the relative-URL invariant across
+  the entire run (login through logout), guarding against any
+  accidental absolute-URL regression elsewhere in the codebase.

--- a/docs/specs/feat_frontend_003/impl_frontend_003.md
+++ b/docs/specs/feat_frontend_003/impl_frontend_003.md
@@ -1,0 +1,132 @@
+# Implementation Notes: feat_frontend_003 — profile page
+
+This document captures the actual implementation as it landed on
+`build/feat_frontend_003`, deviations (none material) from the design
+spec, and the test results Vulcan was able to run on the dev machine.
+
+## What landed
+
+| File | Change |
+|---|---|
+| `frontend/src/pages/ProfilePage.tsx` | **New.** Default-export page component. Reads `useAuth()`. Renders `<h1>Profile</h1>` plus a `<p>` with the email value when `status === 'authenticated'`. Renders a `Loading…` placeholder when `status === 'loading'`. Returns `null` defensively if `user === null`. Zero `fetch` calls, zero `useEffect` calls. |
+| `frontend/src/components/Header.tsx` | **Modified.** Imports `useNavigate` from `react-router-dom`. Adds a plain-text `<button type="button" className="auth-header__profile" data-testid="auth-header-profile">Profile</button>` as the **first** JSX child of `<header data-testid="auth-header">`, before the existing email span. The existing email, role chips, and Logout elements are unchanged in markup; they are now positions 2–4 instead of 1–3. The `user === null` early-return guard is preserved. |
+| `frontend/src/App.tsx` | **Modified.** Adds `import ProfilePage from './pages/ProfilePage';`. Adds a `<Route path="/profile">` element wrapped in `<RequireAuth><AuthedLayout>…</AuthedLayout></RequireAuth>`, placed between `/` and the `*` catch-all. Header JSDoc + route-table comment updated. |
+| `frontend/src/App.css` | **Modified.** Appends `.auth-header__profile`, `.auth-header__profile:focus-visible`, `.profile-page`, `.profile-page__title`, `.profile-page__email`, `.profile-loading`. The new selectors mirror `.auth-header__logout` for visual consistency. No existing rule is altered. |
+| `frontend/tests/e2e/profile.spec.ts` | **New.** Single round-trip Playwright test. Inlines the OTP login dance (~25 lines, copy-shaped after `login.spec.ts`). Asserts: header order is `Profile, email, roles, Logout`; Profile click navigates to `/profile` without re-firing `/api/v1/auth/me`; profile page heading + email visible; no `Email:` label inside `[data-testid="profile-page"]`; same-URL re-click is a no-op (no loading flash, no extra `/auth/me`); back/forward navigation between `/` and `/profile` keeps the dashboard rendering and the Profile button leftmost; logout from `/profile` lands on `/login`; `/profile` after logout redirects to `/login`; relative-URL invariant on every observed `/api/v1/*` request; OTP code never appears in the browser console. Uses `getOtpFixture()` and the same `test.skip` pattern as `login.spec.ts`. |
+| `frontend/README.md` | **Modified.** Updates the `bun run test:e2e` row in the scripts table to mention both specs. Updates the Testing section blurb to call out `feat_frontend_003`. Adds `ProfilePage.tsx` and `profile.spec.ts` rows to the project-layout tree. |
+| `docs/specs/README.md` | **Modified.** Flips the `feat_frontend_003` row from `In Spec` to `In Build`. |
+| `docs/tracking/features.md` | **Modified.** Flips the `feat_frontend_003` row from `Ready` to `In Build`. The `Impl PRs` cell is backfilled with the build PR number on a separate commit after `gh pr create`. |
+
+Zero files under `backend/`, `infra/`, or `tests/` (the REST suite) are
+touched. Zero new runtime or dev dependencies are added.
+
+## Decisions
+
+- **Profile element shape: `<button>` (option 1 from the design spec).**
+  The design spec offered `<button>` vs `<Link>` and recommended `<button>`
+  for symmetry with the existing Logout element. Vulcan went with that
+  recommendation. A future feature that adds nav-active styling can
+  switch both to `<Link>` / `<NavLink>` in one go.
+- **Login helper: inlined, not extracted.** The spec offered to extract
+  the login dance into `frontend/tests/e2e/helpers.ts` if the inline
+  copy would exceed ~20 lines. The inlined version is ~25 lines but the
+  marginal cost of a shared helper file (one more module, one more
+  import) outweighed the saving. If a third spec lands that drives
+  login, that is the right time to refactor.
+- **Back-button regression check folded into the round-trip test.**
+  Test spec Happy Path #13 (back-button keeps dashboard intact, Profile
+  button still leftmost) is asserted in the same `test()` rather than
+  spawned as a separate test, to avoid paying the login cost twice.
+- **`Email:` label assertion uses `textContent` substring check.** The
+  test scopes the check to `[data-testid="profile-page"]` so the
+  header's email span (which is part of `[data-testid="auth-header"]`,
+  a sibling, not a descendant of the profile-page container) does not
+  pollute the assertion. This is the cleanest expression of "the body
+  shows the email value with no label."
+- **Loading state is unreachable in normal flow.** `<RequireAuth>`
+  catches `status === 'loading'` upstream, so `ProfilePage`'s loading
+  branch is reached only if a future `refresh()` call re-enters the
+  loading state while `<RequireAuth>` is mounted with cached state.
+  The branch is preserved per the user's "show a Loading… placeholder"
+  request and the spec's Acceptance Criterion bullet for
+  `status === 'loading'`.
+
+## Deviations
+
+None. The implementation is a 1:1 match against `design_frontend_003.md`
+including class names, `data-testid` attributes, route ordering, and
+the `<button>` choice for the Profile element.
+
+## Test results
+
+| Check | Result |
+|---|---|
+| `bun run build` (TypeScript + Vite production build) | **Pass.** Zero TS errors. `dist/index.html` + `dist/assets/index-*.{js,css}` produced; bundle gzip-size is ~77 kB (unchanged shape — no new dep). |
+| `git diff main...HEAD --stat -- backend/ infra/ tests/` | **Empty.** Zero files outside `frontend/` and `docs/` modified. |
+| `git grep "credentials: 'include'" frontend/src/` | Only one hit, inside a JSDoc comment that pre-dates this feature. No new code uses the option. |
+| `git grep "http://localhost" frontend/src/` | Only one hit, inside `vite-env.d.ts`'s JSDoc example. No new code uses an absolute URL. |
+| `frontend/package.json` diff | **Empty.** No new dependency added. |
+| `./test.sh` | **Blocked on this dev machine** — Docker daemon is not running. The script's first step (`make up` → `docker compose up`) fails with `dial unix /Users/swbs/.docker/run/docker.sock: connect: no such file or directory`. Since this feature touches zero files under `backend/`, `infra/`, or `tests/`, the REST suite cannot regress from this diff; the failure is environmental. The CI/operator running `./test.sh` against the compose stack can confirm the green-state baseline. |
+| `bun run test:e2e` | **Blocked on this dev machine** — same Docker root cause; Playwright drives `http://localhost:5173` against the compose stack, which can't be brought up without Docker. The spec calls `test.skip` cleanly when `TEST_OTP_EMAIL`/`TEST_OTP_CODE` are unset, so an operator with the fixture pair and `make up` running can verify the green path. |
+
+The two blocked checks are environment-only blocks, not code regressions
+introduced by this feature. Both are behaviors the existing project
+test posture (set up by `feat_frontend_002`) already documented as
+operator-side prerequisites.
+
+## How to verify on a Docker-equipped machine
+
+```bash
+# from repo root
+git checkout build/feat_frontend_003
+cd infra && cp .env.example .env && cd ..
+
+# start the stack
+make up
+
+# REST suite (must stay green; this feature touches no backend code)
+./test.sh
+
+# Playwright e2e (must stay green; this feature adds profile.spec.ts)
+export TEST_OTP_EMAIL=e2e@example.com
+export TEST_OTP_CODE=424242
+cd frontend
+bun install
+bunx playwright install chromium
+bun run test:e2e
+```
+
+Both `login.spec.ts` and `profile.spec.ts` should report green; the
+combined suite is two `test()` cases inside `login.spec.ts` plus one
+inside `profile.spec.ts`, for three passing tests total.
+
+## Acceptance criteria status
+
+All twelve acceptance-criteria checkboxes from `feat_frontend_003.md`
+are satisfied by the diff:
+
+- [x] Visiting `/profile` while signed in renders the heading + email.
+- [x] Visiting `/profile` while signed out redirects to `/login` (via
+      `<RequireAuth>`).
+- [x] `<Header>` renders Profile as the leftmost element on `/` and
+      `/profile` (DOM order Profile, email, roles, Logout).
+- [x] Clicking Profile on `/` navigates to `/profile` without a full
+      reload (no `/auth/me` re-fire).
+- [x] Clicking Profile on `/profile` keeps the URL at `/profile` with
+      no crash, no error.
+- [x] Logout from `/profile` calls `POST /api/v1/auth/logout`, clears
+      auth state, navigates to `/login`.
+- [x] Profile body shows the email **value** with no `Email:` label.
+- [x] No new API endpoints; no file under `backend/` modified.
+- [x] Every new fetch (zero of them) uses a relative URL and does not
+      set `credentials: 'include'`.
+- [x] `bun run build` passes with zero TS errors.
+- [x] `frontend/tests/e2e/profile.spec.ts` exists and asserts every
+      bullet point in the acceptance criterion (header order, click
+      navigates, email visible, second click no-op, logout redirect).
+- [x] The Playwright spec calls `test.skip` when the fixture env is
+      unset.
+- [x] `./test.sh` behavior is unchanged (provable by zero diff under
+      `backend/`, `infra/`, `tests/`).
+- [x] `docs/specs/README.md` and `docs/tracking/features.md` rows are
+      updated.

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -11,4 +11,4 @@
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
 | feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | Merged | #25 | #26 | #27 | - |
-| feat_frontend_003 | profile page: /profile route, header Profile button, email-only view | Ready | #28 | #29 | - | - |
+| feat_frontend_003 | profile page: /profile route, header Profile button, email-only view | In Build | #28 | #29 | - | - |

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -11,4 +11,4 @@
 | feat_auth_001 | auth foundation: users, roles, identities, sessions | Merged | #20 | #19 | #21 | - |
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
 | feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | Merged | #25 | #26 | #27 | - |
-| feat_frontend_003 | profile page: /profile route, header Profile button, email-only view | In Build | #28 | #29 | - | - |
+| feat_frontend_003 | profile page: /profile route, header Profile button, email-only view | In Build | #28 | #29 | #30 | - |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,7 +42,7 @@ render a blank screen.
 | `bun run dev` | Start the Vite dev server (default port 5173) with HMR and the `/api` proxy. |
 | `bun run build` | Type-check (`tsc -b`) and produce a production bundle in `dist/`. |
 | `bun run preview` | Serve the built `dist/` locally for sanity checks. |
-| `bun run test:e2e` | Run the Playwright login e2e suite against the compose stack (requires `make up` first; see [Testing](#testing)). |
+| `bun run test:e2e` | Run the Playwright e2e suite (`login.spec.ts` + `profile.spec.ts`) against the compose stack (requires `make up` first; see [Testing](#testing)). |
 
 A thin `start.sh` wrapper mirrors `backend/start.sh` and dispatches to the same
 commands, so local and (later) containerized entrypoints stay aligned:
@@ -111,20 +111,24 @@ frontend/
     pages/
       LoginPage.tsx          # /login — two-step OTP form
       Dashboard.tsx          # / — greeting + roles + HelloPanel
+      ProfilePage.tsx        # /profile — email-only page (feat_frontend_003)
   tests/
     e2e/
       fixtures.ts            # getOtpFixture() — reads TEST_OTP_EMAIL/CODE
       login.spec.ts          # End-to-end login flow + relative-URL invariant
+      profile.spec.ts        # /profile route + header Profile button (feat_frontend_003)
 ```
 
 ## Testing
 
 ### End-to-end (Playwright)
 
-`feat_frontend_002` ships a Playwright login e2e suite that drives a real
-browser against the compose stack. It is **not** part of `./test.sh` — it runs
-via a separate `bun run test:e2e` invocation, mirroring how the external REST
-suite under `tests/` is invoked.
+`feat_frontend_002` introduced the Playwright e2e suite that drives a real
+browser against the compose stack; `feat_frontend_003` extends it with a
+profile-page spec. The suite currently runs `login.spec.ts` and
+`profile.spec.ts`. It is **not** part of `./test.sh` — it runs via a separate
+`bun run test:e2e` invocation, mirroring how the external REST suite under
+`tests/` is invoked.
 
 One-time setup per machine:
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -240,3 +240,42 @@
   max-width: 20rem;
   text-align: center;
 }
+
+/* ---- feat_frontend_003: profile button + page ------------------------- */
+
+.auth-header__profile {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.9rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  background-color: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.auth-header__profile:focus-visible {
+  outline: 2px solid rgba(100, 160, 255, 0.6);
+  outline-offset: 1px;
+}
+
+.profile-page {
+  max-width: 42rem;
+}
+
+.profile-page__title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+}
+
+.profile-page__email {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin: 0;
+}
+
+.profile-loading {
+  margin: 4rem auto;
+  max-width: 20rem;
+  text-align: center;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,14 @@
  *
  * `feat_frontend_001` shipped a single-page hello view here. With
  * `feat_frontend_002` the hello view moves into `HelloPanel` and is
- * rendered from the authed `Dashboard`. This file now only wires the
- * routes.
+ * rendered from the authed `Dashboard`. `feat_frontend_003` adds a
+ * second authed route (`/profile`) that follows the same gate +
+ * layout pattern.
  *
  * Route table:
  *   /login       — public, the two-step OTP form (LoginPage)
  *   /            — authed, dashboard wrapped in <AuthedLayout>
+ *   /profile     — authed, profile page wrapped in <AuthedLayout>
  *   *            — redirect to `/` so typos flow through the auth gate
  *
  * `<BrowserRouter>` and `<AuthProvider>` are applied at `main.tsx` one
@@ -22,6 +24,7 @@ import { RequireAuth } from './auth/RequireAuth';
 import { AuthedLayout } from './components/AuthedLayout';
 import Dashboard from './pages/Dashboard';
 import LoginPage from './pages/LoginPage';
+import ProfilePage from './pages/ProfilePage';
 
 export default function App() {
   return (
@@ -33,6 +36,16 @@ export default function App() {
           <RequireAuth>
             <AuthedLayout>
               <Dashboard />
+            </AuthedLayout>
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/profile"
+        element={
+          <RequireAuth>
+            <AuthedLayout>
+              <ProfilePage />
             </AuthedLayout>
           </RequireAuth>
         }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,18 +1,23 @@
 /**
  * Persistent header strip rendered on authed routes.
  *
- * Shows the signed-in email, role chips, and a logout button. The button
- * calls the context's `logout()` which clears local state and navigates
- * to `/login`. While the logout request is in flight the button is
+ * Shows a Profile button (leftmost), the signed-in email, role chips,
+ * and a logout button (rightmost). The Profile button calls
+ * `useNavigate()` to push `/profile`; clicking it on `/profile` is a
+ * harmless re-navigation to the same URL. The Logout button calls the
+ * context's `logout()` which clears local state and navigates to
+ * `/login`. While the logout request is in flight the button is
  * disabled so a double-click cannot fire two POSTs.
  */
 
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../auth/AuthContext';
 
 export function Header() {
   const { user, logout } = useAuth();
   const [loggingOut, setLoggingOut] = useState(false);
+  const navigate = useNavigate();
 
   if (user === null) {
     // Shouldn't happen — <RequireAuth> guards the routes that render
@@ -35,6 +40,14 @@ export function Header() {
 
   return (
     <header className="auth-header" data-testid="auth-header">
+      <button
+        type="button"
+        className="auth-header__profile"
+        onClick={() => navigate('/profile')}
+        data-testid="auth-header-profile"
+      >
+        Profile
+      </button>
       <span className="auth-header__email" data-testid="auth-header-email">
         {user.email}
       </span>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,49 @@
+/**
+ * `/profile` — the authed profile page.
+ *
+ * Renders a page heading and the signed-in user's email value. Per the
+ * `feat_frontend_003` spec the body shows the email **only** (no
+ * `Email:` label, no other PII fields). The page issues zero `fetch`
+ * calls; it reads the email straight off `AuthContext.user`, which the
+ * `AuthProvider` populated during its mount-time bootstrap.
+ *
+ * `<RequireAuth>` (in `App.tsx`) handles the loading + anonymous cases
+ * before this component ever mounts under normal flow. The
+ * `status === 'loading'` branch below is a defensive belt-and-braces
+ * for a future `refresh()`-triggered re-bootstrap; the `user === null`
+ * branch should never fire under `<RequireAuth>` and renders nothing
+ * rather than crashing if it somehow does.
+ */
+
+import { useAuth } from '../auth/AuthContext';
+
+export default function ProfilePage() {
+  const { user, status } = useAuth();
+
+  if (status === 'loading') {
+    return (
+      <div
+        className="state state--loading profile-loading"
+        role="status"
+        aria-live="polite"
+        data-testid="profile-loading"
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (user === null) {
+    // Defensive — <RequireAuth> guarantees this never fires in practice.
+    return null;
+  }
+
+  return (
+    <div className="profile-page" data-testid="profile-page">
+      <h1 className="profile-page__title">Profile</h1>
+      <p className="profile-page__email" data-testid="profile-page-email">
+        {user.email}
+      </p>
+    </div>
+  );
+}

--- a/frontend/tests/e2e/profile.spec.ts
+++ b/frontend/tests/e2e/profile.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Profile e2e test for feat_frontend_003.
+ *
+ * Drives the profile flow in a real Chromium against the compose stack
+ * the operator has brought up with `make up`. Same `TEST_OTP_EMAIL` /
+ * `TEST_OTP_CODE` fixture pattern as `login.spec.ts`; when either env
+ * var is unset the spec calls `test.skip` and exits cleanly.
+ *
+ * The spec covers (per `test_frontend_003.md`):
+ *   - Happy path #1: Header has a Profile button at the leftmost slot.
+ *   - Happy path #2: Profile button label is exactly `Profile`.
+ *   - Happy path #3: Click Profile navigates to /profile (no
+ *     /api/v1/auth/me re-fire on click).
+ *   - Happy path #4: Profile page renders the `Profile` heading.
+ *   - Happy path #5: Profile page renders the email value.
+ *   - Happy path #6: Profile page does NOT render an `Email:` label
+ *     anywhere inside [data-testid="profile-page"].
+ *   - Happy path #7: Header still rendered on /profile.
+ *   - Happy path #8: Header DOM order is Profile, email, roles, Logout.
+ *   - Happy path #9: Click Profile while on /profile is a no-op.
+ *   - Happy path #10: Logout from /profile ends the session.
+ *   - Happy path #11: After logout, /profile redirects to /login.
+ *   - Happy path #12: Relative-URL invariant — every /api/v1/* request
+ *     observed during the run targets the page origin.
+ *   - Happy path #13: After back-button from /profile to /, the
+ *     dashboard renders normally and the Profile button is still
+ *     present and leftmost (regression check on feat_frontend_002).
+ *   - Boundary #2: 429 on OTP request triggers a clean test.skip.
+ *   - Error case #1: direct visit to /profile while signed out
+ *     redirects to /login (asserted after the logout step).
+ */
+
+import { test, expect, type Request } from '@playwright/test';
+import { getOtpFixture } from './fixtures';
+
+const fixture = getOtpFixture();
+
+test.describe('profile flow', () => {
+  test.skip(fixture === null, 'TEST_OTP_EMAIL / TEST_OTP_CODE not set');
+
+  test('navigate to /profile, see email, logout', async ({ page, baseURL }) => {
+    if (fixture === null) return; // unreachable under test.skip; narrows TS
+
+    // --- network listeners up front -------------------------------------
+    const apiOrigins: string[] = [];
+    const authMeRequests: string[] = [];
+    const consoleLines: string[] = [];
+    const pageOrigin = new URL(baseURL ?? 'http://localhost:5173').origin;
+
+    page.on('request', (req: Request) => {
+      const url = req.url();
+      if (url.includes('/api/v1/')) {
+        apiOrigins.push(new URL(url).origin);
+      }
+      if (url.includes('/api/v1/auth/me')) {
+        authMeRequests.push(url);
+      }
+    });
+
+    page.on('console', (msg) => {
+      consoleLines.push(msg.text());
+    });
+
+    // --- Sign in via OTP fixture (mirrors login.spec.ts steps 1–5) -----
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByTestId('login-email-input')).toBeVisible();
+
+    await page.getByTestId('login-email-input').fill(fixture.email);
+
+    const otpRequestPromise = page.waitForResponse((res) =>
+      res.url().endsWith('/api/v1/auth/otp/request'),
+    );
+    await page.getByTestId('login-request-submit').click();
+    const otpRequestResponse = await otpRequestPromise;
+
+    // Boundary #2: rate-limited OTP request -> clean skip.
+    test.skip(
+      otpRequestResponse.status() === 429,
+      'OTP rate limit hit; retry later',
+    );
+    expect(otpRequestResponse.status()).toBe(204);
+
+    await expect(page.getByTestId('login-code-input')).toBeVisible();
+
+    await page.getByTestId('login-code-input').fill(fixture.code);
+    const verifyPromise = page.waitForResponse((res) =>
+      res.url().endsWith('/api/v1/auth/otp/verify'),
+    );
+    await page.getByTestId('login-verify-submit').click();
+    const verify = await verifyPromise;
+    expect(verify.status()).toBe(200);
+
+    await page.waitForURL(/\/$/);
+
+    // Sanity: header strip and email visible on /
+    await expect(page.getByTestId('auth-header')).toBeVisible();
+    await expect(page.getByTestId('auth-header-email')).toHaveText(fixture.email);
+
+    // --- Happy path #1 + #2: Profile button at leftmost slot -----------
+    const profileBtn = page.getByTestId('auth-header-profile');
+    await expect(profileBtn).toBeVisible();
+    await expect(profileBtn).toBeEnabled();
+    await expect(profileBtn).toHaveText('Profile');
+
+    // Assert Profile is the FIRST child of the header strip.
+    const firstChildTestId = await page
+      .getByTestId('auth-header')
+      .locator('> *')
+      .first()
+      .getAttribute('data-testid');
+    expect(firstChildTestId).toBe('auth-header-profile');
+
+    // --- Happy path #8: header DOM order is Profile, email, roles, Logout
+    const headerChildTestIds = await page
+      .getByTestId('auth-header')
+      .locator('> *')
+      .evaluateAll((els) =>
+        els.map((el) => (el as HTMLElement).getAttribute('data-testid')),
+      );
+    expect(headerChildTestIds).toEqual([
+      'auth-header-profile',
+      'auth-header-email',
+      'auth-header-roles',
+      'auth-header-logout',
+    ]);
+
+    // --- Happy path #3: Click Profile navigates to /profile ------------
+    // No /api/v1/auth/me re-fire on a client-side route push: the
+    // <AuthProvider> stays mounted across the navigation.
+    const meCallsBeforeClick = authMeRequests.length;
+    await profileBtn.click();
+    await page.waitForURL(/\/profile$/);
+    // Give any would-be fetch a tick to settle, then assert /auth/me
+    // didn't fire because of the click.
+    await page.waitForTimeout(150);
+    expect(authMeRequests.length).toBe(meCallsBeforeClick);
+
+    // --- Happy path #4: Profile page heading is visible ----------------
+    await expect(
+      page.getByTestId('profile-page').locator('h1', { hasText: 'Profile' }),
+    ).toBeVisible();
+
+    // --- Happy path #5: Profile page renders the email value -----------
+    await expect(page.getByTestId('profile-page-email')).toHaveText(fixture.email);
+
+    // --- Happy path #6: No `Email:` label inside the profile page ------
+    // The header still shows the email separately; assertion is scoped
+    // to the profile page container.
+    const profileBodyText = await page.getByTestId('profile-page').textContent();
+    expect(profileBodyText ?? '').not.toContain('Email:');
+
+    // --- Happy path #7: Header still rendered on /profile --------------
+    await expect(page.getByTestId('auth-header')).toBeVisible();
+    await expect(page.getByTestId('auth-header-profile')).toBeVisible();
+    await expect(page.getByTestId('auth-header-email')).toBeVisible();
+    await expect(page.getByTestId('auth-header-roles')).toBeVisible();
+    await expect(page.getByTestId('auth-header-logout')).toBeVisible();
+
+    // --- Happy path #9: Click Profile on /profile is a no-op -----------
+    const meCallsBeforeReClick = authMeRequests.length;
+    await page.getByTestId('auth-header-profile').click();
+    await page.waitForTimeout(150);
+    await expect(page).toHaveURL(/\/profile$/);
+    // Profile page still showing the email; no flicker into a loading state.
+    await expect(page.getByTestId('profile-page-email')).toHaveText(fixture.email);
+    await expect(page.getByTestId('profile-loading')).toHaveCount(0);
+    // No /auth/me re-fire on the same-URL push.
+    expect(authMeRequests.length).toBe(meCallsBeforeReClick);
+
+    // --- Happy path #13: back-button to / restores the dashboard ------
+    await page.goBack();
+    await page.waitForURL(/\/$/);
+    await expect(page.getByTestId('dashboard')).toBeVisible();
+    // Profile button still leftmost on /.
+    const dashboardFirstChildTestId = await page
+      .getByTestId('auth-header')
+      .locator('> *')
+      .first()
+      .getAttribute('data-testid');
+    expect(dashboardFirstChildTestId).toBe('auth-header-profile');
+    // Forward back to /profile so we exercise logout from there.
+    await page.goForward();
+    await page.waitForURL(/\/profile$/);
+    await expect(page.getByTestId('profile-page-email')).toHaveText(fixture.email);
+
+    // --- Happy path #10: Logout from /profile -------------------------
+    const logoutPromise = page.waitForResponse((res) =>
+      res.url().endsWith('/api/v1/auth/logout'),
+    );
+    await page.getByTestId('auth-header-logout').click();
+    const logoutResponse = await logoutPromise;
+    expect([200, 204]).toContain(logoutResponse.status());
+    await page.waitForURL(/\/login$/);
+    await expect(page.getByTestId('login-email-input')).toBeVisible();
+
+    // --- Happy path #11 / Error case #1: /profile redirects after logout
+    await page.goto('/profile');
+    await expect(page).toHaveURL(/\/login$/);
+
+    // --- Happy path #12: Relative-URL invariant ----------------------
+    expect(apiOrigins.length).toBeGreaterThan(0);
+    for (const origin of apiOrigins) {
+      expect(origin).toBe(pageOrigin);
+    }
+
+    // --- Security: OTP code is not logged by the frontend ------------
+    const leakedCode = consoleLines.filter((line) => line.includes(fixture.code));
+    expect(leakedCode).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the smallest possible profile page on top of the auth shell shipped by `feat_frontend_002`:

- Plain-text **Profile** button at the leftmost slot of `<Header>`, rendered on every authed route (`/` and `/profile`).
- New authed route `/profile` gated by `<RequireAuth>` and wrapped in `<AuthedLayout>`.
- New `ProfilePage` component renders `<h1>Profile</h1>` plus the email value (no `Email:` label, no other PII).
- Zero backend changes; the page reads `email` straight off `AuthContext.user`.
- New Playwright spec `profile.spec.ts` covers the round trip (login -> click Profile -> assert URL + email -> back/forward -> click Profile again on /profile (no-op) -> Logout -> redirect; plus the relative-URL invariant).

Closes #29

## Spec references

- Feature:     `docs/specs/feat_frontend_003/feat_frontend_003.md`
- Design:      `docs/specs/feat_frontend_003/design_frontend_003.md`
- Test:        `docs/specs/feat_frontend_003/test_frontend_003.md`
- Impl notes:  `docs/specs/feat_frontend_003/impl_frontend_003.md`
- Changelog:   `docs/specs/feat_frontend_003/changelog_frontend_003.md`

## Changes

- **New files:** `frontend/src/pages/ProfilePage.tsx`, `frontend/tests/e2e/profile.spec.ts`, `docs/specs/feat_frontend_003/{impl,changelog}_frontend_003.md`.
- **Modified:** `frontend/src/components/Header.tsx` (prepend Profile `<button>` + `useNavigate` import), `frontend/src/App.tsx` (new `/profile` route + `ProfilePage` import), `frontend/src/App.css` (six new selectors mirroring `.auth-header__logout`), `frontend/README.md` (test-script row + Testing blurb + project-layout tree updated for the new spec).
- **Tracker:** `docs/tracking/features.md` and `docs/specs/README.md` advance the row from `Ready` / `In Spec` to `In Build`. The `Impl PRs` cell will be backfilled with this PR number after creation.

## Hard-invariant checks (from the spec)

- [x] Zero files under `backend/`, `infra/`, or `tests/` modified (`git diff main...HEAD --stat -- backend/ infra/ tests/` is empty).
- [x] Zero new dependencies in `frontend/package.json`.
- [x] No new `fetch` call. The Profile page is read-only against `AuthContext.user`.
- [x] No `credentials: 'include'` and no absolute `http://...` URL in any new code (`git grep` confirms only pre-existing JSDoc-comment hits).
- [x] Profile is the **first** JSX child of `<header data-testid="auth-header">`. Asserted in `profile.spec.ts` via `[data-testid="auth-header"] > *:first-child`.
- [x] Header DOM order is `auth-header-profile, auth-header-email, auth-header-roles, auth-header-logout`. Asserted in `profile.spec.ts`.
- [x] Profile button is a plain `<button>` (not `<Link>`) for symmetry with the existing Logout `<button>`. No icon, no avatar, no styling beyond `.auth-header__profile`.
- [x] Profile page body shows the email **value** with no `Email:` label. Asserted in `profile.spec.ts` via a substring check scoped to `[data-testid="profile-page"]`.

## Test results

- `bun run build` (TypeScript + Vite production build) — **pass**, zero TS errors. Bundle gzip-size unchanged (~77 kB; no new dep).
- `./test.sh` — **blocked on this dev workstation** (Docker daemon not running; the script's first step is `make up` -> `docker compose up`). The diff touches zero files under `backend/`, `infra/`, or `tests/`, so the REST suite cannot regress from this feature; the failure is environmental. CI / a Docker-equipped reviewer should confirm the green-state baseline.
- `bun run test:e2e` — same root cause; Playwright drives `http://localhost:5173` against the compose stack. The spec calls `test.skip` cleanly when the OTP fixture env is unset; an operator with `make up` running and `TEST_OTP_EMAIL` / `TEST_OTP_CODE` set can run the full round-trip locally (see `impl_frontend_003.md` for the exact commands).

Both blocked checks are environmental, not code regressions. Every other verification-checklist item in `test_frontend_003.md` is green by static inspection.

## Self-review notes

- **`<button>` over `<Link>` for Profile.** Picked option 1 from the design spec — matches the existing Logout `<button>` so the two header buttons read as a matched pair (same focus / keyboard semantics). A future feature that lands a third route and adds nav-active styling can switch both to `<NavLink>` in one go.
- **Login dance inlined in `profile.spec.ts`, not extracted.** The spec offered to extract a shared `helpers.ts` module if the inline copy would exceed ~20 lines. The inline copy lands at ~25 lines; an extra module + import felt heavier than the saving for two specs. If a third spec lands that drives login, that is the right time to refactor.
- **Back-button regression check folded into the round-trip test.** Test spec Happy Path #13 asserts that navigating `/profile -> back -> /` keeps the dashboard intact and the Profile button leftmost. Done in the same `test()` to avoid paying the login cost twice.
- **`Email:` label assertion.** The check uses a `textContent` substring scoped to `[data-testid="profile-page"]`. The header still shows the email in its own span (sibling of the page body, not descendant), so the header's email never pollutes the assertion.
- **Loading-state branch is unreachable in normal flow.** `<RequireAuth>` upstream catches `status === 'loading'`. The `ProfilePage` `Loading…` placeholder is preserved per the user's explicit ask and the spec's Acceptance Criterion bullet — defensive in case a future `refresh()` call re-enters the loading state while `<RequireAuth>` is mounted with cached state.

## How to try it locally

```bash
git checkout build/feat_frontend_003
cd infra && cp .env.example .env && cd ..

# stack
make up

# REST suite (must stay green)
./test.sh

# Playwright e2e (login.spec.ts + profile.spec.ts)
export TEST_OTP_EMAIL=e2e@example.com
export TEST_OTP_CODE=424242
cd frontend
bun install
bunx playwright install chromium
bun run test:e2e
```

Both specs should run green. Without the fixture env both skip cleanly with exit 0.