### PR TITLE
spec(feat_frontend_004): dark mode toggle, two-state light/dark, persisted

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -46,5 +46,6 @@ The full ruleset for feature IDs, branch names, commit prefixes, PR titles, labe
 | `feat_auth_002`         | Merged     | Email OTP login: `EmailSender` abstraction, `/auth/otp/request` + `/auth/otp/verify`, Resend provider, deployment docs. |
 | `feat_frontend_002`     | Merged     | Login UI: `AuthContext`, `/login` OTP page with disabled Google-coming-soon button, authed dashboard + header strip, Playwright e2e suite. |
 | `feat_frontend_003`     | Merged     | Profile page: `/profile` authed route, plain-text Profile button at the leftmost slot of `<Header>`, email-only page body, Playwright e2e. |
+| `feat_frontend_004`     | In Spec    | Dark mode: fixed bottom-left toggle, two-state light/dark, `localStorage`-persisted theme behind a `themeStorage` module, `data-theme` on `<html>`, CSS-variable palette, Playwright e2e. |
 
 Future features append rows to this table as they are planned.

--- a/docs/specs/feat_frontend_004/design_frontend_004.md
+++ b/docs/specs/feat_frontend_004/design_frontend_004.md
@@ -1,0 +1,658 @@
+# Design: Dark mode — fixed bottom-left toggle, two-state light/dark, persisted
+
+## Approach
+
+The feature has four moving parts:
+
+1. **A versioned `localStorage` wrapper** (`themeStorage.ts`). One
+   place to read and write the theme. Falls back to in-memory state
+   when storage is unavailable (private windows, quota errors, SSR
+   sneaks). Treats unrecognized stored values (e.g.
+   `'system'` left over from a hypothetical future change) as
+   "unset" rather than crashing.
+2. **A `ThemeContext` provider** (`ThemeContext.tsx`). Owns the
+   in-memory theme state, exposes `{ theme, toggleTheme, setTheme }`
+   via `useTheme()`. On state change, writes to `themeStorage` and
+   sets the `data-theme` attribute on `document.documentElement`.
+   Mounted **above** `<AuthProvider>` in `main.tsx` so the
+   `LoginPage` (which is not wrapped by `AuthedLayout`) can still
+   read it.
+3. **A `ThemeToggle` component** (`ThemeToggle.tsx`). A single
+   `<button>` rendered as a fixed-position overlay in the bottom-left
+   corner. Reads `useTheme()`, renders the action label
+   (`Dark mode` / `Light mode`), and calls `toggleTheme()` on click.
+   Rendered **once** at the React root (alongside `<App />` inside
+   `<ThemeProvider>`) so it never unmounts across route changes.
+4. **An inline boot script in `index.html`** that reads the persisted
+   theme (or seeds it from `prefers-color-scheme`) and applies the
+   `data-theme` attribute **before** the React bundle even loads. This
+   eliminates the wrong-theme flash. The script is intentionally tiny
+   (~15 lines) and does not need to handle every edge case the React
+   layer handles — its only job is to set the attribute fast. The
+   `<ThemeProvider>` re-reads `localStorage` on mount and converges
+   to the same value, so any divergence between the boot script and
+   the React layer is naturally healed on the first effect.
+
+The CSS strategy is **CSS variables** declared at `:root` (the default,
+which is the light theme) and overridden in a `[data-theme="dark"]`
+block. Component CSS in `App.css` then references `var(--bg)`,
+`var(--fg)`, `var(--border)`, etc. instead of literal colors. The few
+existing rules that already use opacity-tinted neutrals
+(`rgba(127, 127, 127, 0.3)`) are left as-is because they read
+acceptably on both backgrounds and migrating them adds noise without
+benefit. Each kept-literal rule gets a one-line comment justifying
+the choice.
+
+## Files to Modify
+
+| File | Change Description |
+|---|---|
+| `frontend/index.html` | Insert a small inline `<script>` in `<head>` (before the existing `<title>` is fine; before `<body>` is required) that reads `localStorage.getItem('minimalist-app:theme:v1')`, falls back to `matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'`, writes the seeded value back to `localStorage` if it was missing, and sets `document.documentElement.setAttribute('data-theme', value)`. The script must be wrapped in a `try { ... } catch { /* in-memory only */ }` so it never throws and breaks page load. |
+| `frontend/src/main.tsx` | Add `import { ThemeProvider } from './theme/ThemeContext';` and `import { ThemeToggle } from './theme/ThemeToggle';`. Wrap the React tree as `<StrictMode><ThemeProvider><BrowserRouter><AuthProvider><App /></AuthProvider></BrowserRouter><ThemeToggle /></ThemeProvider></StrictMode>`. The `<ThemeToggle>` is rendered as a sibling of `<BrowserRouter>` so it is always mounted (it does not need router context — it just calls `useTheme()`). It is positioned via CSS, not via DOM placement. |
+| `frontend/src/index.css` | Replace the current `:root` block with a CSS-variable-based palette: `--bg`, `--fg`, `--fg-muted`, `--border`, `--accent`, `--surface`, `--danger-bg`, `--danger-fg`, `--success-bg`, `--success-fg`. Define light values on `:root` (this is the default, matching the explicit `data-theme="light"` we always set). Override with `[data-theme="dark"] { ... }`. Keep `color-scheme: light dark;` so native form controls (scrollbars, default `<input>` chrome) pick a reasonable variant. **Remove** the existing `@media (prefers-color-scheme: light)` block — the seed script has supplanted it. The `body { ... }` and `#root { ... }` rules are unchanged. |
+| `frontend/src/App.css` | Migrate hard-coded colors to variables where the migration is clean (e.g. `rgba(255, 255, 255, 0.02)` -> `var(--surface)`). Leave opacity-tinted neutrals (`rgba(127, 127, 127, 0.3)`) and the danger / success accents alone — they read acceptably on both themes. Do **not** restructure selectors; do **not** rename classes. The diff should be small and surgical. |
+| `frontend/README.md` | In the **Testing** section, update the bullet that lists the e2e specs to include `theme.spec.ts` alongside `login.spec.ts` and `profile.spec.ts`. Update the `bun run test:e2e` row of the Scripts table to mention all three specs. |
+| `docs/specs/README.md` | Append a feature-roster row for `feat_frontend_004`. |
+| `docs/tracking/features.md` | Append a tracker row. Backfill `Spec PR` and `Issues` columns after `gh pr create` / `gh issue create`. |
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `frontend/src/theme/themeStorage.ts` | Versioned `localStorage` wrapper. Exports `STORAGE_KEY`, `Theme`, `readTheme()`, `writeTheme(theme)`, `seedFromMedia()`. `readTheme()` returns `Theme \| null`. Unrecognized values return `null` (treated as "unset"). All functions guard `try { ... } catch { ... }` and fall through to an in-memory module-level variable when `localStorage` throws. |
+| `frontend/src/theme/ThemeContext.tsx` | `ThemeProvider` and `useTheme()` hook. Initial state is read from `themeStorage.readTheme()`; if `null`, calls `seedFromMedia()` to derive and persist. The provider's effect applies `data-theme` to `<html>` whenever the state changes (idempotent — re-applying the same value is a no-op). The hook returns `{ theme, setTheme, toggleTheme }`. Throws if used outside the provider, mirroring `useAuth()`. |
+| `frontend/src/theme/ThemeToggle.tsx` | The fixed-position button. Reads `useTheme()`. Renders `<button class="theme-toggle" ...>{label}</button>` where `label` is `Dark mode` when `theme === 'light'` and `Light mode` when `theme === 'dark'`. Has `data-testid="theme-toggle"` for the e2e spec. CSS for the fixed positioning lives in `App.css` under a new `feat_frontend_004` comment block. |
+| `frontend/tests/e2e/theme.spec.ts` | Playwright e2e spec. See **Playwright spec contract** below. |
+
+No file is deleted. No file under `backend/`, `infra/`, or `tests/`
+(REST suite) is touched.
+
+## Inline boot script — exact shape
+
+The boot script in `index.html` is the most subtle piece because it
+must be:
+
+- Synchronous (so the attribute is set before first paint).
+- Defensive (so `localStorage` errors do not break page load).
+- Idempotent with the React layer (the `ThemeProvider` will re-read
+  on mount — both must arrive at the same value).
+- Tiny (we are inlining JavaScript in `index.html`; small is good).
+
+Recommended shape:
+
+```html
+<script>
+  (function () {
+    try {
+      var KEY = 'minimalist-app:theme:v1';
+      var stored = localStorage.getItem(KEY);
+      var theme;
+      if (stored === 'light' || stored === 'dark') {
+        theme = stored;
+      } else {
+        var prefersDark =
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        theme = prefersDark ? 'dark' : 'light';
+        try { localStorage.setItem(KEY, theme); } catch (_e) {}
+      }
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (_e) {
+      // localStorage unavailable (private mode, etc.). Fall back to OS
+      // preference for this page load only; React's ThemeProvider will
+      // converge on the same value on mount.
+      try {
+        var prefersDark2 =
+          typeof window.matchMedia === 'function' &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.setAttribute(
+          'data-theme', prefersDark2 ? 'dark' : 'light'
+        );
+      } catch (_e2) {
+        document.documentElement.setAttribute('data-theme', 'light');
+      }
+    }
+  })();
+</script>
+```
+
+The script is plain ES5 (no `let`/`const`/arrow) so it runs without
+transpilation in any browser the project targets. It is placed inside
+`<head>` after `<meta charset>` and `<meta viewport>` and before
+`<title>`. Vulcan must verify the script is **not** processed by Vite's
+HTML pipeline in a way that strips it (Vite leaves inline `<script>` in
+`index.html` alone by default — confirmed by reading
+`frontend/index.html`).
+
+## Component sketch — `themeStorage.ts`
+
+```ts
+/**
+ * Versioned localStorage wrapper for the user's theme choice.
+ *
+ * One key, two values, one media query. Falls back to an in-memory
+ * variable when localStorage throws (private windows, quota errors).
+ */
+
+export const STORAGE_KEY = 'minimalist-app:theme:v1';
+
+export type Theme = 'light' | 'dark';
+
+let inMemory: Theme | null = null;
+
+export function readTheme(): Theme | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === 'light' || raw === 'dark') return raw;
+    return null;
+  } catch {
+    return inMemory;
+  }
+}
+
+export function writeTheme(theme: Theme): void {
+  inMemory = theme;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // private window / quota — keep in-memory fallback
+  }
+}
+
+export function seedFromMedia(): Theme {
+  let prefersDark = false;
+  try {
+    prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  } catch {
+    prefersDark = false;
+  }
+  const theme: Theme = prefersDark ? 'dark' : 'light';
+  writeTheme(theme);
+  return theme;
+}
+```
+
+## Component sketch — `ThemeContext.tsx`
+
+```tsx
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { readTheme, seedFromMedia, writeTheme, type Theme } from './themeStorage';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  // Initial state must be synchronous to avoid a wrong-theme flash on
+  // the React render after the inline boot script has already set the
+  // attribute. We read storage; if missing, we seed (which writes).
+  const [theme, setThemeState] = useState<Theme>(() => {
+    return readTheme() ?? seedFromMedia();
+  });
+
+  // Apply data-theme on every change. The inline boot script already
+  // set this once before React mounted; this effect keeps the DOM and
+  // React state in sync on subsequent toggles.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  const setTheme = useCallback((t: Theme) => {
+    writeTheme(t);
+    setThemeState(t);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((prev) => {
+      const next: Theme = prev === 'light' ? 'dark' : 'light';
+      writeTheme(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({ theme, setTheme, toggleTheme }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (ctx === null) {
+    throw new Error('useTheme() must be used inside a <ThemeProvider>');
+  }
+  return ctx;
+}
+```
+
+## Component sketch — `ThemeToggle.tsx`
+
+```tsx
+import { useTheme } from './ThemeContext';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const label = theme === 'light' ? 'Dark mode' : 'Light mode';
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={toggleTheme}
+      data-testid="theme-toggle"
+      aria-label={`Switch to ${label.toLowerCase()}`}
+    >
+      {label}
+    </button>
+  );
+}
+```
+
+## Updated `main.tsx`
+
+```tsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import './index.css';
+import App from './App.tsx';
+import { AuthProvider } from './auth/AuthContext';
+import { ThemeProvider } from './theme/ThemeContext';
+import { ThemeToggle } from './theme/ThemeToggle';
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element #root not found in index.html');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <ThemeProvider>
+      <BrowserRouter>
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </BrowserRouter>
+      <ThemeToggle />
+    </ThemeProvider>
+  </StrictMode>,
+);
+```
+
+`<ThemeToggle />` is a sibling of `<BrowserRouter>`, not a child — it
+does not need routing context. It is rendered **outside** the router,
+so it is unaffected by route changes (no remount, no `useLocation`
+dependency, no risk of `<RequireAuth>` redirect logic skipping it).
+
+## CSS — variable palette in `index.css`
+
+```css
+:root {
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial,
+    sans-serif;
+  line-height: 1.5;
+  color-scheme: light dark;
+
+  /* Light theme (default). */
+  --bg: #ffffff;
+  --fg: #213547;
+  --fg-muted: rgba(33, 53, 71, 0.7);
+  --border: rgba(0, 0, 0, 0.15);
+  --surface: rgba(0, 0, 0, 0.025);
+  --accent: rgba(70, 130, 220, 0.85);
+  --accent-bg: rgba(70, 130, 220, 0.1);
+  --danger-fg: rgb(180, 30, 30);
+  --danger-border: rgba(180, 30, 30, 0.5);
+  --danger-bg: rgba(180, 30, 30, 0.06);
+  --success-fg: rgb(20, 120, 60);
+  --success-border: rgba(20, 120, 60, 0.45);
+  --success-bg: rgba(20, 120, 60, 0.08);
+
+  color: var(--fg);
+  background-color: var(--bg);
+}
+
+[data-theme="dark"] {
+  --bg: #242424;
+  --fg: rgba(255, 255, 255, 0.87);
+  --fg-muted: rgba(255, 255, 255, 0.6);
+  --border: rgba(255, 255, 255, 0.18);
+  --surface: rgba(255, 255, 255, 0.04);
+  --accent: rgba(100, 160, 255, 0.85);
+  --accent-bg: rgba(100, 160, 255, 0.12);
+  --danger-fg: rgb(255, 120, 120);
+  --danger-border: rgba(220, 50, 50, 0.5);
+  --danger-bg: rgba(220, 50, 50, 0.08);
+  --success-fg: rgb(120, 220, 160);
+  --success-border: rgba(50, 180, 100, 0.5);
+  --success-bg: rgba(50, 180, 100, 0.08);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  place-items: center;
+  justify-content: center;
+}
+
+#root {
+  width: 100%;
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 2rem;
+}
+```
+
+The current `@media (prefers-color-scheme: light)` block is removed.
+The seed script in `index.html` and the `ThemeProvider` together
+guarantee `data-theme` is always set, so the default rules at
+`:root` are the light values (matching what `data-theme="light"`
+would also produce — they are intentionally identical).
+
+## CSS — `App.css` migrations (selective)
+
+The migration is intentionally narrow. Only rules that have a clean
+mapping to a variable get migrated; the rest stay literal. Examples:
+
+| Existing literal | Migrate to | Reasoning |
+|---|---|---|
+| `background-color: rgba(255, 255, 255, 0.02);` (login-page, auth-header) | `background-color: var(--surface);` | Direct semantic match. |
+| `border: 1px solid rgba(127, 127, 127, 0.3);` (state, hello-panel) | **keep literal** | Opacity-tinted neutral reads on both themes; rewriting adds churn without payoff. |
+| `outline: 2px solid rgba(100, 160, 255, 0.6);` (focus rings) | **keep literal** | Focus accent is theme-invariant by design (visible on both bg). |
+| `background-color: rgba(220, 50, 50, 0.08);` (login-form__error) | `background-color: var(--danger-bg);` | Direct match. |
+| `border-color: rgba(220, 50, 50, 0.5);` (login-form__error) | `border-color: var(--danger-border);` | Direct match. |
+| `background-color: rgba(50, 180, 100, 0.08);` (login-form__info) | `background-color: var(--success-bg);` | Direct match. |
+| `border-color: rgba(50, 180, 100, 0.5);` (login-form__info) | `border-color: var(--success-border);` | Direct match. |
+| `background-color: rgba(100, 160, 255, 0.12);` (login-form__submit) | `background-color: var(--accent-bg);` | Direct match. |
+
+Vulcan applies the migrations row by row and leaves a one-line
+`feat_frontend_004` comment above each migrated rule (or one block-
+comment at the top of the section) so the diff is easy to audit.
+
+## CSS — toggle button in `App.css`
+
+```css
+/* ---- feat_frontend_004: theme toggle (fixed bottom-left) -------------- */
+
+.theme-toggle {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 10;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.85rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--border);
+  background-color: var(--surface);
+  color: var(--fg);
+  cursor: pointer;
+  font-family: inherit;
+  /* No transition — flip is instant per the design. */
+}
+
+.theme-toggle:hover {
+  background-color: var(--accent-bg);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid rgba(100, 160, 255, 0.6);
+  outline-offset: 1px;
+}
+```
+
+`z-index: 10` is intentionally low — the page does not currently use
+any layered overlay, modal, or toast. If a future feature adds a modal
+that should occlude the toggle, that feature can bump the modal's
+`z-index` above 10. Keeping the toggle at a small value avoids
+arms-race escalation.
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    A[index.html parsed] --> B{localStorage<br/>has theme?}
+    B -- yes --> C[Apply data-theme from storage]
+    B -- no --> D[matchMedia prefers-color-scheme]
+    D --> E[Write theme to localStorage]
+    E --> C
+    C --> F[React bundle loads]
+    F --> G[ThemeProvider reads localStorage]
+    G --> H[State = stored theme]
+    H --> I[ThemeToggle renders with action label]
+    I --> J{User clicks toggle?}
+    J -- yes --> K[toggleTheme: flip + write storage]
+    K --> L[Effect: setAttribute data-theme]
+    L --> M[CSS variables flip; UI re-renders]
+    M --> J
+    J -- no --> N[Idle]
+```
+
+After the boot script and `ThemeProvider` converge, every subsequent
+toggle is a single round trip: button click -> state update -> effect
+applies attribute -> CSS variables resolve -> repaint.
+
+## Routing / mount-tree contract
+
+The provider tree becomes:
+
+```
+<StrictMode>
+  <ThemeProvider>            <- new, outermost (so /login can read it too)
+    <BrowserRouter>
+      <AuthProvider>
+        <App />              <- routes: /login, /, /profile, *
+      </AuthProvider>
+    </BrowserRouter>
+    <ThemeToggle />          <- always mounted; not affected by route changes
+  </ThemeProvider>
+</StrictMode>
+```
+
+`<ThemeProvider>` is the outermost provider — even outside
+`<BrowserRouter>` — so it does not depend on routing context. The
+`<ThemeToggle>` is rendered as a sibling of `<BrowserRouter>` so
+the route table never unmounts it. `<AuthProvider>` continues to live
+where it is today.
+
+## Edge Cases & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Wrong-theme flash between HTML parse and React mount. | Inline boot script in `index.html` sets `data-theme` before any React code runs. The `ThemeProvider` re-reads the same value and converges. |
+| `localStorage` is disabled (private window / Safari ITP). | `themeStorage` catches and falls back to an in-memory variable. Theme works **within** a session but resets on reload. The boot script also catches and falls back to OS preference. No crash. |
+| `localStorage` contains an unexpected value (e.g. `'system'` from a future change, or hand-edited). | `readTheme()` returns `null` for unrecognized values. The provider then re-seeds from the OS preference. |
+| Two tabs open and the user toggles in one — does the other tab update? | No. Cross-tab `storage` events are intentionally not wired in this feature. Documented as out-of-scope. A future feature may add a `storage` event listener. |
+| The user's OS changes `prefers-color-scheme` while the app is open — should the app react? | No. Once a value is in `localStorage`, the user's choice is sticky. Documented as the explicit design (per the user's "more functional than decorative" guidance). |
+| StrictMode double-mounts the provider in dev. | The provider's `useState` initializer runs twice in dev, but both runs read the same persisted value. The effect that sets `data-theme` is idempotent (same value -> same DOM). No observable difference. |
+| Theme toggle button overlaps page content on small viewports. | `position: fixed; bottom: 1rem; left: 1rem;` puts it in a low-traffic corner. The login form is centered (`max-width: 26rem; margin: 4rem auto;`), the dashboard is left-aligned within the centered `#root`. The toggle does not currently overlap any interactive element. If a future page adds bottom-left content, that feature owns the layout fix. |
+| `data-theme` attribute is set on `<html>`, not `<body>` — does that interfere with anything? | No. `<html>` is the recommended target because CSS variables on `:root` and a sibling `[data-theme="dark"]` selector resolve identically (`:root` and `html` are the same element). The cascade is unambiguous. |
+| Existing tests (`login.spec.ts`, `profile.spec.ts`) break because the theme toggle adds an unexpected element. | The toggle has `data-testid="theme-toggle"` and is positioned via `position: fixed`. None of the existing specs use a global query for `<button>` or rely on element counts. Vulcan must verify locally; if any spec uses `page.getByRole('button')` without a name, it would now find an extra match — none currently do. |
+| Inline boot script fails Content-Security-Policy in a future hardening feature. | The script is currently allowed by default (no CSP shipped). When a future feature adds a CSP, that feature owns moving the script to a hashed inline or an external file. Out of scope here. |
+| Light theme has insufficient contrast on accent-tinted elements. | The chosen palette has been picked to keep WCAG AA ratios on body text (`#213547` on `#ffffff` is ~12:1). Accent-tinted backgrounds (`var(--accent-bg)`) are decorative; text inside them inherits `var(--fg)` which carries the contrast. Vulcan must spot-check the login error / info banners in both themes during the build. |
+| Vite or browser caching serves a stale `index.html` after the inline script changes. | Vite's dev server hot-reloads `index.html`. Production builds emit a fresh `index.html` per build. No special action needed. |
+| `ThemeProvider` wraps `<BrowserRouter>` — does any code expect `useNavigate()` or `useLocation()` inside the theme layer? | No. The `ThemeContext` does not call any router hook. The `ThemeToggle` does not navigate. |
+
+## Playwright spec contract — `theme.spec.ts`
+
+The spec runs against the compose stack but does **not** require the
+OTP fixture (no login is performed). Its assertions all happen on
+`/login` (and on the `/login` redirect from `/`). It uses Playwright's
+`page.emulateMedia({ colorScheme: 'dark' | 'light' })` to control the
+seed-from-OS path.
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test.describe('theme toggle', () => {
+  test('first visit seeds from OS preference (dark)', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('minimalist-app:theme:v1'); } catch {}
+    });
+    await page.goto('/login');
+    const theme = await page.evaluate(() =>
+      document.documentElement.getAttribute('data-theme'),
+    );
+    expect(theme).toBe('dark');
+  });
+
+  test('first visit seeds from OS preference (light)', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('minimalist-app:theme:v1'); } catch {}
+    });
+    await page.goto('/login');
+    const theme = await page.evaluate(() =>
+      document.documentElement.getAttribute('data-theme'),
+    );
+    expect(theme).toBe('light');
+  });
+
+  test('toggle flips theme and persists across reload', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('minimalist-app:theme:v1'); } catch {}
+    });
+    await page.goto('/login');
+
+    // Initial: light (seeded).
+    expect(
+      await page.evaluate(() =>
+        document.documentElement.getAttribute('data-theme'),
+      ),
+    ).toBe('light');
+    await expect(page.getByTestId('theme-toggle')).toHaveText('Dark mode');
+
+    // Click toggle.
+    await page.getByTestId('theme-toggle').click();
+    expect(
+      await page.evaluate(() =>
+        document.documentElement.getAttribute('data-theme'),
+      ),
+    ).toBe('dark');
+    await expect(page.getByTestId('theme-toggle')).toHaveText('Light mode');
+
+    // Reload — theme persists, no flash of wrong theme.
+    await page.reload();
+    const themeOnReload = await page.evaluate(() =>
+      document.documentElement.getAttribute('data-theme'),
+    );
+    expect(themeOnReload).toBe('dark');
+    await expect(page.getByTestId('theme-toggle')).toHaveText('Light mode');
+  });
+
+  test('user choice overrides OS preference', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('minimalist-app:theme:v1'); } catch {}
+    });
+    await page.goto('/login');
+
+    // User picks dark.
+    await page.getByTestId('theme-toggle').click();
+    expect(
+      await page.evaluate(() =>
+        document.documentElement.getAttribute('data-theme'),
+      ),
+    ).toBe('dark');
+
+    // OS preference flips to dark anyway.
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.reload();
+
+    // User's stored choice still wins (still dark — but the test is
+    // really: re-emulate to LIGHT and verify we DO NOT flip back).
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.reload();
+    expect(
+      await page.evaluate(() =>
+        document.documentElement.getAttribute('data-theme'),
+      ),
+    ).toBe('dark');
+  });
+
+  test('toggle button is visible on / -> redirect to /login', async ({ page }) => {
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('minimalist-app:theme:v1'); } catch {}
+    });
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByTestId('theme-toggle')).toBeVisible();
+  });
+});
+```
+
+The spec is self-contained: it does not import `getOtpFixture`, does
+not call `test.skip` on missing fixture, and does not perform any
+OTP flow. It does require the compose stack to be up (so `/login`
+serves a real page) — same prerequisite as `login.spec.ts`.
+
+## Verification matrix
+
+| Theme | Page | Manual check |
+|---|---|---|
+| light | `/login` | Email input border visible against white bg; error banner red on light pink; submit button accent-tinted but readable. |
+| light | `/` (authed) | Header strip visible; role chips readable; HelloPanel border visible. |
+| light | `/profile` | Email value readable in monospace; heading contrast OK. |
+| dark | `/login` | Matches today's look (no regression). |
+| dark | `/` | Matches today's look. |
+| dark | `/profile` | Matches today's look. |
+
+Vulcan should screenshot each combination during the build and attach
+them to the build PR description for human review.
+
+## Dependencies
+
+- **Hard:** `feat_frontend_003` merged to `main` first.
+- **Runtime (no new):** `react`, `react-dom`, `react-router-dom@^7`
+  (all already pulled in by `feat_frontend_001` / `feat_frontend_002`).
+- **Dev (no new):** `@playwright/test@^1` (already present).
+- **External tools (no new):** Playwright Chromium, already installed
+  per the README's e2e-setup instructions.
+- **Backend:** unchanged.
+
+## Deviations
+
+- **OS preference is consulted only on first visit and never again.**
+  The user did not explicitly direct this; Atlas decided it is the
+  most sensible behavior given the user's "user's choice owns it"
+  guidance and the explicit 2-state requirement. Documented in the
+  feature spec under Requirements; flagged here for the user's
+  review. If the user prefers "watch OS preference on every load
+  until the user toggles once," that is a one-line change in
+  `themeStorage.ts` (we would not write the seed back to storage,
+  and we'd re-read the media query on each page load while
+  `localStorage` is empty).
+- **No system / auto state.** Per the user's explicit choice.
+- **No side pane.** Per the user's explicit choice (Option B).
+- **No `storage` event listener for cross-tab sync.** Out of scope;
+  documented as a future-feature opportunity.
+- **Light theme is functional, not designed.** Per the user's "more
+  functional than decorative" guidance. The palette is conservative
+  and may be tuned in a follow-up feature.
+- **Inline boot script is plain ES5.** Even though the rest of the app
+  is TypeScript-targeted-ESNext, the boot script is hand-written in
+  ES5 to avoid any transpilation surprises and to keep the logic
+  trivially auditable in the deployed `index.html`.
+- **Branch and directory use `feat_<domain>_<NNN>` only.** No slug,
+  matching `conventions.md` §2 and every existing sibling under
+  `docs/specs/`.

--- a/docs/specs/feat_frontend_004/feat_frontend_004.md
+++ b/docs/specs/feat_frontend_004/feat_frontend_004.md
@@ -1,0 +1,279 @@
+# Feature: Dark mode — fixed bottom-left toggle, two-state light/dark, persisted
+
+## Problem Statement
+
+The frontend currently ships a single, hard-coded color scheme defined
+in `frontend/src/index.css`. The `:root` selector sets a near-black
+background (`#242424`) with light text, and a `@media (prefers-color-scheme: light)`
+override flips both back to white-on-dark-text. The result is that the
+**operating system's** preference picks the theme — the user has no
+in-app control. There is also no `data-theme` hook, no theme context,
+and no persistence layer; component CSS in `App.css` hard-codes
+opacity-tinted neutrals (`rgba(127, 127, 127, ...)`, `rgba(255, 255, 255, 0.02)`)
+that happen to look reasonable on either background but were never
+designed against an explicit palette.
+
+This feature gives the user a deliberate, in-app toggle between a
+**light** and **dark** theme. The toggle is rendered as a fixed
+bottom-left button on every page (authed and unauthenticated, including
+`/login`). Clicking it flips the theme, applies it instantly via a
+`data-theme` attribute on `<html>`, and persists the choice to
+`localStorage` so a refresh, a new tab, or a new browser session lands
+on the same theme. The user's explicit choice is sticky — the OS
+`prefers-color-scheme` media query is consulted **only** as the seed
+on first visit and is never read again afterward.
+
+The implementation introduces a small `ThemeContext` provider mounted
+above `AuthProvider`, a tiny `themeStorage` module that wraps
+`localStorage`, and a CSS-variable palette in `index.css` with
+`[data-theme="dark"]` overrides. Component CSS in `App.css` is migrated
+to reference the new variables, but the visual look on the dark theme
+matches the current screen pixel-for-pixel where reasonable; the light
+theme is a new but minimal palette.
+
+## Requirements
+
+- A new in-app **theme toggle** is rendered as a fixed-position button
+  in the **bottom-left corner** of the viewport. It sits above page
+  content (small z-index) and is visible on every route, including
+  `/login` (unauthenticated) and the bootstrap-loading state. It does
+  **not** appear inside `<Header>`; it is a global overlay button
+  rendered by the new `<ThemeProvider>` (or a small sibling component
+  rendered alongside it).
+- The toggle has exactly **two states**: `light` and `dark`. There is
+  no `system` / `auto` state, no tri-state cycle, no dropdown.
+  Clicking the button flips between the two states.
+- The currently-applied theme is reflected by a `data-theme="light"` or
+  `data-theme="dark"` attribute on the `<html>` element. CSS rules in
+  `index.css` and `App.css` reference theme variables (e.g.
+  `--bg`, `--fg`, `--border`, `--muted`, `--accent`) defined at
+  `:root` (light defaults) and overridden by `[data-theme="dark"]`.
+- The user's choice is persisted to `localStorage` under a single
+  versioned key (`minimalist-app:theme:v1`). Reads and writes go
+  through a small `themeStorage` module that handles
+  unavailable-storage edge cases (private windows, quota errors,
+  `localStorage` disabled) by falling back to in-memory state without
+  throwing.
+- On **first visit** (no value in `localStorage`), the initial theme
+  is seeded from `window.matchMedia('(prefers-color-scheme: dark)').matches`
+  — `true` -> `dark`, `false` -> `light`. The seeded value is written
+  to `localStorage` immediately so subsequent renders, refreshes, and
+  tabs all read the same value. After the seed, `prefers-color-scheme`
+  is **never** consulted again — the user's explicit choice owns the
+  theme forever.
+- A small **inline script** in `index.html` reads the persisted theme
+  (or seeds it) **before** React mounts, and applies the
+  `data-theme` attribute on `<html>` synchronously. This eliminates
+  the brief "wrong-theme flash" that would otherwise occur between the
+  HTML being parsed and the `<ThemeProvider>` running its effect.
+- A new **`ThemeContext`** provides `{ theme: 'light' | 'dark', toggleTheme: () => void, setTheme: (t) => void }`.
+  It is mounted in `main.tsx` **above** `<AuthProvider>` so every
+  React subtree (including the `LoginPage` route) can read and write
+  the theme.
+- The toggle button shows a clear, accessible label that reflects the
+  **action**, not the current state. Recommended copy: when the
+  current theme is `light`, the button reads `Dark mode` (because
+  clicking it switches to dark); when current is `dark`, it reads
+  `Light mode`. Vulcan may also use icon-only with `aria-label`,
+  but a text-only button is acceptable and consistent with the
+  bland-Vite tone.
+- Existing component visuals must not regress on the dark theme.
+  `App.css` selectors that hard-code colors (e.g.
+  `rgba(220, 50, 50, 0.5)` on `.login-form__error`, the role chip
+  borders, the `.state` panel) are migrated to CSS variables where
+  the variable cleanly applies; otherwise the literal stays and is
+  documented as intentionally theme-invariant.
+- Light theme styling is "good enough": readable contrast, no white
+  text on white background. It does **not** need to win a design
+  award — the user said "more functional than decorative". Dark
+  theme remains the close cousin of today's look.
+- A new **Playwright e2e spec** at `frontend/tests/e2e/theme.spec.ts`
+  drives the toggle end-to-end on `/login` (no login required, since
+  the toggle works pre-auth too): assert initial theme, click toggle,
+  assert `data-theme` flipped and the button label changed, reload
+  the page, assert the theme persisted, navigate to `/` (which
+  redirects to `/login`), assert the theme is still applied. The
+  spec runs without the OTP fixture — it asserts no `/auth/me`
+  re-fire is needed for theme behavior — so it does **not** call
+  `test.skip` based on `getOtpFixture()`.
+- No backend changes. The theme is a pure-frontend concern; the
+  `Me` payload is unchanged; no new API endpoints; no DB migrations.
+- `./test.sh` continues to pass with no behavior change. The new
+  Playwright spec runs via `bun run test:e2e` alongside the existing
+  specs.
+
+## User Stories
+
+- As a user who prefers a light interface during the day, I want a
+  visible toggle on every page so I can switch out of dark mode
+  without hunting through a settings menu.
+- As a user who prefers a dark interface, I want my choice to stick
+  across sessions so I do not have to re-toggle every time I open
+  the app.
+- As a first-time visitor, I want the app to start in whichever theme
+  matches my OS preference so the initial render does not feel
+  jarring.
+- As a user signing in, I want the theme toggle to be reachable from
+  the `/login` page so I can pick my preferred theme before I even
+  authenticate.
+- As a user reloading the page, I want no flash of the wrong theme
+  between page parse and React mount.
+- As a user with `localStorage` disabled (private window), I want the
+  app to keep working — the theme just resets when I navigate
+  between pages, instead of crashing.
+
+## User Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant HTML as index.html
+    participant Storage as localStorage
+    participant Media as matchMedia
+    participant Toggle as ThemeToggle
+    participant CSS as index.css + App.css
+
+    Note over User,HTML: First visit
+    User->>HTML: load /
+    HTML->>Storage: read 'minimalist-app:theme:v1'
+    Storage-->>HTML: null (first visit)
+    HTML->>Media: matchMedia('(prefers-color-scheme: dark)')
+    Media-->>HTML: matches=true
+    HTML->>Storage: write 'dark'
+    HTML->>HTML: <html data-theme="dark">
+    HTML->>CSS: apply [data-theme="dark"] vars
+    CSS-->>User: dark UI rendered
+
+    Note over User,Toggle: User clicks toggle to switch to light
+    User->>Toggle: click "Light mode"
+    Toggle->>Toggle: setTheme('light')
+    Toggle->>Storage: write 'light'
+    Toggle->>HTML: <html data-theme="light">
+    HTML->>CSS: apply :root vars
+    CSS-->>User: light UI rendered
+
+    Note over User,HTML: User reloads
+    User->>HTML: reload
+    HTML->>Storage: read 'minimalist-app:theme:v1'
+    Storage-->>HTML: 'light'
+    HTML->>HTML: <html data-theme="light">
+    CSS-->>User: light UI (no flash)
+```
+
+## Scope
+
+### In Scope
+
+- New file `frontend/src/theme/themeStorage.ts` — read/write with the
+  versioned key, in-memory fallback, sensible types.
+- New file `frontend/src/theme/ThemeContext.tsx` — provider + hook
+  (`useTheme`).
+- New file `frontend/src/theme/ThemeToggle.tsx` — the fixed
+  bottom-left button.
+- Edit to `frontend/src/main.tsx` — mount `<ThemeProvider>` above
+  `<AuthProvider>` and render `<ThemeToggle />` somewhere globally
+  (recommended: inside `<ThemeProvider>` via a child portal or as a
+  fixed sibling in `App` — see the design spec for the exact shape).
+- Edit to `frontend/index.html` — small inline `<script>` that seeds
+  + applies `data-theme` before React mounts.
+- Edit to `frontend/src/index.css` — define a CSS-variable palette
+  on `:root` (light) and `[data-theme="dark"]` (dark). Remove the
+  current `prefers-color-scheme: light` media query (the seed script
+  has replaced it). Keep `color-scheme` declared so form controls
+  pick a sensible default.
+- Edit to `frontend/src/App.css` — migrate hard-coded color rules
+  to the new variable names where applicable. Document any rule
+  that intentionally stays literal.
+- New Playwright spec `frontend/tests/e2e/theme.spec.ts` covering
+  the toggle / persistence / no-flash invariants.
+- Update `frontend/README.md` Testing section to mention the new
+  `theme.spec.ts`.
+- Update `docs/specs/README.md` feature roster row.
+- Update `docs/tracking/features.md` with a new row.
+
+### Out of Scope
+
+- **Side pane / settings drawer.** The user explicitly chose
+  "toggle only" (Option B) and said "defer the side pane".
+- **System / auto theme state.** The user explicitly chose 2-state
+  only. No tri-state cycle, no `system` option in the toggle.
+- **Per-user persistence on the backend.** The theme is local to the
+  browser, not synced across devices. No DB column, no API endpoint.
+- **Theme editor / color picker.** The user has a binary choice; no
+  custom color UI.
+- **Multiple light or dark variants** (e.g. high-contrast,
+  sepia, solarized). One light, one dark.
+- **Animated transitions** between themes (e.g. a CSS `transition`
+  on `background-color`). The flip is instant. A future feature
+  may add a transition.
+- **Re-skinning the app.** The dark theme matches the current look
+  closely. The light theme is functional, not redesigned.
+- **Tailwind / CSS-in-JS migration.** The feature stays on the
+  current `App.css` + `index.css` model; it just adds variables.
+- **Backend changes of any kind.**
+- **Component-level icons / icon library.** The toggle is a
+  text-only button or a single inline emoji-free SVG. No new dep.
+- **Honoring `prefers-color-scheme` changes after first visit.** Once
+  the user has a stored preference, the OS preference no longer
+  affects the app even if it changes. This is the explicit design.
+- **A "reset to OS preference" affordance.** Could land in a future
+  feature; not now.
+- **Non-Chromium browser tests.** Playwright continues to drive
+  Chromium only.
+- **Adding the new spec to `./test.sh`.** Playwright stays out-of-band.
+
+## Acceptance Criteria
+
+- [ ] A fixed bottom-left button is visible on `/login` (unauthenticated)
+      and on `/`, `/profile` (authed). It reads `Dark mode` when the
+      current theme is light and `Light mode` when the current theme
+      is dark.
+- [ ] Clicking the toggle changes the `data-theme` attribute on
+      `<html>` from `light` to `dark` (or vice versa) within the same
+      tick.
+- [ ] After clicking the toggle, `localStorage.getItem('minimalist-app:theme:v1')`
+      reads back the new value (`'light'` or `'dark'`).
+- [ ] After a full page reload, the previously-chosen theme is
+      applied **before any visible flash of the other theme**. The
+      Playwright spec asserts the `data-theme` is correct on the very
+      first paint (using a synchronous evaluate before any
+      interaction).
+- [ ] On a fresh browser (no `localStorage` value), the initial theme
+      matches the result of `matchMedia('(prefers-color-scheme: dark)')`.
+      Playwright asserts this by emulating both color schemes and
+      reloading.
+- [ ] After a user has clicked the toggle once, changing the OS-level
+      `prefers-color-scheme` does **not** change the in-app theme.
+      Playwright asserts this by clicking the toggle, then emulating
+      the opposite color scheme, then asserting the theme is still
+      the user's choice.
+- [ ] Navigating between routes (`/login` -> `/` after login -> `/profile`)
+      preserves the theme. The toggle button stays in the same DOM
+      position (rendered once, not unmounted across route changes).
+- [ ] No new `fetch` is added to `frontend/src/`. (Theme is purely
+      client-side.)
+- [ ] No new dependency is added to `frontend/package.json`.
+- [ ] `bun run build` passes with zero TypeScript errors.
+- [ ] `frontend/tests/e2e/theme.spec.ts` exists and passes locally
+      with `make up` running. It does **not** require the OTP
+      fixture (no login dance).
+- [ ] `frontend/tests/e2e/login.spec.ts` and
+      `frontend/tests/e2e/profile.spec.ts` continue to pass with no
+      changes (the theme toggle does not break their selectors or
+      flows).
+- [ ] `./test.sh` continues to pass.
+- [ ] `docs/specs/README.md` and `docs/tracking/features.md` rows
+      are present and reference this feature.
+
+## Dependencies
+
+- **Hard dependency:** `feat_frontend_003` merged to `main` first.
+  This feature edits files (`main.tsx`, `index.html`, `index.css`,
+  `App.css`, `frontend/README.md`) that already exist after
+  `feat_frontend_003`. It does not touch any code that
+  `feat_frontend_003` introduced (no edits to `ProfilePage.tsx` or
+  `Header.tsx`), so a soft refactor in either direction is unlikely
+  to conflict.
+- No new runtime or dev dependencies. `react`, `react-dom`,
+  `react-router-dom`, and `@playwright/test` are already in
+  `package.json`.

--- a/docs/specs/feat_frontend_004/test_frontend_004.md
+++ b/docs/specs/feat_frontend_004/test_frontend_004.md
@@ -1,0 +1,151 @@
+# Test Spec: Dark mode — fixed bottom-left toggle, two-state light/dark, persisted
+
+## Test harness
+
+This feature ships **Playwright e2e tests only** — consistent with
+`feat_frontend_002` and `feat_frontend_003`. No Vitest, no React
+Testing Library, no component tests. The runner targets the
+compose-brought-up stack (`make up` from the repo root) and drives
+Chromium against `http://localhost:5173` (or `PLAYWRIGHT_BASE_URL`).
+
+- Location: `frontend/tests/e2e/theme.spec.ts` (new, this feature).
+- Existing infrastructure reused (no changes):
+  - `frontend/playwright.config.ts`
+  - `bun run test:e2e` script in `frontend/package.json`
+- The new spec **does not import `getOtpFixture`** and does **not**
+  perform an OTP login. It runs all assertions on `/login`
+  (unauthenticated) and on the `/login` page reached via redirect
+  from `/`. There is no `test.skip` based on a missing OTP fixture.
+- The new spec uses `page.emulateMedia({ colorScheme: 'dark' | 'light' })`
+  to control the seed-from-OS path and `page.addInitScript()` to
+  clear `localStorage` before each scenario.
+- `./test.sh` is unchanged and does **not** invoke Playwright.
+- Existing specs (`login.spec.ts`, `profile.spec.ts`) must continue to
+  pass unchanged. They do not need theme-related modifications.
+
+## Happy Path
+
+| # | Test Case | Input | Expected Output |
+|---|---|---|---|
+| 1 | Toggle button visible on `/login` | `await page.goto('/login')` (clean storage) | `page.getByTestId('theme-toggle')` is visible. |
+| 2 | Toggle button visible on `/` (which redirects to `/login`) | `await page.goto('/')` (clean storage) | URL becomes `/login`; toggle is visible. |
+| 3 | First-visit seed: OS dark -> theme dark | `emulateMedia({ colorScheme: 'dark' })`, clear storage, `goto('/login')` | `document.documentElement.getAttribute('data-theme') === 'dark'`. |
+| 4 | First-visit seed: OS light -> theme light | `emulateMedia({ colorScheme: 'light' })`, clear storage, `goto('/login')` | `document.documentElement.getAttribute('data-theme') === 'light'`. |
+| 5 | First-visit seed writes to localStorage | After Test #3 | `localStorage.getItem('minimalist-app:theme:v1') === 'dark'`. |
+| 6 | Toggle button label reflects action (light current) | OS=light, clean storage, `goto('/login')` | Toggle button text content is exactly `Dark mode`. |
+| 7 | Toggle button label reflects action (dark current) | OS=dark, clean storage, `goto('/login')` | Toggle button text content is exactly `Light mode`. |
+| 8 | Click toggle flips data-theme | OS=light, clean storage, `goto('/login')`, click toggle | `data-theme` becomes `dark` within the same tick (assert without an explicit wait beyond Playwright's auto-waiting). |
+| 9 | Click toggle updates label | OS=light, clean storage, `goto('/login')`, click toggle | Toggle button text content becomes exactly `Light mode`. |
+| 10 | Click toggle persists to localStorage | After Test #8 | `localStorage.getItem('minimalist-app:theme:v1') === 'dark'`. |
+| 11 | Theme persists across reload | OS=light, clean storage, `goto('/login')`, click toggle, `page.reload()` | `data-theme` is `dark` immediately after reload (asserted via `page.evaluate` right after `reload()` resolves, no interaction in between). |
+| 12 | User choice beats OS preference | OS=light, clean storage, `goto('/login')`, click toggle (now dark), `emulateMedia({ colorScheme: 'light' })`, `reload()` | `data-theme` is still `dark`. |
+| 13 | OS-preference change while open does not change theme | After Test #12, in the same page, change emulation back and forth | The `data-theme` attribute remains the user's stored value across both emulations until the user clicks the toggle. |
+| 14 | Toggle stays mounted across route transitions | OS=light, clean storage; assume an authed flow is not required for this assertion: navigate `/login` -> manually `goto('/profile')` (which redirects to `/login`); the toggle element returned by `getByTestId` is the same DOM node throughout (assertable via `evaluate` getting `outerHTML` and a stable reference). | The toggle remains visible; no console error. |
+| 15 | Two themes leave existing e2e specs green | Run `bun run test:e2e` end-to-end (login + profile + theme) | All three specs pass. The login and profile specs do not reference the toggle; their selectors and assertions are unaffected. |
+| 16 | No new fetch calls are made by the theme layer | OS=light, clean storage, `goto('/login')`, click toggle five times | `page.on('request', ...)` log shows zero requests from any URL containing `/api/v1/`. (The page itself triggers an initial bootstrap `/auth/me`; the theme toggling causes no additional traffic.) |
+
+The spec ships **multiple smaller `test()` blocks** rather than one
+giant round-trip. Each test starts with a fresh page (`addInitScript`
+clears storage, `emulateMedia` sets the OS preference), so they are
+independent of order. This differs from `login.spec.ts`'s
+single-test-per-spec choice, which only made sense there because of
+the rate-limit + login-cost concern. Theme tests have neither cost
+nor rate-limit, so finer-grained tests are clearer.
+
+## Error Cases
+
+| # | Test Case | Input | Expected Behavior |
+|---|---|---|---|
+| 1 | localStorage throws on read | Manually wrap `localStorage.getItem` to throw, reload | Boot script catches; falls back to OS preference; `data-theme` is set. App does not crash. (Hard to test in Playwright without monkey-patching pre-load — documented as a property of the boot script + `themeStorage` design; not asserted in CI.) |
+| 2 | localStorage throws on write | Quota exceeded simulated via `addInitScript` to override `setItem` | `themeStorage.writeTheme` catches; in-memory fallback holds the value for the session. The `data-theme` attribute still flips on click. (Documented; optional Playwright assertion.) |
+| 3 | localStorage contains a stale unknown value (e.g. `'system'`) | `addInitScript` -> `localStorage.setItem('minimalist-app:theme:v1', 'system')`, OS=light, `goto('/login')` | Boot script does not match `'light'` or `'dark'`, falls through to OS-preference branch, writes `'light'` back to storage, sets `data-theme="light"`. (Required assertion.) |
+| 4 | The toggle is clicked rapidly (10 clicks in a tight loop) | Programmatic `click()` x10 with no wait | The final `data-theme` matches the parity of the click count (10 clicks from `light` -> `light`). No console error, no React state desync. (Required assertion.) |
+| 5 | `<html>` had `data-theme` removed by an external script before React mounts | Synthetic — not a real flow | The provider's `useEffect` re-applies `data-theme` on next state change. Documented; not asserted. |
+| 6 | The user is in a private window | Real-world but not directly testable in a stock Playwright run | The boot script's `try/catch` and `themeStorage`'s in-memory fallback together keep the theme functional within the session. Documented; not asserted in CI. |
+
+## Boundary Conditions
+
+| # | Test Case | Condition | Expected Behavior |
+|---|---|---|---|
+| 1 | First visit with `matchMedia` undefined (very old browser) | Synthetic — Playwright targets modern Chromium | Boot script's `typeof window.matchMedia === 'function'` guard returns `false`; theme defaults to `light`. Documented; not asserted. |
+| 2 | Theme value matches `data-theme` after a single full second of idle time | `goto('/login')`, wait 1s, assert | `data-theme` is unchanged. (Verifies no late effect or interval is overwriting the attribute.) |
+| 3 | Multiple `<html data-theme>` writers (boot script + provider) converge | `goto('/login')`, observe via `MutationObserver` (synthetic) | The attribute may be set twice in rapid succession (boot script, then the provider's effect on first mount), but the final value is the same. Documented; not asserted unless a flake materializes. |
+| 4 | `bun run build` produces a `dist/` with the inline script intact | Run `bun run build` locally during the build | The compiled `dist/index.html` contains the inline boot script's content (or an inlined-and-minified equivalent that still runs the same logic). Vulcan asserts during the build, not in Playwright. |
+| 5 | Stack not up | Backend not running when Playwright launches | First navigation to `/login` times out. Same operator-side prerequisite as the existing specs. |
+| 6 | Prod-profile frontend | `PLAYWRIGHT_BASE_URL=http://localhost:8080 bun run test:e2e` | Same theme spec passes; the boot script is part of the prod bundle's `index.html`. |
+| 7 | The toggle button is keyboard-reachable | Tab from a fresh `goto('/login')` until focus lands on the toggle | The toggle is reachable via Tab. It receives a visible focus ring (`:focus-visible`). Documented; not strictly asserted unless flaking. |
+| 8 | Theme value is preserved across two open tabs (no cross-tab sync) | Open Tab A and Tab B on `/login`; toggle in A; reload B | Tab B reflects the new theme on reload (because it re-reads `localStorage`). It does **not** auto-update without a reload — by design. (Documented; optional assertion.) |
+| 9 | Light theme contrast is acceptable | Manual visual check | Body text on body bg passes WCAG AA; error/info banners are readable. Vulcan inspects screenshots during the build and includes them in the PR description. |
+| 10 | Dark theme matches today's look | Manual visual check | The dark theme is visually indistinguishable from the current build for header strip, login form, dashboard, profile page (modulo the new toggle button). |
+
+## Security Considerations
+
+- **No new API surface.** The theme layer is pure-frontend. No new
+  `fetch`, no new request body, no new response shape, no new
+  endpoint to authenticate.
+- **No PII in `localStorage`.** The stored value is exactly one of
+  `'light'` or `'dark'`. Nothing user-identifying.
+- **No XSS via theme value.** The `data-theme` attribute is set via
+  `setAttribute`, never via `innerHTML`. The value is constrained to
+  one of two literals; unrecognized values are rejected by
+  `themeStorage.readTheme()` (returns `null`).
+- **Inline `<script>` in `index.html`.** This is the only inline
+  script in the project. It does not interpolate any user-controlled
+  data. A future CSP-hardening feature must either hash this script
+  or move it to an external file; out of scope here.
+- **No `eval`, no `Function()`, no dynamic imports.** The theme layer
+  is pure DOM + storage.
+- **No third-party origins.** The toggle does not reach out to any
+  CDN, font service, or analytics endpoint.
+- **`localStorage` quota.** The single key holds at most six
+  characters; quota concerns are nil. The `try/catch` around
+  `setItem` is defensive against unrelated quota issues caused by
+  other tabs / origins / extensions.
+- **Cross-tab sync is intentionally absent.** A `storage` event
+  handler would be a fine future addition, but it is not required
+  for the security posture of this feature.
+- **Console hygiene.** The theme layer does not `console.log`. The
+  Playwright spec asserts no errors are logged during a click x N
+  loop (boundary-case #4 implicitly covers this).
+
+## Verification checklist for Vulcan
+
+Before opening the build PR, Vulcan should confirm:
+
+- [ ] `bun run build` passes with zero TS errors.
+- [ ] The compiled `dist/index.html` still contains the inline boot
+      script (or an equivalent that runs synchronously before React
+      mounts).
+- [ ] `bun run test:e2e` passes locally with `make up` running. All
+      three specs (`login.spec.ts`, `profile.spec.ts`,
+      `theme.spec.ts`) green.
+- [ ] `bun run test:e2e` skips the OTP-dependent specs cleanly when
+      the OTP fixture env is unset, and the theme spec runs anyway
+      (because it does not require the fixture).
+- [ ] `./test.sh` still passes (backend + REST suite). No regression.
+- [ ] Git grep for `prefers-color-scheme` in `frontend/src/` and
+      `frontend/index.html` returns:
+        - One hit in `frontend/index.html` (the boot script's seed).
+        - One hit in `frontend/src/theme/themeStorage.ts`
+          (`seedFromMedia`).
+        - **Zero hits in `frontend/src/index.css` or `App.css`** —
+          the old media query is removed.
+- [ ] Git grep for `data-theme` in `frontend/index.html`,
+      `frontend/src/`, and `frontend/dist/` (post-build) returns the
+      expected hits and **no stray references** in component CSS.
+- [ ] No new dependency added to `frontend/package.json`.
+- [ ] No file under `backend/`, `infra/`, or `tests/` is modified.
+- [ ] Manual visual check completed for all 6 cells in the
+      design-spec verification matrix (light × {`/login`, `/`,
+      `/profile`} and dark × the same three). Screenshots attached
+      to the build PR.
+- [ ] Spec README and `docs/tracking/features.md` rows are appended
+      and the Spec PR + Issues columns are backfilled.
+- [ ] The `<ThemeProvider>` is the **outermost** provider, above
+      `<BrowserRouter>` and `<AuthProvider>`. The `<ThemeToggle>` is
+      a sibling of `<BrowserRouter>` (not inside it).
+- [ ] The boot script in `index.html` is plain ES5 (no `let`,
+      `const`, arrow functions, or template literals).
+- [ ] The boot script is wrapped in a `try/catch` and never throws
+      out to the page, even when `localStorage` and `matchMedia` are
+      both unavailable.

--- a/docs/tracking/features.md
+++ b/docs/tracking/features.md
@@ -12,3 +12,4 @@
 | feat_auth_002 | email OTP login: EmailSender, OTP endpoints, deployment docs | Merged | #22 | #23 | #24 | - |
 | feat_frontend_002 | login UI: AuthContext, /login page, dashboard, Playwright e2e | Merged | #25 | #26 | #27 | - |
 | feat_frontend_003 | profile page: /profile route, header Profile button, email-only view | Merged | #28 | #29 | #30 | - |
+| feat_frontend_004 | dark mode: fixed bottom-left toggle, two-state light/dark, persisted | Specced | #31 | #32 | - | - |


### PR DESCRIPTION
## Specifications for feat_frontend_004

Adds a fixed bottom-left **theme toggle** that switches the app between a `light` and `dark` palette. The user's choice is persisted to `localStorage` behind a small `themeStorage` module, applied via `data-theme` on `<html>`, and seeded once from `prefers-color-scheme` on first visit. The toggle is rendered globally (above `AuthProvider`), so it is visible on `/login` as well as authed routes.

### Spec Files
- Feature: `docs/specs/feat_frontend_004/feat_frontend_004.md`
- Design:  `docs/specs/feat_frontend_004/design_frontend_004.md`
- Test:    `docs/specs/feat_frontend_004/test_frontend_004.md`

### Notable design decisions
- **2-state only.** No `system`/`auto` — per user direction.
- **No side pane.** Just a fixed bottom-left button (Option B).
- **OS preference seeds once on first visit, then never again.** User's explicit choice owns the theme forever after; flagged in the design spec under **Deviations** for review.
- **Inline boot script in `index.html`** sets `data-theme` synchronously before React mounts, eliminating the wrong-theme flash on reload.
- **CSS variables palette** at `:root` with `[data-theme="dark"]` overrides; existing `App.css` rules migrated selectively (clean semantic mappings only, opacity-tinted neutrals stay literal).
- **New Playwright spec** `frontend/tests/e2e/theme.spec.ts` covers seed-from-OS, toggle-flips-attribute, persistence-across-reload, and user-choice-beats-OS. It does **not** require the OTP fixture.
- **No backend changes.** Pure frontend feature.